### PR TITLE
Feat/review comments

### DIFF
--- a/backend/controllers/reviewController.ts
+++ b/backend/controllers/reviewController.ts
@@ -1,9 +1,11 @@
 import { RequestHandler } from "express";
 import ReviewService from "../services/reviewService";
 import ReviewReactionService from "../services/reviewReactionService";
+import ReviewCommentService from "../services/reviewCommentService";
 
 type CourseParams = { course_id: string };
 type ReviewParams = { review_id: string };
+type ReviewCommentParams = { review_id: string; comment_id: string };
 
 export const getAllReviewsByCourseId: RequestHandler<CourseParams> = async (
   req,
@@ -133,6 +135,124 @@ export const toggleReviewReaction: RequestHandler<ReviewParams> = async (req, re
         return;
       }
       if (err.message === "REACTION_PRESET_NOT_FOUND" || err.message === "REACTION_PRESET_INACTIVE") {
+        res.status(400).json({ message: err.message });
+        return;
+      }
+    }
+    res.status(500).json({ message: err });
+  }
+}
+
+export const getReviewComments: RequestHandler<ReviewParams> = async (req, res): Promise<void> => {
+  try {
+    const review_id = parseInt(req.params.review_id);
+    if (Number.isNaN(review_id)) {
+      res.status(400).json({ message: "Invalid review_id" });
+      return;
+    }
+
+    const user_id = req.user?.id;
+    const comments = await ReviewCommentService.getCommentsByReviewId(review_id, user_id);
+    res.status(200).json(comments);
+  } catch (err) {
+    if (err instanceof Error && err.message === "Review not found") {
+      res.status(404).json({ message: err.message });
+      return;
+    }
+    res.status(500).json({ message: err });
+  }
+}
+
+export const createReviewComment: RequestHandler<ReviewParams> = async (req, res): Promise<void> => {
+  try {
+    if (!req.user) {
+      res.status(401).json({ message: "Unauthorized" });
+      return;
+    }
+
+    const review_id = parseInt(req.params.review_id);
+    if (Number.isNaN(review_id)) {
+      res.status(400).json({ message: "Invalid review_id" });
+      return;
+    }
+
+    const { content } = req.body;
+    if (typeof content !== "string") {
+      res.status(400).json({ message: "Invalid content" });
+      return;
+    }
+
+    await ReviewCommentService.createComment(review_id, req.user.id, content);
+    res.status(201).json({ message: "Create review comment successful" });
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.message === "Review not found") {
+        res.status(404).json({ message: err.message });
+        return;
+      }
+      if (err.message === "COMMENT_EMPTY" || err.message === "COMMENT_TOO_LONG") {
+        res.status(400).json({ message: err.message });
+        return;
+      }
+    }
+    res.status(500).json({ message: err });
+  }
+}
+
+export const deleteReviewComment: RequestHandler<ReviewCommentParams> = async (req, res): Promise<void> => {
+  try {
+    if (!req.user) {
+      res.status(401).json({ message: "Unauthorized" });
+      return;
+    }
+
+    const review_id = parseInt(req.params.review_id);
+    const comment_id = parseInt(req.params.comment_id);
+    if (Number.isNaN(review_id) || Number.isNaN(comment_id)) {
+      res.status(400).json({ message: "Invalid params" });
+      return;
+    }
+
+    await ReviewCommentService.deleteComment(review_id, comment_id, req.user.id);
+    res.status(200).json({ message: "Delete review comment successful" });
+  } catch (err) {
+    if (err instanceof Error && err.message === "COMMENT_NOT_FOUND") {
+      res.status(404).json({ message: err.message });
+      return;
+    }
+    res.status(500).json({ message: err });
+  }
+}
+
+export const updateReviewComment: RequestHandler<ReviewCommentParams> = async (req, res): Promise<void> => {
+  try {
+    if (!req.user) {
+      res.status(401).json({ message: "Unauthorized" });
+      return;
+    }
+
+    const review_id = parseInt(req.params.review_id);
+    const comment_id = parseInt(req.params.comment_id);
+    if (Number.isNaN(review_id) || Number.isNaN(comment_id)) {
+      res.status(400).json({ message: "Invalid params" });
+      return;
+    }
+
+    const { content } = req.body;
+    if (typeof content !== "string") {
+      res.status(400).json({ message: "Invalid content" });
+      return;
+    }
+
+    await ReviewCommentService.updateComment(review_id, comment_id, req.user.id, content);
+    res.status(200).json({ message: "Update review comment successful" });
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.message === "COMMENT_NOT_FOUND") {
+        res.status(404).json({ message: err.message });
+        return;
+      }
+      if (err.message === "COMMENT_EMPTY" || err.message === "COMMENT_TOO_LONG") {
         res.status(400).json({ message: err.message });
         return;
       }

--- a/backend/middlewares/authMiddleware.ts
+++ b/backend/middlewares/authMiddleware.ts
@@ -50,6 +50,7 @@ export const getCookie: RequestHandler = (req, res, next): void => {
     
     next();
   } catch (err) {
-    res.json({ error: err });
+    req.user = undefined;
+    next();
   }
 };

--- a/backend/migrations/20260306110000-create-review-comments.js
+++ b/backend/migrations/20260306110000-create-review-comments.js
@@ -1,0 +1,65 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('ReviewComments', {
+      id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      review_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Reviews',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      user_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Users',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      content: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+
+    await queryInterface.addIndex('ReviewComments', ['review_id'], {
+      name: 'idx_review_comments_review_id',
+    });
+
+    await queryInterface.addIndex('ReviewComments', ['user_id'], {
+      name: 'idx_review_comments_user_id',
+    });
+
+    await queryInterface.addIndex('ReviewComments', ['review_id', 'created_at'], {
+      name: 'idx_review_comments_review_created_at',
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('ReviewComments');
+  },
+};

--- a/backend/models/ReviewComment.ts
+++ b/backend/models/ReviewComment.ts
@@ -1,0 +1,70 @@
+import {
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+  Optional,
+} from 'sequelize'
+import db from './index'
+import ReviewModel from './Review'
+import UserModel from './Users'
+
+interface ReviewCommentCreationAttributes
+  extends Optional<InferCreationAttributes<ReviewCommentModel>, 'id' | 'created_at' | 'updated_at'> {}
+
+class ReviewCommentModel extends Model<
+  InferAttributes<ReviewCommentModel>,
+  ReviewCommentCreationAttributes
+> {
+  declare id: number
+  declare review_id: number
+  declare user_id: number
+  declare content: string
+  declare created_at: Date
+  declare updated_at: Date
+}
+
+ReviewCommentModel.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    review_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    user_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    content: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    sequelize: db.sequelize,
+    tableName: 'ReviewComments',
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at',
+  }
+)
+
+ReviewCommentModel.belongsTo(ReviewModel, { foreignKey: 'review_id' })
+ReviewModel.hasMany(ReviewCommentModel, { foreignKey: 'review_id' })
+
+ReviewCommentModel.belongsTo(UserModel, { foreignKey: 'user_id' })
+UserModel.hasMany(ReviewCommentModel, { foreignKey: 'user_id' })
+
+export default ReviewCommentModel

