### PR TITLE
Feat/add EWANT course

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Repository Instructions
+
+- Keep edits minimal and scoped to the user's request. Do not reorder imports, rename existing identifiers, rewrite whole files, or change surrounding style unless required for the requested change or necessary to fix a related error.
+- Use Traditional Chinese only in user-facing copy, comments, explanations, and newly added text. Do not introduce mojibake or garbled text.
+- For UI or visual style work, prefer referencing the project's previous style-focused branches and existing in-repo visual patterns before introducing a new direction.
+- Prefer clear, semantic variable names over shortened or opaque names, especially when extracting display logic from JSX.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,4 @@
 - Use Traditional Chinese only in user-facing copy, comments, explanations, and newly added text. Do not introduce mojibake or garbled text.
 - For UI or visual style work, prefer referencing the project's previous style-focused branches and existing in-repo visual patterns before introducing a new direction.
 - Prefer clear, semantic variable names over shortened or opaque names, especially when extracting display logic from JSX.
+- When the user asks `幫我生 pr`, generate a PR description in Traditional Chinese using this fixed section order: `## 標題`, `---`, `## 摘要`, `---`, `## 背景／問題`, `---`, `## 變更內容`, `---`, `## 測試方式`, `---`, `## 備註`. Base the content on the current branch changes, keep it concise, and include concrete file names and verification steps when applicable.

--- a/backend/migrations/20260321095000-alter-course-url-to-text.js
+++ b/backend/migrations/20260321095000-alter-course-url-to-text.js
@@ -1,0 +1,17 @@
+"use strict";
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn("Courses", "course_url", {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn("Courses", "course_url", {
+      type: Sequelize.STRING(255),
+      allowNull: true,
+    });
+  },
+};

