### PR TITLE
Feat/add Admin Panel Support for Manually Whitelisting Emails

### DIFF
--- a/backend/controllers/adminController.ts
+++ b/backend/controllers/adminController.ts
@@ -3,6 +3,7 @@ import AdminRelatedPostService from "../services/adminRelatedPostService";
 import { ManualCourseKeywordOverride } from "../types/admin";
 import UserService from "../services/userService";
 import { DcardImportValidationError } from "../utils/dcardImportParser";
+import whitelistService from "../services/whitelistService";
 
 const getErrorStatus = (error: unknown): number =>
   error instanceof DcardImportValidationError ? 400 : 500;
@@ -150,5 +151,28 @@ export const deleteRelatedPostImport: RequestHandler = async (req, res): Promise
     res.status(200).json({ success: true });
   } catch (error) {
     res.status(500).json({ message: error instanceof Error ? error.message : "刪除匯入紀錄失敗" });
+  }
+};
+
+export const addWhitelistEmail: RequestHandler = async (req, res): Promise<void> => {
+  try {
+    const email = typeof req.body?.email === "string" ? req.body.email.trim() : "";
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+    if (!email || !emailPattern.test(email)) {
+      res.status(400).json({ message: "email 格式不正確" });
+      return;
+    }
+
+    const result = await whitelistService.addWhitelistEmail(email);
+    res.status(result.created ? 201 : 200).json({
+      created: result.created,
+      whitelist: {
+        id: result.record.id,
+        email: result.record.email,
+      },
+    });
+  } catch (error) {
+    res.status(500).json({ message: error instanceof Error ? error.message : "加入白名單失敗" });
   }
 };