--- a/backend/repositories/reviewCommentRepository.ts
+++ b/backend/repositories/reviewCommentRepository.ts
@@ -1,0 +1,88 @@
+import ReviewCommentModel from '../models/ReviewComment'
+import UserModel from '../models/Users'
+import { ReviewCommentResponse } from '../types/review'
+import { col, fn, Op } from 'sequelize'
+
+type ReviewCommentWithUser = ReviewCommentModel & {
+  UserModel?: {
+    name?: string
+    avatar?: string | null
+  }
+}
+
+class ReviewCommentRepository {
+  async getCommentCountByReviewIds(review_ids: number[]): Promise<Map<number, number>> {
+    const countMap = new Map<number, number>()
+    if (review_ids.length === 0) return countMap
+
+    const rows = await ReviewCommentModel.findAll({
+      where: { review_id: { [Op.in]: review_ids } },
+      attributes: ['review_id', [fn('COUNT', col('id')), 'comment_count']],
+      group: ['review_id'],
+      raw: true,
+    }) as unknown as Array<{ review_id: number; comment_count: string }>
+
+    rows.forEach((row) => {
+      countMap.set(Number(row.review_id), Number(row.comment_count))
+    })
+    return countMap
+  }
+
+  async getCommentsByReviewId(review_id: number, user_id?: number): Promise<ReviewCommentResponse[]> {
+    const comments = await ReviewCommentModel.findAll({
+      where: { review_id },
+      order: [['created_at', 'ASC']],
+      include: [
+        {
+          model: UserModel,
+          attributes: ['name', 'avatar'],
+        },
+      ],
+    })
+
+    return (comments as unknown as ReviewCommentWithUser[]).map((comment) => {
+      const commentJson = comment.toJSON() as Omit<ReviewCommentResponse, 'is_owner'>
+      return {
+        ...commentJson,
+        is_owner: user_id !== undefined && comment.user_id === user_id,
+      }
+    })
+  }
+
+  async createComment(review_id: number, user_id: number, content: string): Promise<void> {
+    await ReviewCommentModel.create({ review_id, user_id, content })
+  }
+
+  async deleteComment(review_id: number, comment_id: number, user_id: number): Promise<void> {
+    const deleted = await ReviewCommentModel.destroy({
+      where: {
+        id: comment_id,
+        review_id,
+        user_id,
+      },
+    })
+
+    if (deleted === 0) {
+      throw new Error('COMMENT_NOT_FOUND')
+    }
+  }
+
+  async updateComment(review_id: number, comment_id: number, user_id: number, content: string): Promise<void> {
+    const [updatedCount] = await ReviewCommentModel.update(
+      { content },
+      {
+        where: {
+          id: comment_id,
+          review_id,
+          user_id,
+        },
+      }
+    )
+
+    if (updatedCount === 0) {
+      throw new Error('COMMENT_NOT_FOUND')
+    }
+  }
+}
+
+export default new ReviewCommentRepository()

--- a/backend/repositories/reviewCommentRepository.ts
+++ b/backend/repositories/reviewCommentRepository.ts
@@ -41,9 +41,12 @@ class ReviewCommentRepository {
     })
 
     return (comments as unknown as ReviewCommentWithUser[]).map((comment) => {
-      const commentJson = comment.toJSON() as Omit<ReviewCommentResponse, 'is_owner'>
+      const commentJson = comment.toJSON() as ReviewCommentModel['dataValues'] & {
+        UserModel?: ReviewCommentResponse['UserModel']
+      }
+      const { user_id: _userId, ...commentWithoutUserId } = commentJson
       return {
-        ...commentJson,
+        ...commentWithoutUserId,
         is_owner: user_id !== undefined && comment.user_id === user_id,
       }
     })

--- a/backend/repositories/reviewRepository.ts
+++ b/backend/repositories/reviewRepository.ts
@@ -6,6 +6,7 @@ import UserModel from "../models/Users";
 import { AllReviewsResponseByUser, CreateReviewInput, LatestReviewsResponse, ReviewsResponse } from "../types/review";
 import CourseRepository from "./courseRepository";
 import ReviewReactionRepository from "./reviewReactionRepository";
