### PR TITLE
Fix/add sequelize pool config defaults

### DIFF
--- a/backend/config/config.ts
+++ b/backend/config/config.ts
@@ -8,6 +8,12 @@ interface DbConfig {
     host: string;
     port: number;
     dialect: "mysql";
+    pool?: {
+      max?: number;
+      min?: number;
+      idle?: number;
+      acquire?: number;
+    };
   };
 }
 
@@ -19,6 +25,12 @@ const config: DbConfig = {
     host: process.env.DB_HOST || "localhost",
     port: parseInt(process.env.DB_PORT || "3306"),
     dialect: "mysql",
+    pool: {
+      max: 3,
+      min: 0,
+      idle: 10000,
+      acquire: 30000,
+    },
   },
 };
 


### PR DESCRIPTION
## 標題

chore(db): set sequelize pool defaults

---

## 摘要

為小站情境設定 Sequelize 連線池預設值，避免無流量時常駐連線並控制資源使用：

* 新增 pool 預設值（max/min/idle/acquire）
* 以固定數字寫入 config，無需 env

---

## 背景／問題

先前未設定 Sequelize pool，容易在小型機器或低流量情境下造成不必要的連線占用與資源浪費。

---

## 變更內容

### 1) 後端：DB 連線池設定

* 檔案：`config.ts`
* 新增 `pool` 設定
* 預設值：

  * `max: 3`
  * `min: 0`
  * `idle: 10000`
  * `acquire: 30000`

---

## 測試方式（Test Plan）

1. 啟動後端
2. 啟動 API server
   ✅ 預期：啟動正常，無 TypeScript 設定錯誤
3. 確認連線池配置（查看 Sequelize 啟動 log 或 debug，如有）
   ✅ 預期：連線池使用上述預設值