--- a/backend/controllers/adminController.ts
+++ b/backend/controllers/adminController.ts
@@ -157,6 +157,8 @@ export const deleteRelatedPostImport: RequestHandler = async (req, res): Promise
 export const addWhitelistEmail: RequestHandler = async (req, res): Promise<void> => {
   try {
     const email = typeof req.body?.email === "string" ? req.body.email.trim() : "";
+    const studentId = typeof req.body?.student_id === "string" ? req.body.student_id.trim() : "";
+    const note = typeof req.body?.note === "string" ? req.body.note.trim() : "";
     const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
     if (!email || !emailPattern.test(email)) {
@@ -164,12 +166,14 @@ export const addWhitelistEmail: RequestHandler = async (req, res): Promise<void>
       return;
     }
 
-    const result = await whitelistService.addWhitelistEmail(email);
+    const result = await whitelistService.addWhitelistEmail(email, studentId, note);
     res.status(result.created ? 201 : 200).json({
       created: result.created,
       whitelist: {
         id: result.record.id,
         email: result.record.email,
+        student_id: result.record.student_id,
+        note: result.record.note,
       },
     });
   } catch (error) {

--- a/backend/controllers/adminController.ts
+++ b/backend/controllers/adminController.ts
@@ -160,9 +160,21 @@ export const addWhitelistEmail: RequestHandler = async (req, res): Promise<void>
     const studentId = typeof req.body?.student_id === "string" ? req.body.student_id.trim() : "";
     const note = typeof req.body?.note === "string" ? req.body.note.trim() : "";
     const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    const MAX_EMAIL_LENGTH = 255;
+    const MAX_STUDENT_ID_LENGTH = 64;
 
     if (!email || !emailPattern.test(email)) {
       res.status(400).json({ message: "email 格式不正確" });
+      return;
+    }
+
+    if (email.length > MAX_EMAIL_LENGTH) {
+      res.status(400).json({ message: `email 長度不可超過 ${MAX_EMAIL_LENGTH} 字元` });
+      return;
+    }
+
+    if (studentId.length > MAX_STUDENT_ID_LENGTH) {
+      res.status(400).json({ message: `student_id 長度不可超過 ${MAX_STUDENT_ID_LENGTH} 字元` });
       return;
     }
 

--- a/backend/repositories/whitelistRepository.ts
+++ b/backend/repositories/whitelistRepository.ts
@@ -4,6 +4,14 @@ class WhitelistRepository {
   async findByEmail(email: string) {
     return await WhitelistModel.findOne({ where: { email } });
   }
+
+  async create(email: string, student_id: string, note?: string | null) {
+    return await WhitelistModel.create({
+      email,
+      student_id,
+      note: note ?? null,
+    });
+  }
 }
 
 export default new WhitelistRepository();

--- a/backend/repositories/whitelistRepository.ts
+++ b/backend/repositories/whitelistRepository.ts
@@ -5,6 +5,17 @@ class WhitelistRepository {
     return await WhitelistModel.findOne({ where: { email } });
   }
 
+  async findOrCreateByEmail(email: string, student_id: string, note?: string | null) {
+    return await WhitelistModel.findOrCreate({
+      where: { email },
+      defaults: {
+        email,
+        student_id,
+        note: note ?? null,
+      },
+    });
+  }
+
   async create(email: string, student_id: string, note?: string | null) {
     return await WhitelistModel.create({
       email,

--- a/backend/routes/admin.ts
+++ b/backend/routes/admin.ts
@@ -1,6 +1,7 @@
 import express, { Router } from "express";
 import {
   attachRelatedPostToCourses,
+  addWhitelistEmail,
   deleteRelatedPostImport,
   deleteRelatedPost,
   getAdminStatus,
@@ -15,6 +16,7 @@ import { authenticateAdmin } from "../middlewares/adminMiddleware";
 const router: Router = express.Router();
 
 router.get("/status", authenticateJWT, getAdminStatus);
+router.post("/whitelist", authenticateJWT, authenticateAdmin, addWhitelistEmail);
 router.get("/related-posts/overview", authenticateJWT, authenticateAdmin, getRelatedPostOverview);
 router.post("/related-posts/import-dcard-source-preview", authenticateJWT, authenticateAdmin, previewImportDcardSource);
 router.post("/related-posts/import-dcard-source", authenticateJWT, authenticateAdmin, importDcardSource);

--- a/backend/services/whitelistService.ts
+++ b/backend/services/whitelistService.ts
@@ -1,4 +1,5 @@
 import whitelistRepository from "../repositories/whitelistRepository";
+import { UniqueConstraintError } from "sequelize";
 
 const normalizeEmail = (email: string) => email.trim().toLowerCase();
 
@@ -9,11 +10,29 @@ class WhitelistService {
 
   async addWhitelistEmail(email: string, studentId?: string, note?: string | null) {
     const normalizedEmail = normalizeEmail(email);
-    const [record, created] = await whitelistRepository.findOrCreateByEmail(
-      normalizedEmail,
-      studentId?.trim() || `manual-${Date.now()}`,
-      note?.trim() || "管理員手動加入白名單"
-    );
+    let record;
+    let created;
+
+    try {
+      [record, created] = await whitelistRepository.findOrCreateByEmail(
+        normalizedEmail,
+        studentId?.trim() || `manual-${Date.now()}`,
+        note?.trim() || "管理員手動加入白名單"
+      );
+    } catch (error) {
+      if (!(error instanceof UniqueConstraintError)) {
+        throw error;
+      }
+
+      const existing = await whitelistRepository.findByEmail(normalizedEmail);
+      if (!existing) {
+        throw error;
+      }
+
+      record = existing;
+      created = false;
+    }
+
     return {
       created,
       record,

--- a/backend/services/whitelistService.ts
+++ b/backend/services/whitelistService.ts
@@ -7,7 +7,7 @@ class WhitelistService {
     return await whitelistRepository.findByEmail(normalizeEmail(email));
   }
 
-  async addWhitelistEmail(email: string) {
+  async addWhitelistEmail(email: string, studentId?: string, note?: string | null) {
     const normalizedEmail = normalizeEmail(email);
     const existing = await whitelistRepository.findByEmail(normalizedEmail);
     if (existing) {
@@ -19,8 +19,8 @@ class WhitelistService {
 
     const created = await whitelistRepository.create(
       normalizedEmail,
-      `manual-${Date.now()}`,
-      "管理員手動加入白名單"
+      studentId?.trim() || `manual-${Date.now()}`,
+      note?.trim() || "管理員手動加入白名單"
     );
     return {
       created: true,

--- a/backend/services/whitelistService.ts
+++ b/backend/services/whitelistService.ts
@@ -9,22 +9,14 @@ class WhitelistService {
 
   async addWhitelistEmail(email: string, studentId?: string, note?: string | null) {
     const normalizedEmail = normalizeEmail(email);
-    const existing = await whitelistRepository.findByEmail(normalizedEmail);
-    if (existing) {
-      return {
-        created: false,
-        record: existing,
-      };
-    }
-
-    const created = await whitelistRepository.create(
+    const [record, created] = await whitelistRepository.findOrCreateByEmail(
       normalizedEmail,
       studentId?.trim() || `manual-${Date.now()}`,
       note?.trim() || "管理員手動加入白名單"
     );
     return {
-      created: true,
-      record: created,
+      created,
+      record,
     };
   }
 }

--- a/backend/services/whitelistService.ts
+++ b/backend/services/whitelistService.ts
@@ -1,8 +1,31 @@
 import whitelistRepository from "../repositories/whitelistRepository";
 
+const normalizeEmail = (email: string) => email.trim().toLowerCase();
+
 class WhitelistService {
   async getWhitelistByEmail(email: string) {
-    return await whitelistRepository.findByEmail(email);
+    return await whitelistRepository.findByEmail(normalizeEmail(email));
+  }
+
+  async addWhitelistEmail(email: string) {
+    const normalizedEmail = normalizeEmail(email);
+    const existing = await whitelistRepository.findByEmail(normalizedEmail);
+    if (existing) {
+      return {
+        created: false,
+        record: existing,
+      };
+    }
+
+    const created = await whitelistRepository.create(
+      normalizedEmail,
+      `manual-${Date.now()}`,
+      "管理員手動加入白名單"
+    );
+    return {
+      created: true,
+      record: created,
+    };
   }
 }
 

--- a/frontend/src/apis/adminAPI.ts
+++ b/frontend/src/apis/adminAPI.ts
@@ -1,4 +1,6 @@
 import {
+  AddWhitelistEmailPayload,
+  AddWhitelistEmailResponse,
   AdminStatusResponse,
   AttachRelatedPostCoursesPayload,
   AttachRelatedPostCoursesResponse,
@@ -62,5 +64,12 @@ export const deleteRelatedPost = async (id: number): Promise<{ success: boolean 
 
 export const deleteRelatedPostImport = async (id: number): Promise<{ success: boolean }> => {
   const response = await axiosInstance.delete(`/admin/related-post-imports/${id}`)
+  return response.data
+}
+
+export const addWhitelistEmail = async (
+  payload: AddWhitelistEmailPayload
+): Promise<AddWhitelistEmailResponse> => {
+  const response = await axiosInstance.post('/admin/whitelist', payload)
   return response.data
 }

--- a/frontend/src/hooks/admin/useAddWhitelistEmail.ts
+++ b/frontend/src/hooks/admin/useAddWhitelistEmail.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query'
+import { addWhitelistEmail } from '../../apis/adminAPI'
+
+export const useAddWhitelistEmail = () => {
+  return useMutation({
+    mutationFn: addWhitelistEmail,
+  })
+}

--- a/frontend/src/pages/AdminRelatedPostsPage.tsx
+++ b/frontend/src/pages/AdminRelatedPostsPage.tsx
@@ -29,6 +29,7 @@ import { useDeleteRelatedPost } from '../hooks/admin/useDeleteRelatedPost'
 import { useDeleteRelatedPostImport } from '../hooks/admin/useDeleteRelatedPostImport'
 import { usePreviewImportDcardSource } from '../hooks/admin/usePreviewImportDcardSource'
 import { useSyncRelatedPostsFromGoogle } from '../hooks/admin/useSyncRelatedPostsFromGoogle'
+import { useAddWhitelistEmail } from '../hooks/admin/useAddWhitelistEmail'
 import { useGetCourses } from '../hooks/courses/useGetCourses'
 import { ManualImportPayloadItem, ManualImportPreviewResponse } from '../types/adminType'
 import styles from '../styles/pages/AdminRelatedPostsPage.module.css'
@@ -91,6 +92,7 @@ const AdminRelatedPostsPage: React.FC = () => {
   const previewDcardSourceMutation = usePreviewImportDcardSource()
   const googleSyncMutation = useSyncRelatedPostsFromGoogle()
   const attachRelatedPostMutation = useAttachRelatedPostToCourses()
+  const addWhitelistEmailMutation = useAddWhitelistEmail()
 
   const [dcardSourceInput, setDcardSourceInput] = useState('')
   const [previewModalOpened, setPreviewModalOpened] = useState(false)
@@ -128,6 +130,7 @@ const AdminRelatedPostsPage: React.FC = () => {
   const [attachCourseLookupKeyword, setAttachCourseLookupKeyword] = useState('')
   const [selectedAttachCourseIds, setSelectedAttachCourseIds] = useState<number[]>([])
   const [attachCourseKeywordOverrides, setAttachCourseKeywordOverrides] = useState<Record<number, string>>({})
+  const [whitelistEmail, setWhitelistEmail] = useState('')
 
   const previewCourseLookupSearchParams = useMemo(() => ({
     page: 1,
@@ -461,6 +464,36 @@ const AdminRelatedPostsPage: React.FC = () => {
     }
   }
 
+  const handleAddWhitelistEmail = async () => {
+    const normalizedEmail = whitelistEmail.trim().toLowerCase()
+    if (!normalizedEmail) {
+      notifications.show({
+        title: '請輸入 Email',
+        message: '請先輸入要加入白名單的 Email。',
+        color: 'red',
+      })
+      return
+    }
+
+    try {
+      const result = await addWhitelistEmailMutation.mutateAsync({ email: normalizedEmail })
+      notifications.show({
+        title: result.created ? '加入成功' : '已在白名單中',
+        message: result.created
+          ? `${result.whitelist.email} 已加入白名單。`
+          : `${result.whitelist.email} 原本就在白名單中。`,
+        color: 'green',
+      })
+      setWhitelistEmail('')
+    } catch (error) {
+      notifications.show({
+        title: '加入白名單失敗',
+        message: error instanceof Error ? error.message : '請稍後再試',
+        color: 'red',
+      })
+    }
+  }
+
   return (
     <Container size='lg' className={styles.container}>
       <ConfirmModal
@@ -779,6 +812,25 @@ const AdminRelatedPostsPage: React.FC = () => {
         <Title order={2}>相關貼文後台</Title>
         <Text c='dimmed'>手動匯入 Dcard 貼文，或以 Google 搜尋同步到課程詳情頁。</Text>
       </div>
+
+      <Card withBorder className={styles.card}>
+        <Stack>
+          <Title order={4}>白名單管理</Title>
+          <Text size='sm' c='dimmed'>輸入 Email 後可直接加入白名單，供非校內信箱使用者登入。</Text>
+          <Group align='flex-end'>
+            <TextInput
+              label='Email'
+              placeholder='name@example.com'
+              value={whitelistEmail}
+              onChange={(event) => setWhitelistEmail(event.currentTarget.value)}
+              style={{ flex: 1 }}
+            />
+            <Button onClick={() => void handleAddWhitelistEmail()} loading={addWhitelistEmailMutation.isPending}>
+              加入白名單
+            </Button>
+          </Group>
+        </Stack>
+      </Card>
 
       <Group gap='sm' className={styles.badges}>
         <Badge size='lg' variant='light'>manual_import: {countsMap.get('manual_import') ?? 0}</Badge>

--- a/frontend/src/pages/AdminRelatedPostsPage.tsx
+++ b/frontend/src/pages/AdminRelatedPostsPage.tsx
@@ -131,6 +131,8 @@ const AdminRelatedPostsPage: React.FC = () => {
   const [selectedAttachCourseIds, setSelectedAttachCourseIds] = useState<number[]>([])
   const [attachCourseKeywordOverrides, setAttachCourseKeywordOverrides] = useState<Record<number, string>>({})
   const [whitelistEmail, setWhitelistEmail] = useState('')
+  const [whitelistStudentId, setWhitelistStudentId] = useState('')
+  const [whitelistNote, setWhitelistNote] = useState('')
 
   const previewCourseLookupSearchParams = useMemo(() => ({
     page: 1,
@@ -476,15 +478,21 @@ const AdminRelatedPostsPage: React.FC = () => {
     }
 
     try {
-      const result = await addWhitelistEmailMutation.mutateAsync({ email: normalizedEmail })
+      const result = await addWhitelistEmailMutation.mutateAsync({
+        email: normalizedEmail,
+        student_id: whitelistStudentId.trim() || undefined,
+        note: whitelistNote.trim() || undefined,
+      })
       notifications.show({
         title: result.created ? '加入成功' : '已在白名單中',
         message: result.created
-          ? `${result.whitelist.email} 已加入白名單。`
-          : `${result.whitelist.email} 原本就在白名單中。`,
+          ? `${result.whitelist.email} 已加入白名單（學號：${result.whitelist.student_id}）。`
+          : `${result.whitelist.email} 原本就在白名單中（學號：${result.whitelist.student_id}）。`,
         color: 'green',
       })
       setWhitelistEmail('')
+      setWhitelistStudentId('')
+      setWhitelistNote('')
     } catch (error) {
       notifications.show({
         title: '加入白名單失敗',
@@ -816,15 +824,27 @@ const AdminRelatedPostsPage: React.FC = () => {
       <Card withBorder className={styles.card}>
         <Stack>
           <Title order={4}>白名單管理</Title>
-          <Text size='sm' c='dimmed'>輸入 Email 後可直接加入白名單，供非校內信箱使用者登入。</Text>
-          <Group align='flex-end'>
-            <TextInput
-              label='Email'
-              placeholder='name@example.com'
-              value={whitelistEmail}
-              onChange={(event) => setWhitelistEmail(event.currentTarget.value)}
-              style={{ flex: 1 }}
-            />
+          <Text size='sm' c='dimmed'>可輸入 Email、學號與備註後加入白名單，供非校內信箱使用者登入。</Text>
+          <TextInput
+            label='Email'
+            placeholder='name@example.com'
+            value={whitelistEmail}
+            onChange={(event) => setWhitelistEmail(event.currentTarget.value)}
+          />
+          <TextInput
+            label='學號（選填）'
+            placeholder='例如：A123456789'
+            value={whitelistStudentId}
+            onChange={(event) => setWhitelistStudentId(event.currentTarget.value)}
+          />
+          <Textarea
+            label='備註（選填）'
+            placeholder='例如：2026 應屆畢業生，人工審核通過'
+            minRows={2}
+            value={whitelistNote}
+            onChange={(event) => setWhitelistNote(event.currentTarget.value)}
+          />
+          <Group justify='flex-end'>
             <Button onClick={() => void handleAddWhitelistEmail()} loading={addWhitelistEmailMutation.isPending}>
               加入白名單
             </Button>

--- a/frontend/src/types/adminType.ts
+++ b/frontend/src/types/adminType.ts
@@ -150,6 +150,8 @@ export interface AttachRelatedPostCoursesResponse {
 
 export interface AddWhitelistEmailPayload {
   email: string;
+  student_id?: string;
+  note?: string;
 }
 
 export interface AddWhitelistEmailResponse {
@@ -157,5 +159,7 @@ export interface AddWhitelistEmailResponse {
   whitelist: {
     id: number;
     email: string;
+    student_id: string;
+    note?: string | null;
   };
 }

--- a/frontend/src/types/adminType.ts
+++ b/frontend/src/types/adminType.ts
@@ -147,3 +147,15 @@ export interface AttachRelatedPostCoursesResponse {
   skipped_course_ids: number[];
   imported_courses: ImportedCourseSummary[];
 }
+
+export interface AddWhitelistEmailPayload {
+  email: string;
+}
+
+export interface AddWhitelistEmailResponse {
+  created: boolean;
+  whitelist: {
+    id: number;
+    email: string;
+  };
+}


### PR DESCRIPTION
### Motivation
- 提供管理員能手動將非校內信箱加入白名單以便登入，補足現有僅以學校域名或既有白名單登入的機制。

### Description
- 新增後端 API `POST /api/admin/whitelist`（需 JWT 與管理員權限），實作於 `backend/controllers/adminController.ts` 的 `addWhitelistEmail`，包含簡單的 email 格式驗證與建立 / 重複處理邏輯。
- 在白名單服務層新增 email 正規化與建立流程 `backend/services/whitelistService.ts` 的 `addWhitelistEmail`，並在資料層 `backend/repositories/whitelistRepository.ts` 新增 `create` 方法建立記錄。
- 前端新增 API 與型別：`frontend/src/apis/adminAPI.ts` 的 `addWhitelistEmail`，以及 `frontend/src/types/adminType.ts` 的請求/回應型別 `AddWhitelistEmailPayload` / `AddWhitelistEmailResponse`。
- 在後台頁面 `frontend/src/pages/AdminRelatedPostsPage.tsx` 新增「白名單管理」卡片、輸入欄位與送出按鈕，並新增 React Query hook `frontend/src/hooks/admin/useAddWhitelistEmail.ts` 來呼叫 API，含成功/錯誤通知處理。

### Testing
- 在後端執行 TypeScript 檢查：`cd backend && npx tsc --noEmit`，檢查通過。
- 在前端執行建置：`cd frontend && npm run build`，建置成功（vite build 完成）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dde4e483bc8331983dba76044ca77a)