+import ReviewCommentRepository from "./reviewCommentRepository";
 
 class ReviewRepository {
   async getAllReviewsCount(): Promise<number> {
@@ -30,6 +31,9 @@ class ReviewRepository {
       reviews.map((review) => review.id),
       user_id
     );
+    const commentCountMap = await ReviewCommentRepository.getCommentCountByReviewIds(
+      reviews.map((review) => review.id)
+    );
 
     // 目前使用者的評價優先顯示
     const ownerReviews = [];
@@ -47,7 +51,12 @@ class ReviewRepository {
       const reactions = reactionSummaryMap.get(review.id) || { counts: {}, myReactions: [] };
       const reviewJson = review.toJSON();
       const { user_id: userId, ...reviewWithoutUserId } = reviewJson;
-      return { ...reviewWithoutUserId, is_owner, reactions };
+      return {
+        ...reviewWithoutUserId,
+        is_owner,
+        reactions,
+        comment_count: commentCountMap.get(review.id) ?? 0,
+      };
     });
 
     return reviewsWithOwnerFlag as ReviewsResponse[];
@@ -101,13 +110,21 @@ class ReviewRepository {
       reviews.map((review) => review.id),
       user_id
     );
+    const commentCountMap = await ReviewCommentRepository.getCommentCountByReviewIds(
+      reviews.map((review) => review.id)
+    );
 
     const reviewsWithOwnerFlag = reviews.map((review) => {
       const is_owner = review.user_id === user_id;
       const reactions = reactionSummaryMap.get(review.id) || { counts: {}, myReactions: [] };
       const reviewJson = review.toJSON();
       const { user_id: userId, ...reviewWithoutUserId } = reviewJson;
-      return { ...reviewWithoutUserId, is_owner, reactions };
+      return {
+        ...reviewWithoutUserId,
+        is_owner,
+        reactions,
+        comment_count: commentCountMap.get(review.id) ?? 0,
+      };
     });
 
     return reviewsWithOwnerFlag as unknown as AllReviewsResponseByUser[];
@@ -173,6 +190,9 @@ class ReviewRepository {
       reviews.map((review) => review.id),
       user_id
     );
+    const commentCountMap = await ReviewCommentRepository.getCommentCountByReviewIds(
+      reviews.map((review) => review.id)
+    );
 
     const reviewsWithOwnerFlag = reviews.map((review) => {
       const reviewJson = review.toJSON();
@@ -181,8 +201,12 @@ class ReviewRepository {
       const reactions = reactionSummaryMap.get(review.id) || { counts: {}, myReactions: [] };
       return { ...reviewWithoutUserId, is_owner, reactions };
     });
+    const withCommentCount = reviewsWithOwnerFlag.map((review) => ({
+      ...review,
+      comment_count: commentCountMap.get(review.id) ?? 0,
+    }));
 
-    return reviewsWithOwnerFlag as LatestReviewsResponse[];
+    return withCommentCount as LatestReviewsResponse[];
   }
 
   async hasUserReviewedCourse(course_id: number, user_id: number | undefined): Promise<boolean> {

--- a/backend/routes/reviews.ts
+++ b/backend/routes/reviews.ts
@@ -1,15 +1,31 @@
 import express, { Router } from 'express';
-import { upsertReview, getAllReviewsByCourseId, deleteReview, getLatestReviews, getAllReviewsByUserId, getReviewReactions, toggleReviewReaction } from '../controllers/reviewController';
+import {
+  upsertReview,
+  getAllReviewsByCourseId,
+  deleteReview,
+  getLatestReviews,
+  getAllReviewsByUserId,
+  getReviewReactions,
+  toggleReviewReaction,
+  getReviewComments,
+  createReviewComment,
+  deleteReviewComment,
+  updateReviewComment
+} from '../controllers/reviewController';
 import { authenticateJWT, getCookie } from '../middlewares/authMiddleware';
 
 const router: Router = express.Router();
 
 router.get("/getLatestReviews", getCookie, getLatestReviews);
 router.get("/getAllReviewsByUserId", authenticateJWT, getAllReviewsByUserId);
-router.get("/:course_id", getCookie, getAllReviewsByCourseId);
-router.post("/upsertReview", authenticateJWT, upsertReview);
 router.get("/:review_id/reactions", getCookie, getReviewReactions);
 router.post("/:review_id/reactions/toggle", authenticateJWT, toggleReviewReaction);
+router.get("/:review_id/comments", getCookie, getReviewComments);
+router.post("/:review_id/comments", authenticateJWT, createReviewComment);
+router.patch("/:review_id/comments/:comment_id", authenticateJWT, updateReviewComment);
+router.delete("/:review_id/comments/:comment_id", authenticateJWT, deleteReviewComment);
+router.get("/:course_id", getCookie, getAllReviewsByCourseId);
+router.post("/upsertReview", authenticateJWT, upsertReview);
 router.delete("/:review_id", authenticateJWT, deleteReview);
 
 

--- a/backend/services/reviewCommentService.ts
+++ b/backend/services/reviewCommentService.ts
@@ -1,0 +1,46 @@
+import ReviewCommentRepository from '../repositories/reviewCommentRepository'
+import ReviewRepository from '../repositories/reviewRepository'
+import { ReviewCommentResponse } from '../types/review'
+
+const MAX_REVIEW_COMMENT_LENGTH = 500
+
+class ReviewCommentService {
+  async getCommentsByReviewId(review_id: number, user_id?: number): Promise<ReviewCommentResponse[]> {
+    await ReviewRepository.ensureReviewExists(review_id)
+    return await ReviewCommentRepository.getCommentsByReviewId(review_id, user_id)
+  }
+
+  async createComment(review_id: number, user_id: number, content: string): Promise<void> {
+    await ReviewRepository.ensureReviewExists(review_id)
+
+    const normalizedContent = content.trim()
+    if (!normalizedContent) {
+      throw new Error('COMMENT_EMPTY')
+    }
+
+    if (normalizedContent.length > MAX_REVIEW_COMMENT_LENGTH) {
+      throw new Error('COMMENT_TOO_LONG')
+    }
+
+    await ReviewCommentRepository.createComment(review_id, user_id, normalizedContent)
+  }
+
+  async deleteComment(review_id: number, comment_id: number, user_id: number): Promise<void> {
+    await ReviewCommentRepository.deleteComment(review_id, comment_id, user_id)
+  }
+
+  async updateComment(review_id: number, comment_id: number, user_id: number, content: string): Promise<void> {
+    const normalizedContent = content.trim()
+    if (!normalizedContent) {
+      throw new Error('COMMENT_EMPTY')
+    }
+
+    if (normalizedContent.length > MAX_REVIEW_COMMENT_LENGTH) {
+      throw new Error('COMMENT_TOO_LONG')
+    }
+
+    await ReviewCommentRepository.updateComment(review_id, comment_id, user_id, normalizedContent)
+  }
+}
+
+export default new ReviewCommentService()

--- a/backend/types/review.ts
+++ b/backend/types/review.ts
@@ -33,11 +33,10 @@ export interface ReviewsResponse {
 export interface ReviewCommentResponse {
   id: number;
   review_id: number;
-  user_id: number;
   content: string;
   created_at: Date;
   updated_at: Date;
-  UserModel: {
+  UserModel?: {
     name: string;
     avatar: string;
   };

--- a/backend/types/review.ts
+++ b/backend/types/review.ts
@@ -19,6 +19,7 @@ export interface ReviewsResponse {
   coolness: number;
   comment?: string;
   favorites: number;
+  comment_count: number;
   reactions: ReviewReactionSummary;
   created_at: Date;
   updated_at: Date;
@@ -27,6 +28,20 @@ export interface ReviewsResponse {
     avatar: string;
   },
   is_owner: boolean
+}
+
+export interface ReviewCommentResponse {
+  id: number;
+  review_id: number;
+  user_id: number;
+  content: string;
+  created_at: Date;
+  updated_at: Date;
+  UserModel: {
+    name: string;
+    avatar: string;
+  };
+  is_owner: boolean;
 }
 
 export type LatestReviewsResponse = ReviewsResponse & {

--- a/frontend/src/apis/reviewAPI.ts
+++ b/frontend/src/apis/reviewAPI.ts
@@ -1,4 +1,4 @@
-import { UpsertReviewInput, ReviewsResponse, LatestReviewsResponse, ReviewsListResponse } from '../types/reviewType'
+import { UpsertReviewInput, ReviewsResponse, LatestReviewsResponse, ReviewsListResponse, ReviewComment } from '../types/reviewType'
 import { ReviewReactionsResponse, ToggleReviewReactionResponse } from '../types/reactionType'
 import { axiosInstance } from './axiosInstance'
 
@@ -41,4 +41,21 @@ export const toggleReviewReaction = async (
 ): Promise<ToggleReviewReactionResponse> => {
     const response = await axiosInstance.post(`/reviews/${review_id}/reactions/toggle`, { key })
     return response.data
+}
+
+export const getReviewComments = async (review_id: number): Promise<ReviewComment[]> => {
+    const response = await axiosInstance.get(`/reviews/${review_id}/comments`)
+    return response.data
+}
+
+export const createReviewComment = async (review_id: number, content: string): Promise<void> => {
+    await axiosInstance.post(`/reviews/${review_id}/comments`, { content })
+}
+
+export const deleteReviewComment = async (review_id: number, comment_id: number): Promise<void> => {
+    await axiosInstance.delete(`/reviews/${review_id}/comments/${comment_id}`)
+}
+
+export const updateReviewComment = async (review_id: number, comment_id: number, content: string): Promise<void> => {
+    await axiosInstance.patch(`/reviews/${review_id}/comments/${comment_id}`, { content })
 }

--- a/frontend/src/apis/reviewAPI.ts
+++ b/frontend/src/apis/reviewAPI.ts
@@ -45,6 +45,12 @@ export const toggleReviewReaction = async (
 
 export const getReviewComments = async (review_id: number): Promise<ReviewComment[]> => {
     const response = await axiosInstance.get(`/reviews/${review_id}/comments`)
+    if (!Array.isArray(response.data)) {
+        const errorMessage = typeof response.data?.error === 'string'
+            ? response.data.error
+            : 'Invalid review comments response'
+        throw new Error(errorMessage)
+    }
     return response.data
 }
 

--- a/frontend/src/components/ReviewCard.tsx
+++ b/frontend/src/components/ReviewCard.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { ActionIcon, Avatar, Box, Card, Group, Menu, Rating, Text } from '@mantine/core'
+import { ActionIcon, Avatar, Box, Button, Card, Group, Loader, Menu, Rating, Text, Textarea } from '@mantine/core'
 import { BsThreeDots } from 'react-icons/bs'
 import { FaEdit } from 'react-icons/fa'
+import { FiLock, FiMessageCircle, FiSend } from 'react-icons/fi'
 import { RiDeleteBin6Fill } from 'react-icons/ri'
 import style from '../styles/components/ReviewCard.module.css'
 
-import { ReviewsResponse } from '../types/reviewType'
+import { ReviewComment, ReviewsResponse } from '../types/reviewType'
 import { Course } from '../types/courseType'
 import { useAuthStore } from '../stores/authStore'
 import { ReactionPreset, ReviewReactionSummary } from '../types/reactionType'
@@ -18,310 +19,548 @@ import { useDeleteReview } from '../hooks/reviews/useDeleteReview'
 import { useGetReactionPresets } from '../hooks/reactions/useGetReactionPresets'
 import { useToggleReviewReaction } from '../hooks/reactions/useToggleReviewReaction'
 import { getAvatarSrc, getStaticAssetSrc } from '../utils/avatarUrl'
+import { useGetReviewComments } from '../hooks/reviews/useGetReviewComments'
+import { useCreateReviewComment } from '../hooks/reviews/useCreateReviewComment'
+import { useDeleteReviewComment } from '../hooks/reviews/useDeleteReviewComment'
+import { useUpdateReviewComment } from '../hooks/reviews/useUpdateReviewComment'
 
 interface ReviewCardProp {
-	review: ReviewsResponse,
-	course: { course: Course } | null | undefined;
+  review: ReviewsResponse,
+  course: { course: Course } | null | undefined;
 }
 
 const ReviewCard: React.FC<ReviewCardProp> = ({ review, course }) => {
-	const { user } = useAuthStore()
-  
-	const [isAddOrEditReviewModalOpen, setIsAddOrEditReviewModalOpen] = useState(false)
-	const [isDeleteReviewModalOpen, setIsDeleteReviewModalOpen] = useState(false)
-	const [selectedReview, setSelectedReview] = useState<ReviewsResponse | null>(null)
-	const [isCommentExpanded, setIsCommentExpanded] = useState(false)
-	const [isCommentTruncated, setIsCommentTruncated] = useState(false)
-	const commentElementRef = useRef<HTMLParagraphElement | null>(null)
-	const [reactionSummary, setReactionSummary] = useState<ReviewReactionSummary>(review.reactions ?? { counts: {}, myReactions: [] })
+  const { user } = useAuthStore()
 
-	const { data: presetsResponse } = useGetReactionPresets()
-	const presets = presetsResponse?.items ?? []
-	const presetByKey = useMemo(
-		() => new Map<string, ReactionPreset>(presets.map((preset) => [preset.key, preset])),
-		[presets]
-	)
+  const [isAddOrEditReviewModalOpen, setIsAddOrEditReviewModalOpen] = useState(false)
+  const [isDeleteReviewModalOpen, setIsDeleteReviewModalOpen] = useState(false)
+  const [selectedReview, setSelectedReview] = useState<ReviewsResponse | null>(null)
+  const [isCommentExpanded, setIsCommentExpanded] = useState(false)
+  const [isCommentTruncated, setIsCommentTruncated] = useState(false)
+  const commentElementRef = useRef<HTMLParagraphElement | null>(null)
+  const [reactionSummary, setReactionSummary] = useState<ReviewReactionSummary>(review.reactions ?? { counts: {}, myReactions: [] })
 
-	const { mutate: toggleReaction, isPending: isTogglingReaction } = useToggleReviewReaction()
+  const [isCommentsOpen, setIsCommentsOpen] = useState(false)
+  const [commentInput, setCommentInput] = useState('')
+  const [commentError, setCommentError] = useState('')
+  const [commentCount, setCommentCount] = useState(review.comment_count ?? 0)
 
-	const handleEdit = (review: ReviewsResponse) => {
-		setIsAddOrEditReviewModalOpen(true)
-		setSelectedReview(review)
-	}
+  const [editingCommentId, setEditingCommentId] = useState<number | null>(null)
+  const [editingContent, setEditingContent] = useState('')
+  const [editingError, setEditingError] = useState('')
 
-	const { mutate, isPending } = useDeleteReview()
-	const handleConfirmDelete = (review: ReviewsResponse) => {
-		if (review) {
-      mutate(review.id, {
-        onSuccess: () => setIsDeleteReviewModalOpen(false),
-      })
-		}
-	}
+  const { data: presetsResponse } = useGetReactionPresets()
+  const presets = useMemo(() => presetsResponse?.items ?? [], [presetsResponse?.items])
+  const presetByKey = useMemo(
+    () => new Map<string, ReactionPreset>(presets.map((preset) => [preset.key, preset])),
+    [presets]
+  )
 
-	const handleDeleteModal = (review: ReviewsResponse) => {
-		setIsDeleteReviewModalOpen(true)
-		setSelectedReview(review)
-	}
+  const { mutate: toggleReaction, isPending: isTogglingReaction } = useToggleReviewReaction()
+  const {
+    data: comments = [],
+    isLoading: isCommentsLoading,
+  } = useGetReviewComments(review.id, isCommentsOpen)
+  const { mutate: createComment, isPending: isCreatingComment } = useCreateReviewComment(review.id)
+  const { mutate: deleteComment, isPending: isDeletingComment } = useDeleteReviewComment(review.id)
+  const { mutate: updateComment, isPending: isUpdatingComment } = useUpdateReviewComment(review.id)
 
-	const getReactionDisplay = (preset: ReactionPreset | undefined, key: string): string => {
-		if (!preset) return key
-		if (preset.type === 'unicode') return preset.unicode ?? preset.label
-		return preset.label
-	}
+  const handleEdit = (targetReview: ReviewsResponse) => {
+    setIsAddOrEditReviewModalOpen(true)
+    setSelectedReview(targetReview)
+  }
 
-	const sortedReactionKeys = useMemo(() => {
-		const countKeys = Object.keys(reactionSummary.counts).filter((key) => (reactionSummary.counts[key] ?? 0) > 0)
-		const knownKeys = presets
-			.map((preset) => preset.key)
-			.filter((key) => countKeys.includes(key))
-		const unknownKeys = countKeys.filter((key) => !presetByKey.has(key)).sort()
-		return [...knownKeys, ...unknownKeys]
-	}, [reactionSummary.counts, presets, presetByKey])
+  const { mutate, isPending } = useDeleteReview()
+  const handleConfirmDelete = (targetReview: ReviewsResponse) => {
+    mutate(targetReview.id, {
+      onSuccess: () => setIsDeleteReviewModalOpen(false),
+    })
+  }
 
-	const myReactionSet = useMemo(
-		() => new Set(reactionSummary.myReactions),
-		[reactionSummary.myReactions]
-	)
+  const handleDeleteModal = (targetReview: ReviewsResponse) => {
+    setIsDeleteReviewModalOpen(true)
+    setSelectedReview(targetReview)
+  }
 
-	const handleToggleReaction = (key: string) => {
-		if (!user) {
-			return
-		}
+  const getReactionDisplay = (preset: ReactionPreset | undefined, key: string): string => {
+    if (!preset) return key
+    if (preset.type === 'unicode') return preset.unicode ?? preset.label
+    return preset.label
+  }
 
-		toggleReaction(
-			{ review_id: review.id, key },
-			{
-				onSuccess: (result) => {
-					setReactionSummary((prev) => {
-						const nextMyReactions = result.action === 'added'
-							? Array.from(new Set([...prev.myReactions, key]))
-							: prev.myReactions.filter((reactionKey) => reactionKey !== key)
-						return {
-							counts: result.counts,
-							myReactions: nextMyReactions
-						}
-					})
-				}
-			}
-		)
-	}
+  const sortedReactionKeys = useMemo(() => {
+    const countKeys = Object.keys(reactionSummary.counts).filter((key) => (reactionSummary.counts[key] ?? 0) > 0)
+    const knownKeys = presets
+      .map((preset) => preset.key)
+      .filter((key) => countKeys.includes(key))
+    const unknownKeys = countKeys.filter((key) => !presetByKey.has(key)).sort()
+    return [...knownKeys, ...unknownKeys]
+  }, [reactionSummary.counts, presets, presetByKey])
 
-	useEffect(() => {
-		setIsCommentExpanded(false)
-	}, [review.comment])
+  const myReactionSet = useMemo(
+    () => new Set(reactionSummary.myReactions),
+    [reactionSummary.myReactions]
+  )
 
-	useEffect(() => {
-		setReactionSummary(review.reactions ?? { counts: {}, myReactions: [] })
-	}, [review.reactions])
+  const handleToggleReaction = (key: string) => {
+    if (!user) return
 
-	useEffect(() => {
-		const el = commentElementRef.current
-		if (!el) {
-			return
-		}
+    toggleReaction(
+      { review_id: review.id, key },
+      {
+        onSuccess: (result) => {
+          setReactionSummary((prev) => {
+            const nextMyReactions = result.action === 'added'
+              ? Array.from(new Set([...prev.myReactions, key]))
+              : prev.myReactions.filter((reactionKey) => reactionKey !== key)
+            return {
+              counts: result.counts,
+              myReactions: nextMyReactions,
+            }
+          })
+        },
+      }
+    )
+  }
 
-		const checkTruncate = () => {
-			if (isCommentExpanded) {
-				setIsCommentTruncated(false)
-				return
-			}
-			setIsCommentTruncated(el.scrollHeight > el.clientHeight + 1)
-		}
+  const handleSubmitComment = () => {
+    const normalizedComment = commentInput.trim()
+    if (normalizedComment.length === 0) {
+      setCommentError('留言不能是空白')
+      return
+    }
+    if (normalizedComment.length > 500) {
+      setCommentError('留言最多 500 字')
+      return
+    }
 
-		const scheduleCheck = () => {
-			requestAnimationFrame(checkTruncate)
-		}
+    createComment(normalizedComment, {
+      onSuccess: () => {
+        setCommentInput('')
+        setCommentError('')
+        setCommentCount((prev) => prev + 1)
+      },
+      onError: () => {
+        setCommentError('留言送出失敗，請稍後再試')
+      },
+    })
+  }
 
-		scheduleCheck()
+  const handleDeleteComment = (commentId: number) => {
+    deleteComment(commentId, {
+      onSuccess: () => {
+        setCommentCount((prev) => Math.max(prev - 1, 0))
+      },
+    })
+  }
 
-		const resizeObserver = new ResizeObserver(scheduleCheck)
-		resizeObserver.observe(el)
-		window.addEventListener('resize', scheduleCheck)
+  const startEditComment = (comment: ReviewComment) => {
+    setEditingCommentId(comment.id)
+    setEditingContent(comment.content)
+    setEditingError('')
+  }
 
-		return () => {
-			resizeObserver.disconnect()
-			window.removeEventListener('resize', scheduleCheck)
-		}
-	}, [isCommentExpanded, review.comment])
+  const cancelEditComment = () => {
+    setEditingCommentId(null)
+    setEditingContent('')
+    setEditingError('')
+  }
 
-  const reviewerName =
-    review.is_owner
-      ? (user?.name ?? review.UserModel?.name ?? '匿名')
-      : (review.UserModel?.name ?? '匿名')
+  const saveEditComment = (commentId: number) => {
+    const normalizedContent = editingContent.trim()
+    if (!normalizedContent) {
+      setEditingError('留言不能是空白')
+      return
+    }
+    if (normalizedContent.length > 500) {
+      setEditingError('留言最多 500 字')
+      return
+    }
 
-  const reviewerAvatar =
-    review.is_owner
-      ? (user ? (user.avatar ?? null) : (review.UserModel?.avatar ?? null))
-      : (review.UserModel?.avatar ?? null)
+    updateComment(
+      { comment_id: commentId, content: normalizedContent },
+      {
+        onSuccess: () => {
+          cancelEditComment()
+        },
+        onError: () => {
+          setEditingError('更新留言失敗，請稍後再試')
+        },
+      }
+    )
+  }
+
+  useEffect(() => {
+    setIsCommentExpanded(false)
+  }, [review.comment])
+
+  useEffect(() => {
+    setReactionSummary(review.reactions ?? { counts: {}, myReactions: [] })
+  }, [review.reactions])
+
+  useEffect(() => {
+    setCommentCount(review.comment_count ?? 0)
+  }, [review.comment_count])
+
+  useEffect(() => {
+    if (isCommentsOpen && !isCommentsLoading) {
+      setCommentCount(comments.length)
+    }
+  }, [isCommentsOpen, isCommentsLoading, comments.length])
+
+  useEffect(() => {
+    const el = commentElementRef.current
+    if (!el) return
+
+    const checkTruncate = () => {
+      if (isCommentExpanded) {
+        setIsCommentTruncated(false)
+        return
+      }
+      setIsCommentTruncated(el.scrollHeight > el.clientHeight + 1)
+    }
+
+    const scheduleCheck = () => {
+      requestAnimationFrame(checkTruncate)
+    }
+
+    scheduleCheck()
+
+    const resizeObserver = new ResizeObserver(scheduleCheck)
+    resizeObserver.observe(el)
+    window.addEventListener('resize', scheduleCheck)
+
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener('resize', scheduleCheck)
+    }
+  }, [isCommentExpanded, review.comment])
+
+  const reviewerName = review.is_owner
+    ? (user?.name ?? review.UserModel?.name ?? '匿名')
+    : (review.UserModel?.name ?? '匿名')
+
+  const reviewerAvatar = review.is_owner
+    ? (user ? (user.avatar ?? null) : (review.UserModel?.avatar ?? null))
+    : (review.UserModel?.avatar ?? null)
+
   const avatarSrc = getAvatarSrc(reviewerAvatar)
 
+  return (
+    <Card className={style.card}>
+      <Card.Section className={style.cardSection}>
+        <Group justify='space-between' className={style.headerRow}>
+          <Group className={style.userInfo}>
+            <Avatar variant='light' size='lg' color='brick-red.6' src={avatarSrc} />
+            <Box className={style.userMeta}>
+              <Text>{reviewerName}</Text>
+              <Text size='xs' c='dimmed'>{new Date(review.updated_at).toLocaleString()}</Text>
+            </Box>
+          </Group>
+          {review.is_owner && (
+            <Menu>
+              <Menu.Target>
+                <ActionIcon variant='subtle' size='lg' radius='md' className={style.menuButton}>
+                  <BsThreeDots size={16} />
+                </ActionIcon>
+              </Menu.Target>
 
-	return (
-		<Card className={style.card}>
-			<Card.Section className={style.cardSection}>
-				<Group justify='space-between' className={style.headerRow}>
-					<Group className={style.userInfo}>
-						<Avatar variant='light' size='lg' color='brick-red.6' src={avatarSrc} />
-						<Box className={style.userMeta}>
-							<Text>{reviewerName}</Text>
-							<Text size='xs' c='dimmed'>{new Date(review.updated_at).toLocaleString()}</Text>
-						</Box>
-					</Group>
-					{review.is_owner && (
-						<Menu>
-							<Menu.Target>
-								<ActionIcon variant='subtle' size='lg' radius='md' className={style.menuButton}>
-									<BsThreeDots size={16} />
-								</ActionIcon>
-							</Menu.Target>
-
-							<Menu.Dropdown className={style.dropdown}>
-								<Menu.Item
-									leftSection={<FaEdit size={16} />}
-									classNames={{ itemLabel: style.itemLabel }}
-									onClick={() => handleEdit(review)}
-								>
-									編輯
-								</Menu.Item>
-								<Menu.Item
-									leftSection={<RiDeleteBin6Fill size={16} />}
-									classNames={{ itemLabel: style.itemLabel }}
-									color='red'
-									onClick={() => handleDeleteModal(review)}
-								>
-									刪除
-								</Menu.Item>
-							</Menu.Dropdown>
-						</Menu>
-					)}
-				</Group>
-				{course &&
-					<AddOrEditReviewModal opened={isAddOrEditReviewModalOpen} onClose={() => setIsAddOrEditReviewModalOpen(false)} course={course} review={selectedReview} />
-				}
-				{course &&
-					<ConfirmModal
-						opened={isDeleteReviewModalOpen}
-						onClose={() => setIsDeleteReviewModalOpen(false)}
-						title='刪除評論'
+              <Menu.Dropdown className={style.dropdown}>
+                <Menu.Item
+                  leftSection={<FaEdit size={16} />}
+                  classNames={{ itemLabel: style.itemLabel }}
+                  onClick={() => handleEdit(review)}
+                >
+                  編輯
+                </Menu.Item>
+                <Menu.Item
+                  leftSection={<RiDeleteBin6Fill size={16} />}
+                  classNames={{ itemLabel: style.itemLabel }}
+                  color='red'
+                  onClick={() => handleDeleteModal(review)}
+                >
+                  刪除
+                </Menu.Item>
+              </Menu.Dropdown>
+            </Menu>
+          )}
+        </Group>
+        {course && (
+          <AddOrEditReviewModal
+            opened={isAddOrEditReviewModalOpen}
+            onClose={() => setIsAddOrEditReviewModalOpen(false)}
+            course={course}
+            review={selectedReview}
+          />
+        )}
+        {course && (
+          <ConfirmModal
+            opened={isDeleteReviewModalOpen}
+            onClose={() => setIsDeleteReviewModalOpen(false)}
+            title='刪除評論'
             message='確定要刪除評論嗎？一經刪除將無法復原。'
-						confirmText='刪除'
-						cancelText='取消'
-						loading={isPending}
-						onConfirm={() => selectedReview && handleConfirmDelete(selectedReview)}
-					/>
-				}
-			</Card.Section>
+            confirmText='刪除'
+            cancelText='取消'
+            loading={isPending}
+            onConfirm={() => selectedReview && handleConfirmDelete(selectedReview)}
+          />
+        )}
+      </Card.Section>
 
-			<Card.Section className={style.cardSection}>
-				<Text size='md' fw={900} className={style.courseName}>
-					<Link to={`/course/${course?.course.id}`} className={style.link}>
-						{course?.course.course_name} / {course?.course.instructor}
-					</Link>
-				</Text>
-			</Card.Section>
+      <Card.Section className={style.cardSection}>
+        <Text size='md' fw={900} className={style.courseName}>
+          <Link to={`/course/${course?.course.id}`} className={style.link}>
+            {course?.course.course_name} / {course?.course.instructor}
+          </Link>
+        </Text>
+      </Card.Section>
 
-			<Card.Section className={style.cardSection}>
-				<div className={style.ratingsBox}>
-					<Group className={style.ratings}>
-					<Group className={style.ratingItem}>
-						<Text>收穫</Text>
-						<Rating value={review.gain} color='brick-red.6' size='md' fractions={2} readOnly></Rating>
-					</Group>
+      <Card.Section className={style.cardSection}>
+        <div className={style.ratingsBox}>
+          <Group className={style.ratings}>
+            <Group className={style.ratingItem}>
+              <Text>收穫</Text>
+              <Rating value={review.gain} color='brick-red.6' size='md' fractions={2} readOnly />
+            </Group>
 
-					<Group className={style.ratingItem}>
-						<Text>甜度</Text>
-						<Rating value={review.sweetness} color='brick-red.6' size='md' fractions={2} readOnly></Rating>
-					</Group>
+            <Group className={style.ratingItem}>
+              <Text>甜度</Text>
+              <Rating value={review.sweetness} color='brick-red.6' size='md' fractions={2} readOnly />
+            </Group>
 
-					<Group className={style.ratingItem}>
-						<Text>涼度</Text>
-						<Rating value={review.coolness} color='brick-red.6' size='md' fractions={2} readOnly></Rating>
-					</Group>
-					</Group>
-				</div>
-			</Card.Section>
+            <Group className={style.ratingItem}>
+              <Text>涼度</Text>
+              <Rating value={review.coolness} color='brick-red.6' size='md' fractions={2} readOnly />
+            </Group>
+          </Group>
+        </div>
+      </Card.Section>
 
-			<Card.Section className={style.cardSection}>
-				<div className={style.commentBlock}>
-					<Text
-						ref={commentElementRef}
-						className={`${style.commentText}${isCommentExpanded ? '' : ` ${style.commentClamp}`}`}
-					>
-						{review.comment}
-					</Text>
-					{isCommentTruncated && !isCommentExpanded && (
-						<button type='button' className={style.readMore} onClick={() => setIsCommentExpanded(true)}>
-							顯示較多
-						</button>
-					)}
-					{isCommentExpanded && (
-						<button type='button' className={style.readMore} onClick={() => setIsCommentExpanded(false)}>
-							顯示較少
-						</button>
-					)}
-				</div>
-			</Card.Section>
+      <Card.Section className={style.cardSection}>
+        <div className={style.commentBlock}>
+          <Text
+            ref={commentElementRef}
+            className={`${style.commentText}${isCommentExpanded ? '' : ` ${style.commentClamp}`}`}
+          >
+            {review.comment}
+          </Text>
+          {isCommentTruncated && !isCommentExpanded && (
+            <button type='button' className={style.readMore} onClick={() => setIsCommentExpanded(true)}>
+              顯示較多
+            </button>
+          )}
+          {isCommentExpanded && (
+            <button type='button' className={style.readMore} onClick={() => setIsCommentExpanded(false)}>
+              顯示較少
+            </button>
+          )}
+        </div>
+      </Card.Section>
 
-			<Card.Section className={style.cardSection}>
-				<div className={style.reactionBar}>
-					{sortedReactionKeys.map((key) => {
-						const preset = presetByKey.get(key)
-						const isMine = myReactionSet.has(key)
-						const count = reactionSummary.counts[key] ?? 0
-						return (
-							<button
-								key={key}
-								type='button'
-								className={`${style.reactionChip}${isMine ? ` ${style.reactionChipActive}` : ''}`}
-								onClick={() => handleToggleReaction(key)}
-								disabled={!user || isTogglingReaction}
-							>
-								{preset?.type === 'image' && preset.imagePath ? (
-									<img src={getStaticAssetSrc(preset.imagePath) ?? undefined} alt={preset.label} className={style.reactionImage} />
-								) : (
-									<span className={style.reactionEmoji}>{getReactionDisplay(preset, key)}</span>
-								)}
-								<span className={style.reactionCount}>{count}</span>
-							</button>
-						)
-					})}
+      <Card.Section className={style.cardSection}>
+        <div className={style.reactionBar}>
+          <button
+            type='button'
+            className={`${style.commentIconButton}${isCommentsOpen ? ` ${style.commentIconButtonActive}` : ''}`}
+            onClick={() => setIsCommentsOpen((prev) => !prev)}
+            aria-label='切換留言區'
+          >
+            <FiMessageCircle size={16} />
+            <span>{commentCount}</span>
+          </button>
 
-					<Menu withinPortal position='bottom-start'>
-						<Menu.Target>
-							<button
-								type='button'
-								className={style.reactionAddButton}
-								disabled={!user || isTogglingReaction || presets.length === 0}
-							>
-								+
-							</button>
-						</Menu.Target>
-						<Menu.Dropdown className={style.dropdown}>
-							<div className={style.reactionPickerGrid}>
-								{presets.map((preset) => (
-									<button
-										key={preset.key}
-										type='button'
-										className={style.reactionPickerButton}
-										onClick={() => handleToggleReaction(preset.key)}
-										title={preset.label}
-										aria-label={preset.label}
-										disabled={isTogglingReaction}
-									>
-										{preset.type === 'image' && preset.imagePath ? (
-											<img src={getStaticAssetSrc(preset.imagePath) ?? undefined} alt={preset.label} className={style.reactionImage} />
-										) : (
-											<span className={style.reactionEmoji}>{getReactionDisplay(preset, preset.key)}</span>
-										)}
-									</button>
-								))}
-							</div>
-						</Menu.Dropdown>
-					</Menu>
-				</div>
-			</Card.Section>
-		</Card>
-	)
+          {sortedReactionKeys.map((key) => {
+            const preset = presetByKey.get(key)
+            const isMine = myReactionSet.has(key)
+            const count = reactionSummary.counts[key] ?? 0
+            return (
+              <button
+                key={key}
+                type='button'
+                className={`${style.reactionChip}${isMine ? ` ${style.reactionChipActive}` : ''}`}
+                onClick={() => handleToggleReaction(key)}
+                disabled={!user || isTogglingReaction}
+              >
+                {preset?.type === 'image' && preset.imagePath ? (
+                  <img src={getStaticAssetSrc(preset.imagePath) ?? undefined} alt={preset.label} className={style.reactionImage} />
+                ) : (
+                  <span className={style.reactionEmoji}>{getReactionDisplay(preset, key)}</span>
+                )}
+                <span className={style.reactionCount}>{count}</span>
+              </button>
+            )
+          })}
+
+          <Menu withinPortal position='bottom-start'>
+            <Menu.Target>
+              <button
+                type='button'
+                className={style.reactionAddButton}
+                disabled={!user || isTogglingReaction || presets.length === 0}
+              >
+                +
+              </button>
+            </Menu.Target>
+            <Menu.Dropdown className={style.dropdown}>
+              <div className={style.reactionPickerGrid}>
+                {presets.map((preset) => (
+                  <button
+                    key={preset.key}
+                    type='button'
+                    className={style.reactionPickerButton}
+                    onClick={() => handleToggleReaction(preset.key)}
+                    title={preset.label}
+                    aria-label={preset.label}
+                    disabled={isTogglingReaction}
+                  >
+                    {preset.type === 'image' && preset.imagePath ? (
+                      <img src={getStaticAssetSrc(preset.imagePath) ?? undefined} alt={preset.label} className={style.reactionImage} />
+                    ) : (
+                      <span className={style.reactionEmoji}>{getReactionDisplay(preset, preset.key)}</span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            </Menu.Dropdown>
+          </Menu>
+        </div>
+      </Card.Section>
+
+      {isCommentsOpen && (
+        <Card.Section className={style.cardSection}>
+          <div className={style.commentsPanel}>
+            {isCommentsLoading ? (
+              <div className={style.commentsLoading}>
+                <Loader size='sm' />
+              </div>
+            ) : comments.length === 0 ? (
+              <Text size='sm' c='dimmed'>目前還沒有留言。</Text>
+            ) : (
+              <div className={style.commentsList}>
+                {comments.map((comment: ReviewComment) => {
+                  const isEditing = editingCommentId === comment.id
+                  return (
+                    <div key={comment.id} className={style.commentRow}>
+                      <Avatar
+                        variant='light'
+                        size='sm'
+                        color='brick-red.6'
+                        src={getAvatarSrc(comment.UserModel?.avatar ?? null)}
+                      />
+
+                      <div className={style.commentBody}>
+                        <div className={style.commentItemHeader}>
+                          <div>
+                            <Text size='sm' fw={600}>{comment.UserModel?.name ?? '匿名'}</Text>
+                            <Text size='xs' c='dimmed'>{new Date(comment.updated_at).toLocaleString()}</Text>
+                          </div>
+
+                          {comment.is_owner && (
+                            <Menu>
+                              <Menu.Target>
+                                <ActionIcon variant='subtle' size='sm' radius='md' className={style.menuButton}>
+                                  <BsThreeDots size={14} />
+                                </ActionIcon>
+                              </Menu.Target>
+                              <Menu.Dropdown className={style.dropdown}>
+                                <Menu.Item
+                                  leftSection={<FaEdit size={14} />}
+                                  classNames={{ itemLabel: style.itemLabel }}
+                                  onClick={() => startEditComment(comment)}
+                                >
+                                  編輯
+                                </Menu.Item>
+                                <Menu.Item
+                                  leftSection={<RiDeleteBin6Fill size={14} />}
+                                  classNames={{ itemLabel: style.itemLabel }}
+                                  color='red'
+                                  onClick={() => handleDeleteComment(comment.id)}
+                                  disabled={isDeletingComment}
+                                >
+                                  刪除
+                                </Menu.Item>
+                              </Menu.Dropdown>
+                            </Menu>
+                          )}
+                        </div>
+
+                        {isEditing ? (
+                          <div className={style.commentEditBox}>
+                            <Textarea
+                              value={editingContent}
+                              onChange={(event) => {
+                                setEditingContent(event.currentTarget.value)
+                                if (editingError) setEditingError('')
+                              }}
+                              minRows={1}
+                              maxRows={4}
+                              autosize
+                              maxLength={500}
+                            />
+                            <div className={style.commentEditActions}>
+                              <Button size='compact-xs' variant='subtle' onClick={cancelEditComment}>
+                                取消
+                              </Button>
+                              <Button
+                                size='compact-xs'
+                                onClick={() => saveEditComment(comment.id)}
+                                loading={isUpdatingComment}
+                              >
+                                儲存
+                              </Button>
+                            </div>
+                            {editingError && <Text size='xs' c='red'>{editingError}</Text>}
+                          </div>
+                        ) : (
+                          <Text size='sm' className={style.commentItemContent}>{comment.content}</Text>
+                        )}
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+
+            <div className={style.commentComposerRow}>
+              <Avatar
+                variant='light'
+                size='sm'
+                color='brick-red.6'
+                src={getAvatarSrc(user?.avatar ?? null)}
+              />
+              <div className={style.commentComposerMain}>
+                <Textarea
+                  value={commentInput}
+                  onChange={(event) => {
+                    setCommentInput(event.currentTarget.value)
+                    if (commentError) setCommentError('')
+                  }}
+                  placeholder={user ? '輸入留言...' : '請先登入'}
+                  minRows={1}
+                  maxRows={3}
+                  autosize
+                  maxLength={500}
+                  disabled={!user || isCreatingComment}
+                  className={style.commentComposerTextarea}
+                />
+                <ActionIcon
+                  variant='light'
+                  color='brick-red.6'
+                  onClick={handleSubmitComment}
+                  disabled={!user || isCreatingComment}
+                  loading={isCreatingComment}
+                  aria-label='送出留言'
+                >
+                  {user ? <FiSend size={16} /> : <FiLock size={16} />}
+                </ActionIcon>
+              </div>
+            </div>
+            {commentError && <Text size='xs' c='red'>{commentError}</Text>}
+          </div>
+        </Card.Section>
+      )}
+    </Card>
+  )
 }
 
 export default ReviewCard

--- a/frontend/src/components/ReviewCard.tsx
+++ b/frontend/src/components/ReviewCard.tsx
@@ -58,9 +58,11 @@ const ReviewCard: React.FC<ReviewCardProp> = ({ review, course }) => {
 
   const { mutate: toggleReaction, isPending: isTogglingReaction } = useToggleReviewReaction()
   const {
-    data: comments = [],
+    data: comments,
     isLoading: isCommentsLoading,
+    isError: isCommentsError,
   } = useGetReviewComments(review.id, isCommentsOpen)
+  const resolvedComments = comments ?? []
   const { mutate: createComment, isPending: isCreatingComment } = useCreateReviewComment(review.id)
   const { mutate: deleteComment, isPending: isDeletingComment } = useDeleteReviewComment(review.id)
   const { mutate: updateComment, isPending: isUpdatingComment } = useUpdateReviewComment(review.id)
@@ -203,10 +205,10 @@ const ReviewCard: React.FC<ReviewCardProp> = ({ review, course }) => {
   }, [review.comment_count])
 
   useEffect(() => {
-    if (isCommentsOpen && !isCommentsLoading) {
+    if (isCommentsOpen && !isCommentsLoading && comments) {
       setCommentCount(comments.length)
     }
-  }, [isCommentsOpen, isCommentsLoading, comments.length])
+  }, [isCommentsOpen, isCommentsLoading, comments])
 
   useEffect(() => {
     const el = commentElementRef.current
@@ -433,11 +435,13 @@ const ReviewCard: React.FC<ReviewCardProp> = ({ review, course }) => {
               <div className={style.commentsLoading}>
                 <Loader size='sm' />
               </div>
-            ) : comments.length === 0 ? (
+            ) : isCommentsError && !comments ? (
+              <Text size='sm' c='red'>載入留言失敗，請稍後再試。</Text>
+            ) : resolvedComments.length === 0 ? (
               <Text size='sm' c='dimmed'>目前還沒有留言。</Text>
             ) : (
               <div className={style.commentsList}>
-                {comments.map((comment: ReviewComment) => {
+                {resolvedComments.map((comment: ReviewComment) => {
                   const isEditing = editingCommentId === comment.id
                   return (
                     <div key={comment.id} className={style.commentRow}>

--- a/frontend/src/components/ReviewCard.tsx
+++ b/frontend/src/components/ReviewCard.tsx
@@ -62,7 +62,7 @@ const ReviewCard: React.FC<ReviewCardProp> = ({ review, course }) => {
     isLoading: isCommentsLoading,
     isError: isCommentsError,
   } = useGetReviewComments(review.id, isCommentsOpen)
-  const resolvedComments = comments ?? []
+  const resolvedComments = Array.isArray(comments) ? comments : []
   const { mutate: createComment, isPending: isCreatingComment } = useCreateReviewComment(review.id)
   const { mutate: deleteComment, isPending: isDeletingComment } = useDeleteReviewComment(review.id)
   const { mutate: updateComment, isPending: isUpdatingComment } = useUpdateReviewComment(review.id)
@@ -205,7 +205,7 @@ const ReviewCard: React.FC<ReviewCardProp> = ({ review, course }) => {
   }, [review.comment_count])
 
   useEffect(() => {
-    if (isCommentsOpen && !isCommentsLoading && comments) {
+    if (isCommentsOpen && !isCommentsLoading && Array.isArray(comments)) {
       setCommentCount(comments.length)
     }
   }, [isCommentsOpen, isCommentsLoading, comments])
@@ -435,7 +435,7 @@ const ReviewCard: React.FC<ReviewCardProp> = ({ review, course }) => {
               <div className={style.commentsLoading}>
                 <Loader size='sm' />
               </div>
-            ) : isCommentsError && !comments ? (
+            ) : isCommentsError && !Array.isArray(comments) ? (
               <Text size='sm' c='red'>載入留言失敗，請稍後再試。</Text>
             ) : resolvedComments.length === 0 ? (
               <Text size='sm' c='dimmed'>目前還沒有留言。</Text>

--- a/frontend/src/components/ReviewCard.tsx
+++ b/frontend/src/components/ReviewCard.tsx
@@ -371,6 +371,8 @@ const ReviewCard: React.FC<ReviewCardProp> = ({ review, course }) => {
             <span>{commentCount}</span>
           </button>
 
+          <span className={style.reactionDivider} aria-hidden='true' />
+
           {sortedReactionKeys.map((key) => {
             const preset = presetByKey.get(key)
             const isMine = myReactionSet.has(key)

--- a/frontend/src/hooks/queryKeys.ts
+++ b/frontend/src/hooks/queryKeys.ts
@@ -8,6 +8,7 @@ export const QUERY_KEYS = {
   CHECK_AUTH_STATUS: 'checkAuthStatus',
   
   REVIEWS: 'reviews',
+  REVIEW_COMMENTS: 'review_comments',
   INFINITY_REVIEWS: 'infinity_reviews',
   LATEST_REVIEWS: 'latest_reviews',
   REACTION_PRESETS: 'reaction_presets',

--- a/frontend/src/hooks/reviews/useCreateReviewComment.ts
+++ b/frontend/src/hooks/reviews/useCreateReviewComment.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { createReviewComment } from '../../apis/reviewAPI'
+import { QUERY_KEYS } from '../queryKeys'
+
+export const useCreateReviewComment = (review_id: number) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (content: string) => createReviewComment(review_id, content),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.REVIEW_COMMENTS, review_id] })
+    },
+  })
+}

--- a/frontend/src/hooks/reviews/useCreateReviewComment.ts
+++ b/frontend/src/hooks/reviews/useCreateReviewComment.ts
@@ -9,6 +9,9 @@ export const useCreateReviewComment = (review_id: number) => {
     mutationFn: (content: string) => createReviewComment(review_id, content),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.REVIEW_COMMENTS, review_id] })
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.REVIEWS] })
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.INFINITY_REVIEWS] })
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.LATEST_REVIEWS] })
     },
   })
 }

--- a/frontend/src/hooks/reviews/useDeleteReviewComment.ts
+++ b/frontend/src/hooks/reviews/useDeleteReviewComment.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { deleteReviewComment } from '../../apis/reviewAPI'
+import { QUERY_KEYS } from '../queryKeys'
+
+export const useDeleteReviewComment = (review_id: number) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (comment_id: number) => deleteReviewComment(review_id, comment_id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.REVIEW_COMMENTS, review_id] })
+    },
+  })
+}

--- a/frontend/src/hooks/reviews/useDeleteReviewComment.ts
+++ b/frontend/src/hooks/reviews/useDeleteReviewComment.ts
@@ -9,6 +9,9 @@ export const useDeleteReviewComment = (review_id: number) => {
     mutationFn: (comment_id: number) => deleteReviewComment(review_id, comment_id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.REVIEW_COMMENTS, review_id] })
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.REVIEWS] })
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.INFINITY_REVIEWS] })
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.LATEST_REVIEWS] })
     },
   })
 }