--- a/backend/models/Course.ts
+++ b/backend/models/Course.ts
@@ -62,7 +62,7 @@ CourseModel.init(
       type: DataTypes.STRING(100),
     },
     course_url: {
-      type: DataTypes.STRING(255),
+      type: DataTypes.TEXT,
     },
     credit_hours: {
       type: DataTypes.TINYINT,

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "nodemon --exec tsx server.ts",
     "scrape": "tsx scraper/scraper.ts",
+    "scrape:ewant": "tsx scraper/scraperEwant.ts",
     "backfill:schedules": "tsx scripts/backfillCourseSchedules.ts",
     "backfill:dcard-related-post-counts": "tsx scripts/backfillDcardRelatedPostCounts.ts",
     "migrate": "sequelize-cli db:migrate --config config/config.cjs"

--- a/backend/repositories/courseRepository.ts
+++ b/backend/repositories/courseRepository.ts
@@ -155,6 +155,11 @@ class CourseRepository {
   async getAllDepartments(): Promise<string[]> {
     const departments = await CourseModel.findAll({
       attributes: [[db.Sequelize.fn("DISTINCT", db.Sequelize.col("department")), "department"]],
+      where: {
+        department: {
+          [Op.ne]: "校外遠距(EWANT)",
+        },
+      },
       raw: true
     });
     const departmentList = departments.map((item: { department: string }) => {

--- a/backend/repositories/courseRepository.ts
+++ b/backend/repositories/courseRepository.ts
@@ -76,6 +76,7 @@ class CourseRepository {
         [Op.and]: [
           { department: { [Op.notLike]: "%碩士%" } },
           { department: { [Op.notLike]: "%通識%" } },
+          { department: { [Op.notLike]: "校外遠距(EWANT)" } },
         ]
       });
     } else if (search && search.category === "graduate") {

--- a/backend/repositories/courseRepository.ts
+++ b/backend/repositories/courseRepository.ts
@@ -83,6 +83,9 @@ class CourseRepository {
     } else if (search && search.category === "teacher") {
       categoryConditions.push({ department: { [Op.like]: "%師%" } });
     }
+    if (search && search.category === "ewant") {
+      categoryConditions.push({ department: "校外遠距(EWANT)" });
+    }
     if (search && search.department) {
       categoryConditions.push({ department: search.department });
     }

--- a/backend/repositories/timetableItemRepository.ts
+++ b/backend/repositories/timetableItemRepository.ts
@@ -34,7 +34,7 @@ class TimetableItemRepository {
         {
           model: CourseModel,
           as: "course",
-          attributes: ["id", "course_name", "semester", "instructor", "course_room"],
+          attributes: ["id", "course_name", "semester", "department", "instructor", "course_room"],
         },
       ],
       order: [["created_at", "ASC"]],
@@ -53,7 +53,7 @@ class TimetableItemRepository {
         {
           model: CourseModel,
           as: "course",
-          attributes: ["id", "course_name", "semester", "instructor", "course_time", "course_room"],
+          attributes: ["id", "course_name", "semester", "department", "instructor", "course_time", "course_room"],
         },
       ],
       order: [["created_at", "DESC"]],

--- a/backend/scraper/googleRequestCURL.ts
+++ b/backend/scraper/googleRequestCURL.ts
@@ -1,7 +1,10 @@
-// const cURL = {}
+//----- 一般課程爬蟲 -----//
+// 參考 https://github.com/NoZ915/tainan-select_web-crawler/blob/main/README.md
+// 例如 cURL = new URLSearchParams({...})
+const cURL = new URLSearchParams();
+export const googleRequestCURL: URLSearchParams = cURL;
 
-// 抓＊＊＊-＊年
-// export const googleRequestCURL: URLSearchParams = cURL;
 
-// 防止報錯用而已
-export const googleRequestCURL = ""
+//----- EWANT 課程爬蟲 -----//
+// 例如 1142 = 學期 114-2
+export const EWANT_ACS = "1142"

--- a/backend/scraper/scraperEwant.ts
+++ b/backend/scraper/scraperEwant.ts
@@ -1,0 +1,283 @@
+import "dotenv/config";
+import axios from "axios";
+import https from "https";
+import pLimit from "p-limit";
+import * as cheerio from "cheerio";
+import db from "../models";
+import CourseModel from "../models/Course";
+
+// ewant api 回來的 data type
+type GetCourseItem = {
+  Result: string;
+  Message: string;
+  sYear: string;
+  Sec: string;
+  SelCourNo: string;
+  CourNo: string;
+
+  CourName: string;
+  CourEngName: string;
+
+  ClassName1: string;
+
+  TeaNo1: string;
+  TeaName1: string;
+  TeaName: string;
+  TeaEmail: string;
+  AlPt: string;
+
+  Credit: string;
+  TotHour: string;
+
+  Week: string;
+  Section: string;
+
+  Room: string;
+  ComptRoom: string;
+
+  Method: string;
+  EMI: string;
+  Dist: string;
+  Coord: string;
+  Remark: string;
+
+  MaxSel: string;
+  MinSel: string;
+  NowSel: string;
+};
+
+const BASE_URL = "https://academics.nutn.edu.tw";
+const PAGE_URL = `${BASE_URL}/Course/Qry/cos`;
+const API_URL = `${BASE_URL}/Course/api/Query/GetCourse`;
+const EWANT_SEARCH_URL =
+  "https://www.ewant.org/admin/tool/mooccourse/allcourses.php?filter=4&schoolid=0&categoryid=0&course_filter=3&search=";
+
+// 要爬的條件：114-2 / 其他 / 校外遠距(EWANT)
+const PAYLOAD = {
+  acs: "1142", // acadamic semester 學期：1142 = 114-2
+  kw: "",
+  dc: "",
+  gr: "",
+  ch: "",
+  ot: "DIS_1", // 類別：校外遠距(EWANT)
+  ge: "A",
+  ta: "ZZS101",
+  we: "",
+  ki: "6", // 單位：其他
+  ll: "zh-TW",
+};
+
+const DEPARTMENT_LABEL = "校外遠距(EWANT)";
+
+// 處理爬蟲被擋的問題
+const httpsAgent = new https.Agent({
+  keepAlive: true,
+  maxSockets: 20,
+});
+
+const detailClient = axios.create({
+  httpsAgent,
+  timeout: 15_000,
+  headers: {
+    "User-Agent":
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
+    "Accept-Language": "zh-TW,zh;q=0.9,en;q=0.8",
+    Accept: "*/*",
+  },
+});
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function isRetryableNetworkError(err: any) {
+  const code = err?.code;
+  const status = err?.response?.status;
+
+  return (
+    code === "ETIMEDOUT" ||
+    code === "ECONNRESET" ||
+    code === "ECONNABORTED" ||
+    code === "EAI_AGAIN" ||
+    code === "ENOTFOUND" ||
+    status === 429 ||
+    (status >= 500 && status <= 599)
+  );
+}
+
+async function postWithRetry<T>(
+  url: string,
+  data: any,
+  headers: Record<string, string>,
+  retries = 3
+) {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      return await detailClient.post<T>(url, data, { headers });
+    } catch (err: any) {
+      if (attempt === retries || !isRetryableNetworkError(err)) throw err;
+      const backoff = 400 * 2 ** (attempt - 1) + Math.floor(Math.random() * 300);
+      await sleep(backoff);
+    }
+  }
+  throw new Error("unreachable");
+}
+
+// 初始化 DB
+async function initializeDatabase(): Promise<void> {
+  try {
+    await db.sequelize.authenticate();
+    console.log("MySQL 連線成功");
+  } catch (error) {
+    console.error("無法連接到 MySQL:", error);
+    process.exit(1);
+  }
+}
+
+function pickCookieHeader(setCookie?: string[] | string): string {
+  if (!setCookie) return "";
+  const array = Array.isArray(setCookie) ? setCookie : [setCookie];
+  return array
+    .map((cookie) => cookie.split(";")[0])
+    .filter(Boolean)
+    .join("; ");
+}
+
+function formatSemesterFromAcs(acs: string) {
+  // "1142" -> "114-2"
+  if (!acs || acs.length < 4) return acs;
+  return `${acs.slice(0, 3)}-${acs.slice(3)}`;
+}
+
+function buildInstructorName(item: GetCourseItem) {
+  const name = (item.TeaName1 || item.TeaName || "").trim();
+  if (!name || name === "無") return "無教師";
+  return name;
+}
+
+function buildInstructorUrl(item: GetCourseItem) {
+  // 依你貼的前端 getTea() 邏輯
+  const teano = (item.TeaNo1 || "").trim();
+  const apl = (item.AlPt || "").trim();
+  const email = (item.TeaEmail || "").trim();
+  const teaname = (item.TeaName1 || "").trim();
+
+  if (!teano || !teaname) return undefined;
+
+  if (apl === "1" && email) {
+    const id = email.split("@")[0];
+    return `https://gaweb.nutn.edu.tw/faculty/teaData.aspx?id=${id}`;
+  }
+
+  return `${BASE_URL}/Course/Qry/TeaInfo?id=${teano}&ap=${apl}`;
+}
+
+function buildCourseUrl(courseName: string) {
+  return `${EWANT_SEARCH_URL}${encodeURIComponent(courseName)}`;
+}
+
+async function fetchSession(): Promise<{ csrfToken: string; cookie: string }> {
+  const res = await detailClient.get(PAGE_URL, {
+    headers: {
+      accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      referer: PAGE_URL,
+    },
+  });
+
+  const cookie = pickCookieHeader(res.headers["set-cookie"]);
+  const $ = cheerio.load(res.data);
+
+  const csrfToken = ($("#ctl00_hv_token").val() as string) || "";
+
+  if (!csrfToken) {
+    throw new Error("無法從頁面抓到 csrf token (#ctl00_hv_token)");
+  }
+
+  return { csrfToken, cookie };
+}
+
+async function runScraper(): Promise<void> {
+  try {
+    const semester = formatSemesterFromAcs(PAYLOAD.acs);
+
+    // 1) 先拿 csrf + cookie
+    const { csrfToken, cookie } = await fetchSession();
+
+    // 2) 打 API
+    const headers = {
+      accept: "*/*",
+      "content-type": "application/json; charset=utf-8",
+      origin: BASE_URL,
+      referer: PAGE_URL,
+      cookie,
+      "x-csrf-token": csrfToken,
+    };
+
+    const res = await postWithRetry<GetCourseItem[]>(API_URL, PAYLOAD, headers, 3);
+    const data = res.data || [];
+    const items = data.filter((x) => x && x.Result === "00");
+
+    console.log(`GetCourse 回傳: ${data.length} 筆，Result=00: ${items.length} 筆`);
+
+    const limit = pLimit(10);
+    let created = 0;
+    let updated = 0;
+    let failed = 0;
+
+    const tasks = items.map((item) =>
+      limit(async () => {
+        try {
+          const courseName = (item.CourName || "").trim() || "未知課程";
+          const courseUrl = buildCourseUrl(courseName);
+
+          // ✅ 依你需求：遠距固定寫「遠距」，不看 API Room（也不 trim）
+          // ✅ course_time 讓它空（不存）
+          // ✅ course_url 不存
+          const payload = {
+            semester,
+            academy: "其他", // 你也可以改成 null，不影響（欄位可空）
+            department: DEPARTMENT_LABEL,
+            course_name: courseName,
+            instructor: "EWANT教師",
+            instructor_url: undefined,
+            course_room: "遠距",
+            course_url: courseUrl,
+            credit_hours: Number.parseInt(item.Credit || "0", 10) || 0,
+            course_type: "選修",
+            updated_at: new Date(),
+          };
+
+          const existing = await CourseModel.findOne({
+            where: {
+              semester: payload.semester,
+              department: payload.department,
+              course_name: payload.course_name,
+              instructor: payload.instructor,
+              credit_hours: payload.credit_hours,
+            },
+          });
+
+          if (existing) {
+            await existing.update(payload);
+            updated++;
+            return;
+          }
+
+          await CourseModel.create(payload as any);
+          created++;
+        } catch (err) {
+          failed++;
+          console.error(`寫入失敗：${item.CourName} (${item.SelCourNo})`, err);
+        }
+      })
+    );
+
+    await Promise.all(tasks);
+
+    console.log(`完成：created=${created}, updated=${updated}, failed=${failed}`);
+    process.exit(0);
+  } catch (error) {
+    console.error("Error scraping EWANT courses:", error);
+    process.exit(1);
+  }
+}
+
+initializeDatabase().then(() => runScraper());

--- a/backend/scraper/scraperEwant.ts
+++ b/backend/scraper/scraperEwant.ts
@@ -254,7 +254,7 @@ async function runScraper(): Promise<void> {
               department: payload.department,
               course_name: payload.course_name,
               instructor: {
-                [Op.in]: [payload.instructor, "EWANT教師"],
+                [Op.in]: [payload.instructor, "EWANT教師", "無教師"],
               },
               credit_hours: payload.credit_hours,
             },

--- a/backend/scraper/scraperEwant.ts
+++ b/backend/scraper/scraperEwant.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import https from "https";
 import pLimit from "p-limit";
 import * as cheerio from "cheerio";
+import { Op } from "sequelize";
 import db from "../models";
 import CourseModel from "../models/Course";
 
@@ -227,6 +228,8 @@ async function runScraper(): Promise<void> {
         try {
           const courseName = (item.CourName || "").trim() || "未知課程";
           const courseUrl = buildCourseUrl(courseName);
+          const instructorName = buildInstructorName(item);
+          const instructorUrl = buildInstructorUrl(item);
 
           // ✅ 依你需求：遠距固定寫「遠距」，不看 API Room（也不 trim）
           // ✅ course_time 讓它空（不存）
@@ -236,8 +239,8 @@ async function runScraper(): Promise<void> {
             academy: "其他", // 你也可以改成 null，不影響（欄位可空）
             department: DEPARTMENT_LABEL,
             course_name: courseName,
-            instructor: "EWANT教師",
-            instructor_url: undefined,
+            instructor: instructorName,
+            instructor_url: instructorUrl,
             course_room: "遠距",
             course_url: courseUrl,
             credit_hours: Number.parseInt(item.Credit || "0", 10) || 0,
@@ -250,7 +253,9 @@ async function runScraper(): Promise<void> {
               semester: payload.semester,
               department: payload.department,
               course_name: payload.course_name,
-              instructor: payload.instructor,
+              instructor: {
+                [Op.in]: [payload.instructor, "EWANT教師"],
+              },
               credit_hours: payload.credit_hours,
             },
           });

--- a/backend/scraper/scraperEwant.ts
+++ b/backend/scraper/scraperEwant.ts
@@ -6,8 +6,8 @@ import * as cheerio from "cheerio";
 import { Op } from "sequelize";
 import db from "../models";
 import CourseModel from "../models/Course";
+import { EWANT_ACS } from "./googleRequestCURL";
 
-// ewant api 回來的 data type
 type GetCourseItem = {
   Result: string;
   Message: string;
@@ -15,33 +15,23 @@ type GetCourseItem = {
   Sec: string;
   SelCourNo: string;
   CourNo: string;
-
   CourName: string;
   CourEngName: string;
-
   ClassName1: string;
-
   TeaNo1: string;
   TeaName1: string;
   TeaName: string;
   TeaEmail: string;
   AlPt: string;
-
   Credit: string;
   TotHour: string;
-
-  Week: string;
-  Section: string;
-
   Room: string;
   ComptRoom: string;
-
   Method: string;
   EMI: string;
   Dist: string;
   Coord: string;
   Remark: string;
-
   MaxSel: string;
   MinSel: string;
   NowSel: string;
@@ -53,24 +43,22 @@ const API_URL = `${BASE_URL}/Course/api/Query/GetCourse`;
 const EWANT_SEARCH_URL =
   "https://www.ewant.org/admin/tool/mooccourse/allcourses.php?filter=4&schoolid=0&categoryid=0&course_filter=3&search=";
 
-// 要爬的條件：114-2 / 其他 / 校外遠距(EWANT)
 const PAYLOAD = {
-  acs: "1142", // acadamic semester 學期：1142 = 114-2
+  acs: EWANT_ACS,
   kw: "",
   dc: "",
   gr: "",
   ch: "",
-  ot: "DIS_1", // 類別：校外遠距(EWANT)
+  ot: "DIS_1",
   ge: "A",
   ta: "ZZS101",
   we: "",
-  ki: "6", // 單位：其他
+  ki: "6",
   ll: "zh-TW",
 };
 
 const DEPARTMENT_LABEL = "校外遠距(EWANT)";
 
-// 處理爬蟲被擋的問題
 const httpsAgent = new https.Agent({
   keepAlive: true,
   maxSockets: 20,
@@ -87,7 +75,7 @@ const detailClient = axios.create({
   },
 });
 
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function isRetryableNetworkError(err: any) {
   const code = err?.code;
@@ -106,11 +94,11 @@ function isRetryableNetworkError(err: any) {
 
 async function postWithRetry<T>(
   url: string,
-  data: any,
+  data: unknown,
   headers: Record<string, string>,
   retries = 3
 ) {
-  for (let attempt = 1; attempt <= retries; attempt++) {
+  for (let attempt = 1; attempt <= retries; attempt += 1) {
     try {
       return await detailClient.post<T>(url, data, { headers });
     } catch (err: any) {
@@ -119,10 +107,10 @@ async function postWithRetry<T>(
       await sleep(backoff);
     }
   }
+
   throw new Error("unreachable");
 }
 
-// 初始化 DB
 async function initializeDatabase(): Promise<void> {
   try {
     await db.sequelize.authenticate();
@@ -135,17 +123,28 @@ async function initializeDatabase(): Promise<void> {
 
 function pickCookieHeader(setCookie?: string[] | string): string {
   if (!setCookie) return "";
-  const array = Array.isArray(setCookie) ? setCookie : [setCookie];
-  return array
+
+  const cookies = Array.isArray(setCookie) ? setCookie : [setCookie];
+  return cookies
     .map((cookie) => cookie.split(";")[0])
     .filter(Boolean)
     .join("; ");
 }
 
 function formatSemesterFromAcs(acs: string) {
-  // "1142" -> "114-2"
   if (!acs || acs.length < 4) return acs;
   return `${acs.slice(0, 3)}-${acs.slice(3)}`;
+}
+
+function formatSemesterFromApi(item: GetCourseItem) {
+  const year = (item.sYear || "").replace(/\D/g, "");
+  const sec = (item.Sec || "").replace(/\D/g, "");
+
+  if (year.length >= 3 && sec) {
+    return `${year.slice(0, 3)}-${sec}`;
+  }
+
+  return "";
 }
 
 function buildInstructorName(item: GetCourseItem) {
@@ -155,20 +154,19 @@ function buildInstructorName(item: GetCourseItem) {
 }
 
 function buildInstructorUrl(item: GetCourseItem) {
-  // 依你貼的前端 getTea() 邏輯
-  const teano = (item.TeaNo1 || "").trim();
-  const apl = (item.AlPt || "").trim();
-  const email = (item.TeaEmail || "").trim();
-  const teaname = (item.TeaName1 || "").trim();
+  const teacherNo = (item.TeaNo1 || "").trim();
+  const teacherName = (item.TeaName1 || "").trim();
+  const teacherEmail = (item.TeaEmail || "").trim();
+  const teacherApl = (item.AlPt || "").trim();
 
-  if (!teano || !teaname) return undefined;
+  if (!teacherNo || !teacherName) return undefined;
 
-  if (apl === "1" && email) {
-    const id = email.split("@")[0];
+  if (teacherApl === "1" && teacherEmail) {
+    const id = teacherEmail.split("@")[0];
     return `https://gaweb.nutn.edu.tw/faculty/teaData.aspx?id=${id}`;
   }
 
-  return `${BASE_URL}/Course/Qry/TeaInfo?id=${teano}&ap=${apl}`;
+  return `${BASE_URL}/Course/Qry/TeaInfo?id=${teacherNo}&ap=${teacherApl}`;
 }
 
 function buildCourseUrl(courseName: string) {
@@ -185,7 +183,6 @@ async function fetchSession(): Promise<{ csrfToken: string; cookie: string }> {
 
   const cookie = pickCookieHeader(res.headers["set-cookie"]);
   const $ = cheerio.load(res.data);
-
   const csrfToken = ($("#ctl00_hv_token").val() as string) || "";
 
   if (!csrfToken) {
@@ -197,12 +194,8 @@ async function fetchSession(): Promise<{ csrfToken: string; cookie: string }> {
 
 async function runScraper(): Promise<void> {
   try {
-    const semester = formatSemesterFromAcs(PAYLOAD.acs);
-
-    // 1) 先拿 csrf + cookie
     const { csrfToken, cookie } = await fetchSession();
 
-    // 2) 打 API
     const headers = {
       accept: "*/*",
       "content-type": "application/json; charset=utf-8",
@@ -214,9 +207,9 @@ async function runScraper(): Promise<void> {
 
     const res = await postWithRetry<GetCourseItem[]>(API_URL, PAYLOAD, headers, 3);
     const data = res.data || [];
-    const items = data.filter((x) => x && x.Result === "00");
+    const items = data.filter((item) => item && item.Result === "00");
 
-    console.log(`GetCourse 回傳: ${data.length} 筆，Result=00: ${items.length} 筆`);
+    console.log(`GetCourse 使用學期代碼 ${EWANT_ACS}，回傳: ${data.length} 筆，Result=00: ${items.length} 筆`);
 
     const limit = pLimit(10);
     let created = 0;
@@ -226,23 +219,17 @@ async function runScraper(): Promise<void> {
     const tasks = items.map((item) =>
       limit(async () => {
         try {
+          const semester = formatSemesterFromApi(item) || formatSemesterFromAcs(EWANT_ACS);
           const courseName = (item.CourName || "").trim() || "未知課程";
-          const courseUrl = buildCourseUrl(courseName);
-          const instructorName = buildInstructorName(item);
-          const instructorUrl = buildInstructorUrl(item);
-
-          // ✅ 依你需求：遠距固定寫「遠距」，不看 API Room（也不 trim）
-          // ✅ course_time 讓它空（不存）
-          // ✅ course_url 不存
           const payload = {
             semester,
-            academy: "其他", // 你也可以改成 null，不影響（欄位可空）
+            academy: "其他",
             department: DEPARTMENT_LABEL,
             course_name: courseName,
-            instructor: instructorName,
-            instructor_url: instructorUrl,
+            instructor: buildInstructorName(item),
+            instructor_url: buildInstructorUrl(item),
             course_room: "遠距",
-            course_url: courseUrl,
+            course_url: buildCourseUrl(courseName),
             credit_hours: Number.parseInt(item.Credit || "0", 10) || 0,
             course_type: "選修",
             updated_at: new Date(),
@@ -262,14 +249,14 @@ async function runScraper(): Promise<void> {
 
           if (existing) {
             await existing.update(payload);
-            updated++;
+            updated += 1;
             return;
           }
 
           await CourseModel.create(payload as any);
-          created++;
+          created += 1;
         } catch (err) {
-          failed++;
+          failed += 1;
           console.error(`寫入失敗：${item.CourName} (${item.SelCourNo})`, err);
         }
       })

--- a/backend/services/timetableService.ts
+++ b/backend/services/timetableService.ts
@@ -18,6 +18,7 @@ type CourseMeta = {
   id: number;
   name: string;
   semester: string;
+  department: string;
   instructor: string;
   room?: string;
 };
@@ -184,6 +185,7 @@ class TimetableService {
           id: course.id,
           name: course.course_name,
           semester: course.semester,
+          department: course.department,
           instructor: course.instructor,
           room: course.course_room,
         },
@@ -241,6 +243,7 @@ class TimetableService {
         id: raw.course.id,
         name: raw.course.course_name,
         semester: raw.course.semester,
+        department: raw.course.department,
         instructor: raw.course.instructor,
         room: raw.course.course_room,
       };
@@ -249,6 +252,7 @@ class TimetableService {
       id: course.id,
       name: course.course_name,
       semester: course.semester,
+      department: course.department,
       instructor: course.instructor,
       room: course.course_room,
     };
@@ -306,6 +310,7 @@ class TimetableService {
       id: course.id,
       name: course.course_name,
       semester: course.semester,
+      department: course.department,
       instructor: course.instructor,
       room: course.course_room,
     };
@@ -328,6 +333,7 @@ class TimetableService {
             id: raw.course.id,
             name: raw.course.course_name,
             semester: raw.course.semester,
+            department: raw.course.department,
             instructor: raw.course.instructor,
             room: raw.course.course_room,
           };
@@ -382,6 +388,7 @@ class TimetableService {
       id: interest.course.id,
       name: interest.course.course_name,
       semester: interest.course.semester,
+      department: interest.course.department,
       instructor: interest.course.instructor,
     }));
     const existingCourses: CourseMeta[] = existingItems.map((item) => {
@@ -390,6 +397,7 @@ class TimetableService {
         id: raw.course.id,
         name: raw.course.course_name,
         semester: raw.course.semester,
+        department: raw.course.department,
         instructor: raw.course.instructor,
         room: raw.course.course_room,
       };
@@ -460,6 +468,7 @@ class TimetableService {
           id: raw.course.id,
           name: raw.course.course_name,
           semester: raw.course.semester,
+          department: raw.course.department,
           instructor: raw.course.instructor,
           room: raw.course.course_room,
           courseTime: raw.course.course_time,
@@ -475,6 +484,7 @@ type TimetableItemModelJson = {
     id: number;
     course_name: string;
     semester: string;
+    department: string;
     instructor: string;
     course_time?: string;
     course_room?: string;

--- a/backend/types/timetable.ts
+++ b/backend/types/timetable.ts
@@ -23,6 +23,7 @@ export interface TimetableItemResponse {
     id: number;
     name: string;
     semester: string;
+    department: string;
     instructor: string;
     room?: string;
   };
@@ -45,6 +46,7 @@ export interface AddedCourseItemResponse {
     id: number;
     name: string;
     semester: string;
+    department: string;
     instructor: string;
     room?: string;
     courseTime?: string;

--- a/frontend/src/components/CourseCard.tsx
+++ b/frontend/src/components/CourseCard.tsx
@@ -12,6 +12,19 @@ interface CourseCardProp {
 }
 
 const CourseCard: React.FC<CourseCardProp> = ({ course }) => {
+	const courseLocationAndTimeParts = [
+		course.course_room?.trim(),
+		course.course_time ? formatCourseTime(course.course_time) : null,
+	].filter(Boolean)
+	const courseLocationAndTime = courseLocationAndTimeParts.length > 0
+		? courseLocationAndTimeParts.map((part, index) => (
+			<span key={index}>
+				{index > 0 ? ' / ' : ''}
+				{part}
+			</span>
+		))
+		: null
+
 	return (
 		<Card padding='lg' className={style.courseCard}>
 			<Link to={`/course/${course.id}`} style={{ textDecoration: 'none', flexGrow: 1, color: 'black' }} >
@@ -24,7 +37,7 @@ const CourseCard: React.FC<CourseCardProp> = ({ course }) => {
 				<Text fw={300} c='gray'>{course.instructor}</Text>
 
 				<Group justify='center'>
-					<Text fw={300} c='gray'>{course.course_room} / {formatCourseTime(course.course_time)}</Text>
+					<Text fw={300} c='gray'>{courseLocationAndTime}</Text>
 				</Group>
 
 				<Group justify='center' mt='sm' >

--- a/frontend/src/components/CourseFilter.tsx
+++ b/frontend/src/components/CourseFilter.tsx
@@ -42,6 +42,7 @@ const CourseFilter: React.FC<CourseFilterProps> = ({ searchParams, onSearch, onC
         { label: '大學', value: 'university' },
         { label: '研究所', value: 'graduate' },
         { label: '師培', value: 'teacher' },
+        { label: 'EWANT', value: 'ewant' },
     ]
     const { data: departmentList, isLoading: isLoadingDepartments } = useGetDepartments()
     const { data: academyList, isLoading: isLoadingAcademies } = useGetAcademies()
@@ -179,55 +180,57 @@ const CourseFilter: React.FC<CourseFilterProps> = ({ searchParams, onSearch, onC
                         searchable
                     />
                 )}
-                <Accordion
-                    variant='separated'
-                    radius='md'
-                    className={style.advancedFilterAccordion}
-                    value={advancedAccordionValue}
-                    onChange={setAdvancedAccordionValue}
-                >
-                    <Accordion.Item value='time-semester-filters'>
-                        <Accordion.Control>
-                            進階篩選：星期／節次／學期
-                            <div className={style.advancedFilterSummary}>{advancedSummaryText}</div>
-                        </Accordion.Control>
-                        <Accordion.Panel>
-                            <MultiSelect
-                                placeholder='篩選星期（可多選）'
-                                data={weekdayOptions}
-                                value={weekdays}
-                                size='md'
-                                classNames={{ input: style.selectInput }}
-                                className={style.select}
-                                onChange={setWeekdays}
-                                searchable
-                                clearable
-                            />
-                            <MultiSelect
-                                placeholder='篩選節次（可多選）'
-                                data={periodOptions}
-                                value={periods}
-                                size='md'
-                                classNames={{ input: style.selectInput }}
-                                className={style.select}
-                                onChange={setPeriods}
-                                searchable
-                                clearable
-                            />
-                            <MultiSelect
-                                placeholder='篩選學期（可多選）'
-                                data={semesterOptions}
-                                value={semesters}
-                                size='md'
-                                classNames={{ input: style.selectInput }}
-                                className={style.select}
-                                onChange={setSemesters}
-                                searchable
-                                clearable
-                            />
-                        </Accordion.Panel>
-                    </Accordion.Item>
-                </Accordion>
+                {activeTab !== 'ewant' && (
+                    <Accordion
+                        variant='separated'
+                        radius='md'
+                        className={style.advancedFilterAccordion}
+                        value={advancedAccordionValue}
+                        onChange={setAdvancedAccordionValue}
+                    >
+                        <Accordion.Item value='time-semester-filters'>
+                            <Accordion.Control>
+                                進階篩選：星期／節次／學期
+                                <div className={style.advancedFilterSummary}>{advancedSummaryText}</div>
+                            </Accordion.Control>
+                            <Accordion.Panel>
+                                <MultiSelect
+                                    placeholder='篩選星期（可多選）'
+                                    data={weekdayOptions}
+                                    value={weekdays}
+                                    size='md'
+                                    classNames={{ input: style.selectInput }}
+                                    className={style.select}
+                                    onChange={setWeekdays}
+                                    searchable
+                                    clearable
+                                />
+                                <MultiSelect
+                                    placeholder='篩選節次（可多選）'
+                                    data={periodOptions}
+                                    value={periods}
+                                    size='md'
+                                    classNames={{ input: style.selectInput }}
+                                    className={style.select}
+                                    onChange={setPeriods}
+                                    searchable
+                                    clearable
+                                />
+                                <MultiSelect
+                                    placeholder='篩選學期（可多選）'
+                                    data={semesterOptions}
+                                    value={semesters}
+                                    size='md'
+                                    classNames={{ input: style.selectInput }}
+                                    className={style.select}
+                                    onChange={setSemesters}
+                                    searchable
+                                    clearable
+                                />
+                            </Accordion.Panel>
+                        </Accordion.Item>
+                    </Accordion>
+                )}
 
                 <Button className={style.searchButton} onClick={() => handleClick()}>
                     搜尋

--- a/frontend/src/components/CourseInfoPanel.tsx
+++ b/frontend/src/components/CourseInfoPanel.tsx
@@ -39,6 +39,10 @@ const CourseInfoPanel: React.FC<CourseInfoPanelProps> = ({ course, isLoading }) 
   const instructorUrl = courseData?.instructor_url
   const courseTime = courseData?.course_time ? formatCourseTime(courseData.course_time) : '-'
   const courseRoom = displayText(courseData?.course_room)
+  const mobileCourseMeta = [
+    courseData?.course_time ? formatCourseTime(courseData.course_time) : null,
+    courseData?.course_room?.trim() || null,
+  ].filter(Boolean)
   const courseType = displayText(courseData?.course_type)
   const creditHours = displayText(courseData?.credit_hours)
 
@@ -62,7 +66,16 @@ const CourseInfoPanel: React.FC<CourseInfoPanelProps> = ({ course, isLoading }) 
 
         <div>
           <Text className={style.label}>上課時間 / 上課教室</Text>
-          <Text className={style.courseDetail}>{courseTime} / {courseRoom}</Text>
+          <Text className={style.courseDetail}>
+            {mobileCourseMeta.length > 0
+              ? mobileCourseMeta.map((item, index) => (
+                <span key={index}>
+                  {index > 0 ? ' / ' : ''}
+                  {item}
+                </span>
+              ))
+              : '-'}
+          </Text>
         </div>
 
         <div>

--- a/frontend/src/components/TimetableSection/Timetable.tsx
+++ b/frontend/src/components/TimetableSection/Timetable.tsx
@@ -37,6 +37,7 @@ const weekdays: WeekdayOption[] = [
 ]
 const EMPTY_TIMETABLE_ITEMS: TimetableItem[] = []
 const EMPTY_ADDED_ITEMS: AddedCourseItem[] = []
+const EWANT_DEPARTMENT = '校外遠距(EWANT)'
 
 const periodOrder = Object.keys(periodTimeMap) as PeriodKey[]
 const periodIndexMap = periodOrder.reduce<Record<string, number>>((acc, period, index) => {
@@ -110,10 +111,22 @@ const Timetable: React.FC = () => {
     if (!selectedSemester) return []
     return allAddedItems.filter((item) => item.semester === selectedSemester)
   }, [allAddedItems, selectedSemester])
+  const ewantItemsInSelectedSemester = useMemo(
+    () => addedItemsInSelectedSemester.filter((item) => item.course.department === EWANT_DEPARTMENT),
+    [addedItemsInSelectedSemester],
+  )
+  const scheduledItemsInSelectedSemester = useMemo(
+    () => addedItemsInSelectedSemester.filter((item) => item.course.department !== EWANT_DEPARTMENT),
+    [addedItemsInSelectedSemester],
+  )
+  const gridItems = useMemo(
+    () => items.filter((item) => item.course.department !== EWANT_DEPARTMENT),
+    [items],
+  )
   const timetableId = timetableData?.timetable.id
-  const grid = useMemo(() => buildGrid(items), [items])
+  const grid = useMemo(() => buildGrid(gridItems), [gridItems])
   const missingTimeslotCountInCurrentSemester = useMemo(
-    () => items.filter((item) => item.timeslots.length === 0).length,
+    () => items.filter((item) => item.course.department !== EWANT_DEPARTMENT && item.timeslots.length === 0).length,
     [items],
   )
   const existingCourseIdSet = useMemo(() => new Set(items.map((item) => item.course.id)), [items])
@@ -143,8 +156,8 @@ const Timetable: React.FC = () => {
     [grid],
   )
   const hasWeekendCourses = useMemo(
-    () => items.some((item) => item.timeslots.some((timeslot) => timeslot.dayOfWeek === 6 || timeslot.dayOfWeek === 7)),
-    [items],
+    () => gridItems.some((item) => item.timeslots.some((timeslot) => timeslot.dayOfWeek === 6 || timeslot.dayOfWeek === 7)),
+    [gridItems],
   )
   const weekdaysToRender = useMemo(
     () => (hasWeekendCourses ? weekdays : weekdays.filter((day) => day.value <= 5)),
@@ -263,11 +276,13 @@ const Timetable: React.FC = () => {
           itemsCount={items.length}
           selectableCount={selectableInterestCourses.length}
           missingTimeslotCount={missingTimeslotCountInCurrentSemester}
+          ewantCount={ewantItemsInSelectedSemester.length}
         />
 
         <TimetableCourseLists
           selectableInterestCourses={selectableInterestCourses}
-          addedItemsInSelectedSemester={addedItemsInSelectedSemester}
+          addedItemsInSelectedSemester={scheduledItemsInSelectedSemester}
+          ewantItemsInSelectedSemester={ewantItemsInSelectedSemester}
           isAdding={addCourseMutation.isPending}
           isRemoving={removeCourseMutation.isPending}
           onAddCourse={(course) => {
@@ -292,9 +307,16 @@ const Timetable: React.FC = () => {
                 星期{conflict.dayLabel} 第{conflict.period}節：{conflict.courses.join(' / ')}
               </Text>
             ))}
-            <Text size='sm' c='dimmed'>
-              缺時段課程 {missingTimeslotCountInCurrentSemester} 門，不參與衝堂判斷。
-            </Text>
+            {missingTimeslotCountInCurrentSemester > 0 && (
+              <Text size='sm' c='dimmed'>
+                缺時段課程 {missingTimeslotCountInCurrentSemester} 門，不參與衝堂判斷。
+              </Text>
+            )}
+            {ewantItemsInSelectedSemester.length > 0 && (
+              <Text size='sm' c='dimmed'>
+                遠距課程 {ewantItemsInSelectedSemester.length} 門，已移到下方獨立區塊，不顯示在時間格中。
+              </Text>
+            )}
             {conflicts.length > 6 && (
               <Text size='sm' c='dimmed'>
                 還有 {conflicts.length - 6} 個衝堂時段...
@@ -308,6 +330,14 @@ const Timetable: React.FC = () => {
         <Alert color='orange' title='缺少時段資料'>
           <Text size='sm'>
             本學期有 {missingTimeslotCountInCurrentSemester} 門課資料較舊，平台尚未更新時段資料。這些課程不會顯示在課表格，也不參與衝堂判斷。
+          </Text>
+        </Alert>
+      )}
+
+      {ewantItemsInSelectedSemester.length > 0 && (
+        <Alert color='blue' title='遠距課程已獨立顯示'>
+          <Text size='sm'>
+            本學期有 {ewantItemsInSelectedSemester.length} 門 EWANT 遠距課程，已集中顯示在「遠距課程」區塊，不會直接排進時間格，也不參與衝堂判斷。
           </Text>
         </Alert>
       )}

--- a/frontend/src/components/TimetableSection/TimetableCourseLists.tsx
+++ b/frontend/src/components/TimetableSection/TimetableCourseLists.tsx
@@ -7,6 +7,7 @@ import { AddedTimetableItem, SelectableInterestCourse } from './types'
 type TimetableCourseListsProps = {
   selectableInterestCourses: SelectableInterestCourse[]
   addedItemsInSelectedSemester: AddedTimetableItem[]
+  ewantItemsInSelectedSemester: AddedTimetableItem[]
   isAdding: boolean
   isRemoving: boolean
   onAddCourse: (course: SelectableInterestCourse) => void
@@ -16,6 +17,7 @@ type TimetableCourseListsProps = {
 const TimetableCourseLists: React.FC<TimetableCourseListsProps> = ({
   selectableInterestCourses,
   addedItemsInSelectedSemester,
+  ewantItemsInSelectedSemester,
   isAdding,
   isRemoving,
   onAddCourse,
@@ -94,6 +96,54 @@ const TimetableCourseLists: React.FC<TimetableCourseListsProps> = ({
                       {[item.course.instructor, item.semester, item.course.room].filter(Boolean).join('・')}
                     </Text>
                     <Text size='xs' c='dimmed' ta='left'>{item.course.courseTime}</Text>
+                  </div>
+                </Link>
+                <Tooltip label='從課表移除'>
+                  <ActionIcon
+                    color='red'
+                    variant='light'
+                    loading={isRemoving}
+                    onClick={() => onRemoveCourse(item)}
+                  >
+                    <FaTrashAlt size={14} />
+                  </ActionIcon>
+                </Tooltip>
+              </div>
+            ))}
+          </Stack>
+        )}
+      </div>
+
+      <div className={`${styles.listPanel} ${styles.asyncPanel}`}>
+        <Group justify='space-between' mb='xs'>
+          <Text fw={600}>遠距課程</Text>
+          <Badge variant='light' color='blue'>{ewantItemsInSelectedSemester.length}</Badge>
+        </Group>
+        {ewantItemsInSelectedSemester.length === 0 ? (
+          <Stack gap={2}>
+            <Text size='sm' fw={600}>此學期目前沒有遠距課程。</Text>
+            <Text size='sm' c='dimmed'>EWANT 課程加入後會集中列在這裡，不顯示在時間格中。</Text>
+          </Stack>
+        ) : (
+          <Stack gap={0}>
+            {ewantItemsInSelectedSemester.map((item) => (
+              <div key={`${item.timetableId}-${item.course.id}`} className={styles.listRow}>
+                <Link to={`/course/${item.course.id}`} className={styles.courseInfoLink}>
+                  <div className={styles.courseInfoBlock}>
+                    <Group gap='xs'>
+                      <Text size='sm' fw={600} ta='left'>
+                        {item.course.name}
+                      </Text>
+                      <Badge size='xs' color='blue' variant='light'>
+                        遠距
+                      </Badge>
+                    </Group>
+                    <Text size='xs' c='dimmed' ta='left'>
+                      {[item.course.instructor, item.semester, item.course.room].filter(Boolean).join('・')}
+                    </Text>
+                    <Text size='xs' c='dimmed' ta='left'>
+                      {item.course.courseTime || '非同步／無固定時段'}
+                    </Text>
                   </div>
                 </Link>
                 <Tooltip label='從課表移除'>

--- a/frontend/src/components/TimetableSection/TimetableHeader.tsx
+++ b/frontend/src/components/TimetableSection/TimetableHeader.tsx
@@ -14,6 +14,7 @@ type TimetableHeaderProps = {
   itemsCount: number
   selectableCount: number
   missingTimeslotCount: number
+  ewantCount: number
 }
 
 const TimetableHeader: React.FC<TimetableHeaderProps> = ({
@@ -24,6 +25,7 @@ const TimetableHeader: React.FC<TimetableHeaderProps> = ({
   itemsCount,
   selectableCount,
   missingTimeslotCount,
+  ewantCount,
 }) => {
   return (
     <>
@@ -58,6 +60,9 @@ const TimetableHeader: React.FC<TimetableHeaderProps> = ({
         </Badge>
         <Badge variant='light' color={missingTimeslotCount > 0 ? 'orange' : 'gray'}>
           缺時段課程 {missingTimeslotCount}
+        </Badge>
+        <Badge variant='light' color={ewantCount > 0 ? 'blue' : 'gray'}>
+          遠距課程 {ewantCount}
         </Badge>
       </Group>
     </>

--- a/frontend/src/styles/components/Timetable.module.css
+++ b/frontend/src/styles/components/Timetable.module.css
@@ -16,7 +16,7 @@
 .listGrid {
   margin-top: 16px;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 24px;
 }
 
@@ -33,6 +33,10 @@
 
 .addedPanel {
   border-bottom-color: #dc2626;
+}
+
+.asyncPanel {
+  border-bottom-color: #2563eb;
 }
 
 .listRow {

--- a/frontend/src/types/timetableType.ts
+++ b/frontend/src/types/timetableType.ts
@@ -10,6 +10,7 @@ export interface TimetableCourse {
   id: number
   name: string
   semester: string
+  department: string
   instructor: string
   room?: string
 }
@@ -35,6 +36,7 @@ export interface AddedCourseItem {
     id: number
     name: string
     semester: string
+    department: string
     instructor: string
     room?: string
     courseTime?: string


### PR DESCRIPTION
## 標題

新增 EWANT 課程匯入與查詢入口，並調整課程資訊顯示

---

## 摘要

這個 PR 新增 EWANT 課程爬蟲與對應查詢分類，讓校外遠距課程可以被匯入並在前台以 `EWANT` 分類瀏覽，同時修正課程卡片與課程資訊面板在沒有時間或教室資料時的顯示方式。

---

## 背景／問題

目前系統缺少 EWANT 課程來源，校外遠距課程無法透過既有流程匯入與查詢。另外，課程列表與詳情頁在 `course_time` 或 `course_room` 缺值時，會出現不自然的 `/` 分隔顯示。  
此外，EWANT 課程連結可能超過既有 `course_url` 欄位長度，因此需要調整資料庫欄位型別。

---

## 變更內容

- `backend/scraper/scraperEwant.ts`
  新增 EWANT 課程爬蟲，透過南大課程 API 撈取 `校外遠距(EWANT)` 課程並寫入資料庫。
- `backend/package.json`
  新增 `scrape:ewant` script，方便單獨執行 EWANT 匯入。
- `backend/repositories/courseRepository.ts`
  新增 `ewant` 分類篩選，對應 `department = 校外遠距(EWANT)`。
- `frontend/src/components/CourseFilter.tsx`
  新增 `EWANT` tab，並在該分類下隱藏不適用的進階篩選。
- `frontend/src/components/CourseCard.tsx`
  調整課程卡片的教室／時間組合顯示，避免空值時出現多餘分隔符號。
- `frontend/src/components/CourseInfoPanel.tsx`
  調整課程詳情頁資訊顯示，改善手機版時間／教室空值處理。
- `backend/models/Course.ts`
  將 `course_url` 型別改為 `TEXT`。
- `backend/migrations/20260321095000-alter-course-url-to-text.js`
  新增 migration，調整 `Courses.course_url` 欄位長度。
- `AGENTS.md`
  補上 repo 協作與 PR 產生規範。
---

## 測試方式

- 執行 `cd backend && npm run migrate`，確認 `Courses.course_url` 成功改為 `TEXT`。
- 執行 `cd backend && npm run scrape:ewant`，確認 EWANT 課程可成功寫入或更新。
- 前台切換到 `EWANT` 分類，確認可看到 `校外遠距(EWANT)` 課程。
- 檢查課程列表與課程詳情頁，確認沒有 `course_time` 或 `course_room` 時不會顯示多餘的 `/`。
---

## 備註

- 目前 branch：`feat/course-detail-style`
- 這個 branch 也包含 `AGENTS.md` 規範檔調整
- 我這邊沒有另外執行自動化測試，以上為建議驗證步驟