### PR TITLE
Fix/toggle-interest-ui

### DIFF
--- a/frontend/src/hooks/interests/useToggleInterest.ts
+++ b/frontend/src/hooks/interests/useToggleInterest.ts
@@ -1,6 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toggleInterest } from '../../apis/interestAPI'
-import { ToggleInterestResult } from '../../types/interestType'
 import { QUERY_KEYS } from '../queryKeys'
 
 export const useToggleInterest = () => {
@@ -8,13 +7,18 @@ export const useToggleInterest = () => {
 
 	return useMutation({
 		mutationFn: (course_id: number) => toggleInterest(course_id),
-		onSuccess: (data) => {
-			queryClient.setQueryData([QUERY_KEYS.COURSE], (oldData: ToggleInterestResult) => ({
-				...oldData,
-				hasUserAddInterest: data.isInterest
-			}))
+		onSuccess: (data, course_id) => {
+			const courseIdKey = String(course_id)
+			queryClient.setQueryData([QUERY_KEYS.COURSE, courseIdKey], (oldData: { course: { interests_count: number }, hasUserAddInterest: boolean } | undefined) => {
+				if (!oldData) return oldData
+				return {
+					...oldData,
+					hasUserAddInterest: data.isInterest
+				}
+			})
+			queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.COURSE, courseIdKey] })
 			queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.INTERESTS] })
 			queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.INFINITY_INTERESTS] })
-		}
+		},
 	})
 }


### PR DESCRIPTION
## 標題
fix(interest): refresh course cache after toggleInterest

## 摘要
修正課程詳細頁點擊興趣按鈕後 UI 不更新：改用正確 query key（[COURSE, course_id]），並在成功後更新 hasUserAddInterest 與刷新該課程資料；同時保留原本 INTERESTS / INFINITY_INTERESTS 的 invalidate。

## 背景／問題
課程詳細頁 InterestButton 無法即時更新，原因：
- useGetCourse 的 query key：`[COURSE, course_id]`
- useToggleInterest 之前更新：`[COURSE]`（key 不一致）

## 變更內容
1) 修正 cache key  
- useToggleInterest 改用 `String(course_id)` 組成 `queryKey: [COURSE, course_id]`

2) 成功後刷新課程資料  
- `setQueryData([COURSE, course_id])` 更新 `hasUserAddInterest`
- `invalidateQueries([COURSE, course_id])` 確保資料同步
- 保留 `invalidateQueries([INTERESTS])` / `invalidateQueries([INFINITY_INTERESTS])`

## 測試方式
1. 進入課程詳細頁  
2. 點擊「加入/移除興趣」  

預期結果：
- 按鈕狀態立即更新
- 重新整理後狀態一致

## 備註
- 本次維持最小改動，未加入 optimistic update
- 若需同步列表頁 `interests_count`，可再擴充 invalidate 範圍