--- a/frontend/src/hooks/reviews/useGetReviewComments.ts
+++ b/frontend/src/hooks/reviews/useGetReviewComments.ts
@@ -1,10 +1,13 @@
 import { useQuery } from '@tanstack/react-query'
 import { getReviewComments } from '../../apis/reviewAPI'
 import { QUERY_KEYS } from '../queryKeys'
+import { useAuthStore } from '../../stores/authStore'
 
 export const useGetReviewComments = (review_id: number, enabled: boolean) => {
+  const userId = useAuthStore((state) => state.user?.id ?? 'guest')
+
   return useQuery({
-    queryKey: [QUERY_KEYS.REVIEW_COMMENTS, review_id],
+    queryKey: [QUERY_KEYS.REVIEW_COMMENTS, review_id, userId],
     queryFn: () => getReviewComments(review_id),
     enabled,
   })

--- a/frontend/src/hooks/reviews/useGetReviewComments.ts
+++ b/frontend/src/hooks/reviews/useGetReviewComments.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query'
+import { getReviewComments } from '../../apis/reviewAPI'
+import { QUERY_KEYS } from '../queryKeys'
+
+export const useGetReviewComments = (review_id: number, enabled: boolean) => {
+  return useQuery({
+    queryKey: [QUERY_KEYS.REVIEW_COMMENTS, review_id],
+    queryFn: () => getReviewComments(review_id),
+    enabled,
+  })
+}

--- a/frontend/src/hooks/reviews/useUpdateReviewComment.ts
+++ b/frontend/src/hooks/reviews/useUpdateReviewComment.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { updateReviewComment } from '../../apis/reviewAPI'
+import { QUERY_KEYS } from '../queryKeys'
+
+export const useUpdateReviewComment = (review_id: number) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ comment_id, content }: { comment_id: number; content: string }) =>
+      updateReviewComment(review_id, comment_id, content),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.REVIEW_COMMENTS, review_id] })
+    },
+  })
+}

--- a/frontend/src/styles/components/ReviewCard.module.css
+++ b/frontend/src/styles/components/ReviewCard.module.css
@@ -109,6 +109,13 @@
   gap: 0.5rem;
 }
 
+.reactionDivider {
+  width: 1px;
+  align-self: stretch;
+  min-height: 1.75rem;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.08) 0%, rgba(0, 0, 0, 0.24) 50%, rgba(0, 0, 0, 0.08) 100%);
+}
+
 .reactionChip {
   border: 1px solid #d2d2d2;
   border-radius: 999px;
@@ -317,5 +324,9 @@
 
   .commentComposerMain {
     align-items: stretch;
+  }
+
+  .reactionDivider {
+    min-height: 1.5rem;
   }
 }

--- a/frontend/src/styles/components/ReviewCard.module.css
+++ b/frontend/src/styles/components/ReviewCard.module.css
@@ -86,7 +86,6 @@
   border: 1px solid #e1dbd2;
   border-radius: 6px;
   padding: 0.75rem 0.75rem;
-  
   background-color: #f7f5f2;
 }
 
@@ -167,12 +166,6 @@
   opacity: 0.65;
 }
 
-.reactionMenuItem {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-}
-
 .reactionPickerGrid {
   display: grid;
   grid-template-columns: repeat(6, minmax(0, 1fr));
@@ -210,15 +203,119 @@
   border-radius: 4px;
 }
 
+.commentIconButton {
+  border: 1px solid #d2d2d2;
+  border-radius: 999px;
+  background: #fff;
+  color: #2e2e2e;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.22rem 0.7rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.commentIconButton:hover {
+  background: #f6f6f6;
+}
+
+.commentIconButtonActive {
+  border-color: #a88755;
+  background: #f4eee5;
+}
+
+.commentsPanel {
+  margin-top: 0.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.commentComposerRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.commentComposerMain {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.commentComposerTextarea {
+  flex: 1;
+}
+
+.commentsLoading {
+  display: flex;
+  justify-content: center;
+  padding: 0.5rem 0;
+}
+
+.commentsList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.commentRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.commentBody {
+  flex: 1;
+  border: 1px solid #ececec;
+  border-radius: 10px;
+  background: #fff;
+  padding: 0.5rem 0.65rem;
+}
+
+.commentItemHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.commentItemContent {
+  margin-top: 0.25rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.commentEditBox {
+  margin-top: 0.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.commentEditActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.35rem;
+}
+
 @media (max-width: 768px) {
   .ratings {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 0.5rem;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
   }
 
   .ratingItem {
-      width: 100%;
-      justify-content: space-between;
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .commentComposerMain {
+    align-items: stretch;
   }
 }

--- a/frontend/src/types/reviewType.ts
+++ b/frontend/src/types/reviewType.ts
@@ -10,6 +10,7 @@ export interface ReviewsResponse {
   coolness: number;
   comment?: string;
   favorites: number;
+  comment_count: number;
   reactions: ReviewReactionSummary;
   created_at: Date;
   updated_at: Date;
@@ -38,4 +39,18 @@ export interface UpsertReviewInput {
   sweetness: number;
   coolness: number;
   comment: string;
+}
+
+export interface ReviewComment {
+  id: number;
+  review_id: number;
+  user_id: number;
+  content: string;
+  created_at: Date;
+  updated_at: Date;
+  UserModel: {
+    name: string;
+    avatar: string;
+  };
+  is_owner: boolean;
 }

--- a/frontend/src/types/reviewType.ts
+++ b/frontend/src/types/reviewType.ts
@@ -44,11 +44,10 @@ export interface UpsertReviewInput {
 export interface ReviewComment {
   id: number;
   review_id: number;
-  user_id: number;
   content: string;
   created_at: Date;
   updated_at: Date;
-  UserModel: {
+  UserModel?: {
     name: string;
     avatar: string;
   };


### PR DESCRIPTION
## 標題

feat(review-comments): add inline comments for course reviews

---

## 摘要

新增課程評價的留言功能，支援前後端完整串接：

* 後端新增 `ReviewComments` 資料表與 CRUD API
* 前端新增評價留言的型別、API hooks 與狀態管理
* 評價卡片支援展開留言、建立留言、編輯留言、刪除留言
* 留言操作整合到既有評價區塊，提供更完整的互動討論流程

---

## 背景／問題

原本課程頁的使用者評價只能單篇閱讀，缺少後續追問、補充與回覆機制。當使用者想針對某篇評價補充資訊或追問細節時，系統沒有可用的留言層。

---

## 變更內容

### 1) 後端：留言資料模型與 API

* `20260306110000-create-review-comments.js`
  * 新增 `ReviewComments` 資料表
* `ReviewComment.ts`
  * 新增評價留言 model
* `reviewCommentRepository.ts`
  * 新增留言查詢、建立、更新、刪除操作
* `reviewCommentService.ts`
  * 新增留言服務層
* `reviewController.ts`
  * 新增留言 CRUD controller
* `routes/reviews.ts`
  * 掛入留言相關 routes
* `backend/types/review.ts`
  * 新增留言型別
* `reviewRepository.ts`
  * 補齊與留言功能整合所需查詢邏輯

### 2) 前端：留言型別、API 與 hooks

* `frontend/src/types/reviewType.ts`
  * 新增留言型別
* `frontend/src/apis/reviewAPI.ts`
  * 新增留言 API 呼叫
* `useGetReviewComments.ts`
  * 取得單篇評價留言
* `useCreateReviewComment.ts`
  * 建立留言
* `useUpdateReviewComment.ts`
  * 編輯留言
* `useDeleteReviewComment.ts`
  * 刪除留言
* `frontend/src/hooks/queryKeys.ts`
  * 新增留言 query key

### 3) 前端：評價卡片留言 UI

* `ReviewCard.tsx`
  * 新增留言展開/收合
  * 支援新增留言
  * 支援編輯與刪除自己留言
* `ReviewCard.module.css`
  * 新增留言區塊樣式

---

## 測試方式

### 1) 前端建置

* `cd frontend && npm run build`
* 預期：build 成功

### 2) 後端型別檢查

* `cd backend && npx tsc --noEmit -p tsconfig.json`
* 預期：無 TS 錯誤

### 3) 功能驗證（手動）

* 進入任一課程詳情頁
* 展開使用者評價
* 對一篇評價新增留言
* 預期：
  * 留言成功寫入並立即顯示
* 編輯剛建立的留言
* 預期：
  * 留言內容成功更新
* 刪除留言
* 預期：
  * 留言從列表移除

### 4) 顯示驗證

* 展開有留言的評價卡片
* 預期：
  * 留言區塊正常顯示
  * 留言數與內容正確
  * 操作按鈕只對可操作的留言顯示

---

## 備註

* 本 PR 包含資料表、後端 API、前端 hooks 與評價卡片 UI，屬完整端到端的評價留言功能。