### PR TITLE
Feat/feature request wishlist

### DIFF
--- a/.agents/skills/fix-pr/SKILL.md
+++ b/.agents/skills/fix-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: gh-fix-unresolved-review
+name: fix-pr
 description: 處理 GitHub Pull Request 尚未解決且可執行的 review threads，完成程式碼修正、驗證、commit、push，並在每個原始 comment 下以可點擊的完整 commit SHA 逐則回覆，再串行觸發 @codex review 並等待回應。當使用者要求處理 PR 未解決問題、修正 review 意見、推送修正並回覆 reviewer 時使用；預設保留 threads 為 unresolved，不直接 resolve。
 ---
 

--- a/.agents/skills/fix-pr/agents/openai.yaml
+++ b/.agents/skills/fix-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Fix PR"
+  short_description: "修正 PR review 並逐則等待 Codex 複查"
+  default_prompt: "使用 $fix-pr 處理目前 PR 尚未解決的 review 意見，完成驗證與發布，並逐 thread 等待 Codex 複查。"

--- a/.agents/skills/gh-fix-unresolved-review/SKILL.md
+++ b/.agents/skills/gh-fix-unresolved-review/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: gh-fix-unresolved-review
+description: 處理 GitHub Pull Request 尚未解決且可執行的 review threads，完成程式碼修正、驗證、commit、push，並在每個原始 comment 下以可點擊的完整 commit SHA 逐則回覆，再串行觸發 @codex review 並等待回應。當使用者要求處理 PR 未解決問題、修正 review 意見、推送修正並回覆 reviewer 時使用；預設保留 threads 為 unresolved，不直接 resolve。
+---
+
+# 處理未解決的 PR Review
+
+依序完成 thread 查核、修正、驗證、發布及逐則回覆。遵守專案 AGENTS.md，維持變更最小且可追溯。
+
+## 工作流程
+
+1. 確認 PR 與工作區
+   - 優先使用使用者提供的 PR URL 或編號；否則從目前分支查找 PR。
+   - 檢查目前分支、remote、工作區狀態及 PR head branch。
+   - 保留使用者既有變更；若會與修正範圍衝突，先向使用者說明。
+
+2. 取得 thread-aware review 資料
+   - 使用能回傳 thread ID、isResolved、isOutdated、檔案與行號的 GitHub API 或 GraphQL 查詢。
+   - 不以 flat comments 列表判斷 resolution 狀態。
+   - 只處理 unresolved 且可執行的意見；排除已解決、純資訊、重複及已過時且不再適用的意見。
+
+3. 實作修正
+   - 依檔案或行為領域整理問題，讓每項變更可對應回原始 thread。
+   - 使用者要求處理全部問題時，處理所有 unresolved actionable threads。
+   - 若意見互相衝突、語意不明或修正可能造成回歸，先說明取捨，不自行猜測。
+
+4. 驗證
+   - 執行與異動相稱的型別檢查、lint、測試或 build。
+   - 檢查 git diff 與 git diff --check，確保沒有無關變更。
+   - 驗證失敗時先修正；若是既有問題，清楚記錄證據與影響範圍。
+
+5. Commit 與 push
+   - 僅在使用者要求時 commit 與 push。
+   - 只 stage 本次修正檔案；commit message 遵循 repository 既有英文風格，不使用中文。
+   - push 到 PR 的 head branch，並取得 push 後 HEAD 的完整 40 字元 SHA。
+   - 若程式碼早已修正，不建立空 commit；找出實際包含修正的 commit。
+
+6. 串行回覆並觸發複查
+   - 等 push 成功後，依序處理每個 thread 的最上層 review comment，不發一則籠統的 PR conversation comment。
+   - 一次只處理一個 thread。禁止以 Promise.all、平行工具呼叫或短時間連續留言同時觸發多個 @codex review。
+   - 每則回覆第一行加入：@codex review 請確認此問題是否已修正。
+   - 使用完整 40 字元 commit SHA，且不得用反引號或 code block 包住 SHA，確保 GitHub 可自動產生連結。
+   - 以繁體中文簡述該 thread 的實際修正及通過的驗證。
+
+回覆格式：
+
+@codex review 請確認此問題是否已修正。
+
+已於 <完整 40 字元 commit SHA> 修正。<對應修正摘要>。已通過 <驗證項目>。
+
+7. 等待該 thread 的 Codex 回應
+   - 留言後記錄時間與 comment ID，輪詢同一個 review thread，確認出現建立時間較新的 Codex bot 回覆。
+   - 每次輪詢間隔不超過 60 秒，等待期間提供簡短進度更新。
+   - 收到該 thread 的 Codex 回覆後，才觸發下一個 thread；不得只因留言 API 成功就立即處理下一則。
+   - 若 Codex 回覆提出新問題，先處理該問題並重新驗證、push、回覆，再繼續下一個 thread。
+   - 若合理等待時間內沒有回覆，停止後續 @codex 觸發並回報卡住的 thread，避免多個 review 任務互相合併或被忽略。
+
+8. 保留 thread 未解決
+   - 回覆後不要呼叫 resolve review thread。
+   - 若 thread 先前已被誤設為 resolved，先 unresolve，再重新回覆。
+   - 只有使用者在後續明確要求，且複查結果確認修正後，才 resolve 指定 thread。
+
+9. 最後確認
+   - 重新讀取目標 threads，確認新回覆存在、包含 @codex review、完整 SHA 未被 code formatting 包住，且 isResolved 為 false。
+   - 確認每個已觸發的 thread 都收到各自的新 Codex bot 回覆；列出尚未收到回覆的 thread。
+   - 確認本機分支與遠端同步、工作區沒有本次流程遺留的未提交變更。
+   - 回報修正數量、commit、push、驗證結果及仍保留 unresolved 的 threads。
+
+## 寫入安全
+
+- GitHub 回覆、commit、push、unresolve 或 resolve 都必須符合使用者明確授權。
+- 不因完成修正而推定可以 merge、resolve、關閉 PR 或改寫歷史。
+- GitHub CLI 不可用時，改用具備 thread resolution 資料與 review reply 能力的 GitHub connector；不要退回 flat comments 猜測狀態。

--- a/.agents/skills/gh-fix-unresolved-review/agents/openai.yaml
+++ b/.agents/skills/gh-fix-unresolved-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "處理未解決 PR Review"
+  short_description: "修正 PR review 並逐則等待 Codex 複查"
+  default_prompt: "使用 $gh-fix-unresolved-review 處理目前 PR 尚未解決的 review 意見，完成驗證與發布，並逐 thread 等待 Codex 複查。"

--- a/.agents/skills/gh-fix-unresolved-review/agents/openai.yaml
+++ b/.agents/skills/gh-fix-unresolved-review/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "處理未解決 PR Review"
-  short_description: "修正 PR review 並逐則等待 Codex 複查"
-  default_prompt: "使用 $gh-fix-unresolved-review 處理目前 PR 尚未解決的 review 意見，完成驗證與發布，並逐 thread 等待 Codex 複查。"

--- a/backend/controllers/featureRequestController.ts
+++ b/backend/controllers/featureRequestController.ts
@@ -1,0 +1,120 @@
+import { RequestHandler } from "express";
+import FeatureRequestService from "../services/featureRequestService";
+import UserService from "../services/userService";
+import { FEATURE_REQUEST_STATUSES, FeatureRequestStatus } from "../types/featureRequest";
+
+type FeatureRequestParams = { id: string };
+
+const ERROR_STATUS_MAP: Record<string, number> = {
+  EMPTY_CONTENT: 400,
+  CONTENT_TOO_LONG: 400,
+  INVALID_STATUS: 400,
+  ADMIN_REPLY_TOO_LONG: 400,
+  FEATURE_REQUEST_NOT_FOUND: 404,
+  FORBIDDEN: 403,
+};
+
+const ERROR_MESSAGE_MAP: Record<string, string> = {
+  EMPTY_CONTENT: "許願內容不可為空",
+  CONTENT_TOO_LONG: "許願內容長度過長",
+  INVALID_STATUS: "狀態參數不正確",
+  ADMIN_REPLY_TOO_LONG: "回覆內容長度過長",
+  FEATURE_REQUEST_NOT_FOUND: "找不到此許願",
+  FORBIDDEN: "沒有權限執行此操作",
+};
+
+const resolveError = (err: unknown, fallbackMessage: string): { status: number; message: string } => {
+  const key = err instanceof Error ? err.message : undefined;
+  if (key && ERROR_STATUS_MAP[key]) {
+    return { status: ERROR_STATUS_MAP[key], message: ERROR_MESSAGE_MAP[key] };
+  }
+  return { status: 500, message: fallbackMessage };
+};
+
+export const getFeatureRequests: RequestHandler = async (req, res): Promise<void> => {
+  try {
+    const statusParam = req.query.status;
+    const status = FEATURE_REQUEST_STATUSES.includes(statusParam as FeatureRequestStatus)
+      ? (statusParam as FeatureRequestStatus)
+      : undefined;
+
+    const featureRequests = await FeatureRequestService.getAll(status, req.user?.id);
+    res.status(200).json(featureRequests);
+  } catch (err) {
+    const { status, message } = resolveError(err, "取得功能許願列表失敗");
+    res.status(status).json({ message });
+  }
+};
+
+export const createFeatureRequest: RequestHandler = async (req, res): Promise<void> => {
+  try {
+    if (!req.user) {
+      res.status(401).json({ message: "Unauthorized" });
+      return;
+    }
+
+    const content = typeof req.body?.content === "string" ? req.body.content : "";
+    await FeatureRequestService.create(req.user.id, content);
+    res.status(201).json({ message: "許願新增成功" });
+  } catch (err) {
+    const { status, message } = resolveError(err, "新增許願失敗");
+    res.status(status).json({ message });
+  }
+};
+
+export const toggleFeatureRequestVote: RequestHandler<FeatureRequestParams> = async (req, res): Promise<void> => {
+  try {
+    if (!req.user) {
+      res.status(401).json({ message: "Unauthorized" });
+      return;
+    }
+
+    const feature_request_id = parseInt(req.params.id);
+    const result = await FeatureRequestService.toggleVote(feature_request_id, req.user.id);
+    res.status(200).json(result);
+  } catch (err) {
+    const { status, message } = resolveError(err, "按讚失敗");
+    res.status(status).json({ message });
+  }
+};
+
+export const updateFeatureRequestStatus: RequestHandler<FeatureRequestParams> = async (req, res): Promise<void> => {
+  try {
+    const feature_request_id = parseInt(req.params.id);
+    const status = typeof req.body?.status === "string" ? req.body.status : "";
+    await FeatureRequestService.updateStatus(feature_request_id, status);
+    res.status(200).json({ message: "狀態更新成功" });
+  } catch (err) {
+    const { status, message } = resolveError(err, "更新狀態失敗");
+    res.status(status).json({ message });
+  }
+};
+
+export const updateFeatureRequestAdminReply: RequestHandler<FeatureRequestParams> = async (req, res): Promise<void> => {
+  try {
+    const feature_request_id = parseInt(req.params.id);
+    const adminReply = typeof req.body?.admin_reply === "string" ? req.body.admin_reply : "";
+    await FeatureRequestService.updateAdminReply(feature_request_id, adminReply);
+    res.status(200).json({ message: "回覆更新成功" });
+  } catch (err) {
+    const { status, message } = resolveError(err, "更新回覆失敗");
+    res.status(status).json({ message });
+  }
+};
+
+export const deleteFeatureRequest: RequestHandler<FeatureRequestParams> = async (req, res): Promise<void> => {
+  try {
+    if (!req.user) {
+      res.status(401).json({ message: "Unauthorized" });
+      return;
+    }
+
+    const feature_request_id = parseInt(req.params.id);
+    const user = await UserService.getUserById(req.user.id);
+    await FeatureRequestService.remove(feature_request_id, req.user.id, Boolean(user?.is_admin));
+    res.status(200).json({ message: "刪除成功" });
+  } catch (err) {
+    const { status, message } = resolveError(err, "刪除許願失敗");
+    res.status(status).json({ message });
+  }
+};

--- a/backend/controllers/featureRequestController.ts
+++ b/backend/controllers/featureRequestController.ts
@@ -9,6 +9,7 @@ const ERROR_STATUS_MAP: Record<string, number> = {
   EMPTY_CONTENT: 400,
   CONTENT_TOO_LONG: 400,
   INVALID_STATUS: 400,
+  INVALID_ADMIN_REPLY: 400,
   ADMIN_REPLY_TOO_LONG: 400,
   FEATURE_REQUEST_NOT_FOUND: 404,
   FORBIDDEN: 403,
@@ -18,6 +19,7 @@ const ERROR_MESSAGE_MAP: Record<string, string> = {
   EMPTY_CONTENT: "許願內容不可為空",
   CONTENT_TOO_LONG: "許願內容長度過長",
   INVALID_STATUS: "狀態參數不正確",
+  INVALID_ADMIN_REPLY: "回覆內容格式不正確",
   ADMIN_REPLY_TOO_LONG: "回覆內容長度過長",
   FEATURE_REQUEST_NOT_FOUND: "找不到此許願",
   FORBIDDEN: "沒有權限執行此操作",
@@ -93,7 +95,11 @@ export const updateFeatureRequestStatus: RequestHandler<FeatureRequestParams> = 
 export const updateFeatureRequestAdminReply: RequestHandler<FeatureRequestParams> = async (req, res): Promise<void> => {
   try {
     const feature_request_id = parseInt(req.params.id);
-    const adminReply = typeof req.body?.admin_reply === "string" ? req.body.admin_reply : "";
+    if (typeof req.body?.admin_reply !== "string") {
+      throw new Error("INVALID_ADMIN_REPLY");
+    }
+
+    const adminReply = req.body.admin_reply;
     await FeatureRequestService.updateAdminReply(feature_request_id, adminReply);
     res.status(200).json({ message: "回覆更新成功" });
   } catch (err) {

--- a/backend/migrations/20260619000000-create-feature-requests.js
+++ b/backend/migrations/20260619000000-create-feature-requests.js
@@ -1,0 +1,109 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('FeatureRequests', {
+      id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      user_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Users',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      content: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      status: {
+        type: Sequelize.ENUM('pending', 'in_progress', 'completed'),
+        allowNull: false,
+        defaultValue: 'pending',
+      },
+      admin_reply: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      vote_count: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 0,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+
+    await queryInterface.addIndex('FeatureRequests', ['status'], {
+      name: 'idx_feature_requests_status',
+    });
+    await queryInterface.addIndex('FeatureRequests', ['vote_count'], {
+      name: 'idx_feature_requests_vote_count',
+    });
+
+    await queryInterface.createTable('FeatureRequestVotes', {
+      id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      feature_request_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'FeatureRequests',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      user_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Users',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+
+    await queryInterface.addConstraint('FeatureRequestVotes', {
+      fields: ['feature_request_id', 'user_id'],
+      type: 'unique',
+      name: 'uniq_feature_request_votes_request_user',
+    });
+
+    await queryInterface.addIndex('FeatureRequestVotes', ['feature_request_id'], {
+      name: 'idx_feature_request_votes_request_id',
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('FeatureRequestVotes');
+    await queryInterface.dropTable('FeatureRequests');
+  },
+};

--- a/backend/models/FeatureRequest.ts
+++ b/backend/models/FeatureRequest.ts
@@ -1,0 +1,77 @@
+import {
+  CreationOptional,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+} from "sequelize";
+import db from "./index";
+import UserModel from "./Users";
+
+export type FeatureRequestStatus = "pending" | "in_progress" | "completed";
+
+class FeatureRequestModel extends Model<
+  InferAttributes<FeatureRequestModel>,
+  InferCreationAttributes<FeatureRequestModel>
+> {
+  declare id: CreationOptional<number>;
+  declare user_id: number;
+  declare content: string;
+  declare status: CreationOptional<FeatureRequestStatus>;
+  declare admin_reply: CreationOptional<string | null>;
+  declare vote_count: CreationOptional<number>;
+  declare created_at: CreationOptional<Date>;
+  declare updated_at: CreationOptional<Date>;
+}
+
+FeatureRequestModel.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    user_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    content: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    status: {
+      type: DataTypes.ENUM("pending", "in_progress", "completed"),
+      allowNull: false,
+      defaultValue: "pending",
+    },
+    admin_reply: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    vote_count: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    sequelize: db.sequelize,
+    tableName: "FeatureRequests",
+    timestamps: true,
+    createdAt: "created_at",
+    updatedAt: "updated_at",
+  }
+);
+
+FeatureRequestModel.belongsTo(UserModel, { foreignKey: "user_id" });
+UserModel.hasMany(FeatureRequestModel, { foreignKey: "user_id" });
+
+export default FeatureRequestModel;

--- a/backend/models/FeatureRequestVote.ts
+++ b/backend/models/FeatureRequestVote.ts
@@ -1,0 +1,55 @@
+import {
+  CreationOptional,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+} from "sequelize";
+import db from "./index";
+import UserModel from "./Users";
+import FeatureRequestModel from "./FeatureRequest";
+
+class FeatureRequestVoteModel extends Model<
+  InferAttributes<FeatureRequestVoteModel>,
+  InferCreationAttributes<FeatureRequestVoteModel>
+> {
+  declare id: CreationOptional<number>;
+  declare feature_request_id: number;
+  declare user_id: number;
+  declare created_at: CreationOptional<Date>;
+}
+
+FeatureRequestVoteModel.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    feature_request_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    user_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    sequelize: db.sequelize,
+    tableName: "FeatureRequestVotes",
+    timestamps: false,
+    createdAt: "created_at",
+    updatedAt: false,
+  }
+);
+
+FeatureRequestVoteModel.belongsTo(UserModel, { foreignKey: "user_id" });
+FeatureRequestVoteModel.belongsTo(FeatureRequestModel, { foreignKey: "feature_request_id" });
+FeatureRequestModel.hasMany(FeatureRequestVoteModel, { foreignKey: "feature_request_id" });
+
+export default FeatureRequestVoteModel;

--- a/backend/repositories/featureRequestRepository.ts
+++ b/backend/repositories/featureRequestRepository.ts
@@ -18,8 +18,11 @@ class FeatureRequestRepository {
     });
   }
 
-  async findById(id: number, transaction?: Transaction): Promise<FeatureRequestModel | null> {
-    return await FeatureRequestModel.findByPk(id, { transaction });
+  async findById(id: number, transaction?: Transaction, lockForUpdate = false): Promise<FeatureRequestModel | null> {
+    return await FeatureRequestModel.findByPk(id, {
+      transaction,
+      lock: transaction && lockForUpdate ? transaction.LOCK.UPDATE : undefined,
+    });
   }
 
   async create(user_id: number, content: string): Promise<FeatureRequestModel> {

--- a/backend/repositories/featureRequestRepository.ts
+++ b/backend/repositories/featureRequestRepository.ts
@@ -1,0 +1,90 @@
+import { Op, Transaction } from "sequelize";
+import FeatureRequestModel from "../models/FeatureRequest";
+import FeatureRequestVoteModel from "../models/FeatureRequestVote";
+import UserModel from "../models/Users";
+import { FeatureRequestStatus } from "../types/featureRequest";
+
+class FeatureRequestRepository {
+  async getAll(status: FeatureRequestStatus | undefined): Promise<FeatureRequestModel[]> {
+    return await FeatureRequestModel.findAll({
+      where: status ? { status } : undefined,
+      order: [["vote_count", "DESC"], ["created_at", "DESC"]],
+      include: [
+        {
+          model: UserModel,
+          attributes: ["name", "avatar"],
+        },
+      ],
+    });
+  }
+
+  async findById(id: number, transaction?: Transaction): Promise<FeatureRequestModel | null> {
+    return await FeatureRequestModel.findByPk(id, { transaction });
+  }
+
+  async create(user_id: number, content: string): Promise<FeatureRequestModel> {
+    return await FeatureRequestModel.create({ user_id, content });
+  }
+
+  async destroy(id: number): Promise<number> {
+    return await FeatureRequestModel.destroy({ where: { id } });
+  }
+
+  async updateStatus(id: number, status: FeatureRequestStatus): Promise<number> {
+    const [count] = await FeatureRequestModel.update({ status }, { where: { id } });
+    return count;
+  }
+
+  async updateAdminReply(id: number, admin_reply: string | null): Promise<number> {
+    const [count] = await FeatureRequestModel.update({ admin_reply }, { where: { id } });
+    return count;
+  }
+
+  async incrementVoteCount(id: number, transaction: Transaction): Promise<void> {
+    await FeatureRequestModel.increment("vote_count", { by: 1, where: { id }, transaction });
+  }
+
+  async decrementVoteCount(id: number, transaction: Transaction): Promise<void> {
+    await FeatureRequestModel.decrement("vote_count", { by: 1, where: { id }, transaction });
+  }
+
+  async findVote(
+    feature_request_id: number,
+    user_id: number,
+    transaction: Transaction
+  ): Promise<FeatureRequestVoteModel | null> {
+    return await FeatureRequestVoteModel.findOne({
+      where: { feature_request_id, user_id },
+      transaction,
+      lock: transaction.LOCK.UPDATE,
+    });
+  }
+
+  async addVote(feature_request_id: number, user_id: number, transaction: Transaction): Promise<void> {
+    await FeatureRequestVoteModel.create({ feature_request_id, user_id }, { transaction });
+  }
+
+  async removeVote(feature_request_id: number, user_id: number, transaction: Transaction): Promise<number> {
+    return await FeatureRequestVoteModel.destroy({
+      where: { feature_request_id, user_id },
+      transaction,
+    });
+  }
+
+  async getVotedIdsByUser(feature_request_ids: number[], user_id: number): Promise<Set<number>> {
+    if (feature_request_ids.length === 0) return new Set();
+
+    const votes = await FeatureRequestVoteModel.findAll({
+      where: {
+        feature_request_id: { [Op.in]: feature_request_ids },
+        user_id,
+      },
+      attributes: ["feature_request_id"],
+      raw: true,
+    });
+
+    return new Set(votes.map((vote) => vote.feature_request_id));
+  }
+}
+
+export default new FeatureRequestRepository();

--- a/backend/routes/featureRequests.ts
+++ b/backend/routes/featureRequests.ts
@@ -1,0 +1,22 @@
+import express, { Router } from "express";
+import {
+  createFeatureRequest,
+  deleteFeatureRequest,
+  getFeatureRequests,
+  toggleFeatureRequestVote,
+  updateFeatureRequestAdminReply,
+  updateFeatureRequestStatus,
+} from "../controllers/featureRequestController";
+import { authenticateJWT, getCookie } from "../middlewares/authMiddleware";
+import { authenticateAdmin } from "../middlewares/adminMiddleware";
+
+const router: Router = express.Router();
+
+router.get("/", getCookie, getFeatureRequests);
+router.post("/", authenticateJWT, createFeatureRequest);
+router.post("/:id/vote", authenticateJWT, toggleFeatureRequestVote);
+router.patch("/:id/status", authenticateJWT, authenticateAdmin, updateFeatureRequestStatus);
+router.patch("/:id/reply", authenticateJWT, authenticateAdmin, updateFeatureRequestAdminReply);
+router.delete("/:id", authenticateJWT, deleteFeatureRequest);
+
+export default router;

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -18,6 +18,7 @@ import semestersRoutes from "./routes/semesters";
 import timetablesRoutes from "./routes/timetables";
 import reactionsRoutes from "./routes/reactions";
 import adminRoutes from "./routes/admin";
+import featureRequestsRoutes from "./routes/featureRequests";
 
 const app: Express = express();
 const __filename = fileURLToPath(import.meta.url);
@@ -49,6 +50,7 @@ app.use("/api/reactions", reactionsRoutes);
 app.use("/api/semesters", semestersRoutes);
 app.use("/api/timetables", timetablesRoutes);
 app.use("/api/admin", adminRoutes);
+app.use("/api/feature-requests", featureRequestsRoutes);
 
 const startServer = async (): Promise<void> => {
   try {

--- a/backend/services/featureRequestService.ts
+++ b/backend/services/featureRequestService.ts
@@ -47,7 +47,7 @@ class FeatureRequestService {
     const transaction = await db.sequelize.transaction();
 
     try {
-      const featureRequest = await FeatureRequestRepository.findById(feature_request_id, transaction);
+const featureRequest = await FeatureRequestRepository.findById(feature_request_id, transaction, true);
       if (!featureRequest) {
         throw new Error("FEATURE_REQUEST_NOT_FOUND");
       }

--- a/backend/services/featureRequestService.ts
+++ b/backend/services/featureRequestService.ts
@@ -44,34 +44,30 @@ class FeatureRequestService {
   }
 
   async toggleVote(feature_request_id: number, user_id: number): Promise<ToggleFeatureRequestVoteResult> {
-    const transaction = await db.sequelize.transaction();
-
     try {
-const featureRequest = await FeatureRequestRepository.findById(feature_request_id, transaction, true);
-      if (!featureRequest) {
-        throw new Error("FEATURE_REQUEST_NOT_FOUND");
-      }
+      return await db.sequelize.transaction(async (transaction) => {
+        const featureRequest = await FeatureRequestRepository.findById(feature_request_id, transaction, true);
+        if (!featureRequest) {
+          throw new Error("FEATURE_REQUEST_NOT_FOUND");
+        }
 
-      const existingVote = await FeatureRequestRepository.findVote(feature_request_id, user_id, transaction);
-      let has_voted: boolean;
+        const existingVote = await FeatureRequestRepository.findVote(feature_request_id, user_id, transaction);
+        let has_voted: boolean;
 
-      if (existingVote) {
-        await FeatureRequestRepository.removeVote(feature_request_id, user_id, transaction);
-        await FeatureRequestRepository.decrementVoteCount(feature_request_id, transaction);
-        has_voted = false;
-      } else {
-        await FeatureRequestRepository.addVote(feature_request_id, user_id, transaction);
-        await FeatureRequestRepository.incrementVoteCount(feature_request_id, transaction);
-        has_voted = true;
-      }
+        if (existingVote) {
+          await FeatureRequestRepository.removeVote(feature_request_id, user_id, transaction);
+          await FeatureRequestRepository.decrementVoteCount(feature_request_id, transaction);
+          has_voted = false;
+        } else {
+          await FeatureRequestRepository.addVote(feature_request_id, user_id, transaction);
+          await FeatureRequestRepository.incrementVoteCount(feature_request_id, transaction);
+          has_voted = true;
+        }
 
-      await transaction.commit();
-
-      const updated = await FeatureRequestRepository.findById(feature_request_id);
-      return { has_voted, vote_count: updated?.vote_count ?? 0 };
+        const updated = await FeatureRequestRepository.findById(feature_request_id, transaction);
+        return { has_voted, vote_count: updated?.vote_count ?? 0 };
+      });
     } catch (err) {
-      await transaction.rollback();
-
       if (err instanceof UniqueConstraintError) {
         const updated = await FeatureRequestRepository.findById(feature_request_id);
         return { has_voted: true, vote_count: updated?.vote_count ?? 0 };

--- a/backend/services/featureRequestService.ts
+++ b/backend/services/featureRequestService.ts
@@ -1,0 +1,127 @@
+import { UniqueConstraintError } from "sequelize";
+import db from "../models";
+import FeatureRequestRepository from "../repositories/featureRequestRepository";
+import {
+  FEATURE_REQUEST_STATUSES,
+  FeatureRequestResponse,
+  FeatureRequestStatus,
+  ToggleFeatureRequestVoteResult,
+} from "../types/featureRequest";
+
+const MAX_CONTENT_LENGTH = 500;
+const MAX_ADMIN_REPLY_LENGTH = 500;
+
+class FeatureRequestService {
+  async getAll(
+    status: FeatureRequestStatus | undefined,
+    user_id: number | undefined
+  ): Promise<FeatureRequestResponse[]> {
+    const featureRequests = await FeatureRequestRepository.getAll(status);
+    const votedIds = user_id !== undefined
+      ? await FeatureRequestRepository.getVotedIdsByUser(featureRequests.map((item) => item.id), user_id)
+      : new Set<number>();
+
+    return featureRequests.map((featureRequest) => {
+      const { user_id: ownerId, ...rest } = featureRequest.toJSON();
+      return {
+        ...rest,
+        is_owner: ownerId === user_id,
+        has_voted: votedIds.has(rest.id),
+      } as FeatureRequestResponse;
+    });
+  }
+
+  async create(user_id: number, content: string): Promise<void> {
+    const trimmedContent = content.trim();
+    if (!trimmedContent) {
+      throw new Error("EMPTY_CONTENT");
+    }
+    if (trimmedContent.length > MAX_CONTENT_LENGTH) {
+      throw new Error("CONTENT_TOO_LONG");
+    }
+
+    await FeatureRequestRepository.create(user_id, trimmedContent);
+  }
+
+  async toggleVote(feature_request_id: number, user_id: number): Promise<ToggleFeatureRequestVoteResult> {
+    const transaction = await db.sequelize.transaction();
+
+    try {
+      const featureRequest = await FeatureRequestRepository.findById(feature_request_id, transaction);
+      if (!featureRequest) {
+        throw new Error("FEATURE_REQUEST_NOT_FOUND");
+      }
+
+      const existingVote = await FeatureRequestRepository.findVote(feature_request_id, user_id, transaction);
+      let has_voted: boolean;
+
+      if (existingVote) {
+        await FeatureRequestRepository.removeVote(feature_request_id, user_id, transaction);
+        await FeatureRequestRepository.decrementVoteCount(feature_request_id, transaction);
+        has_voted = false;
+      } else {
+        await FeatureRequestRepository.addVote(feature_request_id, user_id, transaction);
+        await FeatureRequestRepository.incrementVoteCount(feature_request_id, transaction);
+        has_voted = true;
+      }
+
+      await transaction.commit();
+
+      const updated = await FeatureRequestRepository.findById(feature_request_id);
+      return { has_voted, vote_count: updated?.vote_count ?? 0 };
+    } catch (err) {
+      await transaction.rollback();
+
+      if (err instanceof UniqueConstraintError) {
+        const updated = await FeatureRequestRepository.findById(feature_request_id);
+        return { has_voted: true, vote_count: updated?.vote_count ?? 0 };
+      }
+
+      throw err;
+    }
+  }
+
+  async updateAdminReply(feature_request_id: number, adminReply: string): Promise<void> {
+    const trimmed = adminReply.trim();
+    if (trimmed.length > MAX_ADMIN_REPLY_LENGTH) {
+      throw new Error("ADMIN_REPLY_TOO_LONG");
+    }
+
+    const updatedCount = await FeatureRequestRepository.updateAdminReply(
+      feature_request_id,
+      trimmed.length > 0 ? trimmed : null
+    );
+    if (updatedCount === 0) {
+      throw new Error("FEATURE_REQUEST_NOT_FOUND");
+    }
+  }
+
+  async updateStatus(feature_request_id: number, status: string): Promise<void> {
+    if (!FEATURE_REQUEST_STATUSES.includes(status as FeatureRequestStatus)) {
+      throw new Error("INVALID_STATUS");
+    }
+
+    const updatedCount = await FeatureRequestRepository.updateStatus(
+      feature_request_id,
+      status as FeatureRequestStatus
+    );
+    if (updatedCount === 0) {
+      throw new Error("FEATURE_REQUEST_NOT_FOUND");
+    }
+  }
+
+  async remove(feature_request_id: number, user_id: number, isAdmin: boolean): Promise<void> {
+    const featureRequest = await FeatureRequestRepository.findById(feature_request_id);
+    if (!featureRequest) {
+      throw new Error("FEATURE_REQUEST_NOT_FOUND");
+    }
+
+    if (!isAdmin && featureRequest.user_id !== user_id) {
+      throw new Error("FORBIDDEN");
+    }
+
+    await FeatureRequestRepository.destroy(feature_request_id);
+  }
+}
+
+export default new FeatureRequestService();

--- a/backend/types/featureRequest.ts
+++ b/backend/types/featureRequest.ts
@@ -1,0 +1,24 @@
+export type FeatureRequestStatus = "pending" | "in_progress" | "completed";
+
+export const FEATURE_REQUEST_STATUSES: FeatureRequestStatus[] = ["pending", "in_progress", "completed"];
+
+export interface FeatureRequestResponse {
+  id: number;
+  content: string;
+  status: FeatureRequestStatus;
+  admin_reply: string | null;
+  vote_count: number;
+  has_voted: boolean;
+  is_owner: boolean;
+  created_at: Date;
+  updated_at: Date;
+  UserModel: {
+    name: string;
+    avatar: string;
+  };
+}
+
+export interface ToggleFeatureRequestVoteResult {
+  has_voted: boolean;
+  vote_count: number;
+}

--- a/frontend/src/apis/featureRequestAPI.ts
+++ b/frontend/src/apis/featureRequestAPI.ts
@@ -1,0 +1,30 @@
+import { FeatureRequest, FeatureRequestStatus, ToggleFeatureRequestVoteResult } from '../types/featureRequestType'
+import { axiosInstance } from './axiosInstance'
+
+export const getFeatureRequests = async (status?: FeatureRequestStatus): Promise<FeatureRequest[]> => {
+  const response = await axiosInstance.get('/feature-requests', {
+    params: status ? { status } : undefined,
+  })
+  return response.data
+}
+
+export const createFeatureRequest = async (content: string): Promise<void> => {
+  await axiosInstance.post('/feature-requests', { content })
+}
+
+export const toggleFeatureRequestVote = async (id: number): Promise<ToggleFeatureRequestVoteResult> => {
+  const response = await axiosInstance.post(`/feature-requests/${id}/vote`)
+  return response.data
+}
+
+export const updateFeatureRequestStatus = async (id: number, status: FeatureRequestStatus): Promise<void> => {
+  await axiosInstance.patch(`/feature-requests/${id}/status`, { status })
+}
+
+export const updateFeatureRequestAdminReply = async (id: number, admin_reply: string): Promise<void> => {
+  await axiosInstance.patch(`/feature-requests/${id}/reply`, { admin_reply })
+}
+
+export const deleteFeatureRequest = async (id: number): Promise<void> => {
+  await axiosInstance.delete(`/feature-requests/${id}`)
+}

--- a/frontend/src/components/FeatureRequestCard.tsx
+++ b/frontend/src/components/FeatureRequestCard.tsx
@@ -147,7 +147,7 @@ const FeatureRequestCard: React.FC<FeatureRequestCardProps> = ({
             size='xs'
             leftSection={item.has_voted ? <FaThumbsUp size={14} /> : <FaRegThumbsUp size={14} />}
             onClick={handleToggleVote}
-            disabled={!isAuthenticated || isTogglingVote}
+            disabled={isTogglingVote}
             loading={isTogglingVote}
           >
             {item.vote_count}

--- a/frontend/src/components/FeatureRequestCard.tsx
+++ b/frontend/src/components/FeatureRequestCard.tsx
@@ -1,0 +1,185 @@
+import { useState } from 'react'
+import { Avatar, Badge, Box, Button, Card, Group, Select, Stack, Text, Textarea, Tooltip } from '@mantine/core'
+import { notifications } from '@mantine/notifications'
+import { FaEdit, FaRegThumbsUp, FaThumbsUp } from 'react-icons/fa'
+import { RiDeleteBin6Fill } from 'react-icons/ri'
+
+import { FeatureRequest, FeatureRequestStatus } from '../types/featureRequestType'
+import { useToggleFeatureRequestVote } from '../hooks/featureRequests/useToggleFeatureRequestVote'
+import { useUpdateFeatureRequestStatus } from '../hooks/featureRequests/useUpdateFeatureRequestStatus'
+import { useUpdateFeatureRequestAdminReply } from '../hooks/featureRequests/useUpdateFeatureRequestAdminReply'
+import { getAvatarSrc } from '../utils/avatarUrl'
+import styles from '../styles/pages/WishlistPage.module.css'
+
+const MAX_ADMIN_REPLY_LENGTH = 500
+
+const STATUS_LABEL: Record<FeatureRequestStatus, string> = {
+  pending: '許願中',
+  in_progress: '進行中',
+  completed: '已完成',
+}
+
+const STATUS_COLOR: Record<FeatureRequestStatus, string> = {
+  pending: 'gray',
+  in_progress: 'blue',
+  completed: 'green',
+}
+
+const STATUS_SELECT_DATA = (Object.keys(STATUS_LABEL) as FeatureRequestStatus[]).map((status) => ({
+  value: status,
+  label: STATUS_LABEL[status],
+}))
+
+interface FeatureRequestCardProps {
+  item: FeatureRequest;
+  isAuthenticated: boolean;
+  isAdmin: boolean;
+  onRequireLogin: () => void;
+  onRequestDelete: (item: FeatureRequest) => void;
+}
+
+const FeatureRequestCard: React.FC<FeatureRequestCardProps> = ({
+  item,
+  isAuthenticated,
+  isAdmin,
+  onRequireLogin,
+  onRequestDelete,
+}) => {
+  const [isEditingReply, setIsEditingReply] = useState(false)
+  const [replyDraft, setReplyDraft] = useState(item.admin_reply ?? '')
+
+  const { mutate: toggleVote, isPending: isTogglingVote } = useToggleFeatureRequestVote()
+  const { mutate: updateStatus } = useUpdateFeatureRequestStatus()
+  const { mutate: updateAdminReply, isPending: isSavingReply } = useUpdateFeatureRequestAdminReply()
+
+  const handleToggleVote = () => {
+    if (!isAuthenticated) {
+      onRequireLogin()
+      return
+    }
+    toggleVote(item.id)
+  }
+
+  const startEditReply = () => {
+    setReplyDraft(item.admin_reply ?? '')
+    setIsEditingReply(true)
+  }
+
+  const handleSaveReply = () => {
+    const trimmed = replyDraft.trim()
+    if (trimmed.length > MAX_ADMIN_REPLY_LENGTH) {
+      notifications.show({ title: '無法儲存', message: `回覆最多 ${MAX_ADMIN_REPLY_LENGTH} 字`, color: 'red' })
+      return
+    }
+
+    updateAdminReply(
+      { id: item.id, admin_reply: trimmed },
+      {
+        onSuccess: () => setIsEditingReply(false),
+        onError: (error) => {
+          notifications.show({ title: '儲存失敗', message: error instanceof Error ? error.message : '請稍後再試', color: 'red' })
+        },
+      }
+    )
+  }
+
+  const avatarSrc = getAvatarSrc(item.UserModel?.avatar)
+
+  return (
+    <Card className={styles.card}>
+      <Group justify='space-between' align='flex-start' wrap='nowrap' className={styles.headerRow}>
+        <Group className={styles.userInfo}>
+          <Avatar variant='light' size='lg' color='brick-red.6' src={avatarSrc} />
+          <Box className={styles.userMeta}>
+            <Text>{item.UserModel?.name ?? '匿名'}</Text>
+            <Text size='xs' c='dimmed'>{new Date(item.created_at).toLocaleString()}</Text>
+          </Box>
+        </Group>
+        <Badge color={STATUS_COLOR[item.status]} variant='light'>
+          {STATUS_LABEL[item.status]}
+        </Badge>
+      </Group>
+
+      <Text className={styles.contentText} mt='sm'>{item.content}</Text>
+
+      {isEditingReply ? (
+        <Stack gap={4} className={styles.replyEditBox}>
+          <Textarea
+            value={replyDraft}
+            onChange={(event) => setReplyDraft(event.currentTarget.value)}
+            placeholder='輸入官方回覆'
+            minRows={2}
+            autosize
+            maxLength={MAX_ADMIN_REPLY_LENGTH}
+          />
+          <Group justify='flex-end' gap='xs'>
+            <Button size='compact-xs' variant='subtle' onClick={() => setIsEditingReply(false)}>取消</Button>
+            <Button size='compact-xs' onClick={handleSaveReply} loading={isSavingReply}>儲存</Button>
+          </Group>
+        </Stack>
+      ) : item.admin_reply ? (
+        <div className={styles.replyBox}>
+          <Group justify='space-between' align='flex-start' wrap='nowrap'>
+            <Stack gap={2}>
+              <Text size='xs' fw={700} c='brick-red.7'>官方回覆</Text>
+              <Text size='sm' className={styles.contentText}>{item.admin_reply}</Text>
+            </Stack>
+            {isAdmin && (
+              <Button size='compact-xs' variant='subtle' leftSection={<FaEdit size={12} />} onClick={startEditReply}>
+                編輯
+              </Button>
+            )}
+          </Group>
+        </div>
+      ) : (
+        isAdmin && (
+          <Button size='compact-xs' variant='subtle' mt='xs' onClick={startEditReply}>
+            新增官方回覆
+          </Button>
+        )
+      )}
+
+      <Group justify='space-between' mt='sm'>
+        <Tooltip label={isAuthenticated ? '按讚支持' : '請先登入才能按讚'}>
+          <Button
+            variant={item.has_voted ? 'filled' : 'light'}
+            color='brick-red.6'
+            size='xs'
+            leftSection={item.has_voted ? <FaThumbsUp size={14} /> : <FaRegThumbsUp size={14} />}
+            onClick={handleToggleVote}
+            disabled={!isAuthenticated || isTogglingVote}
+            loading={isTogglingVote}
+          >
+            {item.vote_count}
+          </Button>
+        </Tooltip>
+
+        {isAuthenticated && (isAdmin || item.is_owner) && (
+          <Group gap='xs'>
+            {isAdmin && (
+              <Select
+                size='xs'
+                data={STATUS_SELECT_DATA}
+                value={item.status}
+                allowDeselect={false}
+                onChange={(value) => value && updateStatus({ id: item.id, status: value as FeatureRequestStatus })}
+                className={styles.statusSelect}
+              />
+            )}
+            <Button
+              variant='subtle'
+              color='red'
+              size='xs'
+              leftSection={<RiDeleteBin6Fill size={14} />}
+              onClick={() => onRequestDelete(item)}
+            >
+              刪除
+            </Button>
+          </Group>
+        )}
+      </Group>
+    </Card>
+  )
+}
+
+export default FeatureRequestCard

--- a/frontend/src/components/FeatureRequestCard.tsx
+++ b/frontend/src/components/FeatureRequestCard.tsx
@@ -57,7 +57,11 @@ const FeatureRequestCard: React.FC<FeatureRequestCardProps> = ({
       onRequireLogin()
       return
     }
-    toggleVote(item.id)
+    toggleVote(item.id, {
+      onError: (error) => {
+        notifications.show({ title: '投票失敗', message: error instanceof Error ? error.message : '請稍後再試', color: 'red' })
+      },
+    })
   }
 
   const startEditReply = () => {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -42,6 +42,9 @@ const Header: React.FC = () => {
             相關貼文後台
           </Menu.Item>
         )}
+        <Menu.Item component={Link} to='/wishlist'>
+          功能許願
+        </Menu.Item>
         <Menu.Item component={Link} to='/versions'>
           版本紀錄
         </Menu.Item>
@@ -83,6 +86,14 @@ const Header: React.FC = () => {
             <div className={styles.mobileDivider} />
             <AuthButton className={styles.mobileAuthButton} onClick={() => setOpened(false)} />
             <div className={styles.mobileDivider} />
+            <Text
+              component={Link}
+              to='/wishlist'
+              onClick={() => setOpened(false)}
+              className={styles.mobileSecondaryLink}
+            >
+              功能許願
+            </Text>
             <Text
               component={Link}
               to='/versions'

--- a/frontend/src/hooks/featureRequests/useCreateFeatureRequest.ts
+++ b/frontend/src/hooks/featureRequests/useCreateFeatureRequest.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { createFeatureRequest } from '../../apis/featureRequestAPI'
+import { QUERY_KEYS } from '../queryKeys'
+
+export const useCreateFeatureRequest = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (content: string) => createFeatureRequest(content),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.FEATURE_REQUESTS] })
+    },
+  })
+}

--- a/frontend/src/hooks/featureRequests/useDeleteFeatureRequest.ts
+++ b/frontend/src/hooks/featureRequests/useDeleteFeatureRequest.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { deleteFeatureRequest } from '../../apis/featureRequestAPI'
+import { QUERY_KEYS } from '../queryKeys'
+
+export const useDeleteFeatureRequest = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (id: number) => deleteFeatureRequest(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.FEATURE_REQUESTS] })
+    },
+  })
+}

--- a/frontend/src/hooks/featureRequests/useGetFeatureRequests.ts
+++ b/frontend/src/hooks/featureRequests/useGetFeatureRequests.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query'
+import { getFeatureRequests } from '../../apis/featureRequestAPI'
+import { FeatureRequestStatus } from '../../types/featureRequestType'
+import { QUERY_KEYS } from '../queryKeys'
+import { useAuthStore } from '../../stores/authStore'
+
+export const useGetFeatureRequests = (status?: FeatureRequestStatus) => {
+  const userId = useAuthStore((state) => state.user?.id)
+
+  return useQuery({
+    queryKey: [QUERY_KEYS.FEATURE_REQUESTS, status ?? 'all', userId ?? 'anonymous'],
+    queryFn: () => getFeatureRequests(status),
+    staleTime: 1000 * 60,
+  })
+}

--- a/frontend/src/hooks/featureRequests/useToggleFeatureRequestVote.ts
+++ b/frontend/src/hooks/featureRequests/useToggleFeatureRequestVote.ts
@@ -12,9 +12,14 @@ export const useToggleFeatureRequestVote = () => {
       queryClient.setQueriesData<FeatureRequest[]>(
         { queryKey: [QUERY_KEYS.FEATURE_REQUESTS] },
         (oldData) =>
-          oldData?.map((item) =>
-            item.id === id ? { ...item, has_voted: data.has_voted, vote_count: data.vote_count } : item
-          )
+          oldData
+            ?.map((item) =>
+              item.id === id ? { ...item, has_voted: data.has_voted, vote_count: data.vote_count } : item
+            )
+            .sort((firstItem, secondItem) => {
+              if (secondItem.vote_count !== firstItem.vote_count) return secondItem.vote_count - firstItem.vote_count
+              return new Date(secondItem.created_at).getTime() - new Date(firstItem.created_at).getTime()
+            })
       )
     },
   })

--- a/frontend/src/hooks/featureRequests/useToggleFeatureRequestVote.ts
+++ b/frontend/src/hooks/featureRequests/useToggleFeatureRequestVote.ts
@@ -6,15 +6,15 @@ import { QUERY_KEYS } from '../queryKeys'
 
 export const useToggleFeatureRequestVote = () => {
   const queryClient = useQueryClient()
-  const userId = useAuthStore((state) => state.user?.id)
 
   return useMutation({
     mutationFn: (id: number) => toggleFeatureRequestVote(id),
-    onSuccess: (data, id) => {
+    onMutate: () => ({ userKey: useAuthStore.getState().user?.id ?? 'anonymous' }),
+    onSuccess: (data, id, context) => {
       queryClient.setQueriesData<FeatureRequest[]>(
         {
           queryKey: [QUERY_KEYS.FEATURE_REQUESTS],
-          predicate: (query) => query.queryKey[2] === (userId ?? 'anonymous'),
+          predicate: (query) => query.queryKey[2] === context.userKey,
         },
         (oldData) =>
           oldData

--- a/frontend/src/hooks/featureRequests/useToggleFeatureRequestVote.ts
+++ b/frontend/src/hooks/featureRequests/useToggleFeatureRequestVote.ts
@@ -12,19 +12,23 @@ export const useToggleFeatureRequestVote = () => {
     onMutate: () => ({ userKey: useAuthStore.getState().user?.id ?? 'anonymous' }),
     onSuccess: (data, id, context) => {
       queryClient.setQueriesData<FeatureRequest[]>(
+        { queryKey: [QUERY_KEYS.FEATURE_REQUESTS] },
+        (oldData) =>
+          oldData
+            ?.map((item) => (item.id === id ? { ...item, vote_count: data.vote_count } : item))
+            .sort((firstItem, secondItem) => {
+              if (secondItem.vote_count !== firstItem.vote_count) return secondItem.vote_count - firstItem.vote_count
+              return new Date(secondItem.created_at).getTime() - new Date(firstItem.created_at).getTime()
+            })
+      )
+
+      queryClient.setQueriesData<FeatureRequest[]>(
         {
           queryKey: [QUERY_KEYS.FEATURE_REQUESTS],
           predicate: (query) => query.queryKey[2] === context.userKey,
         },
         (oldData) =>
-          oldData
-            ?.map((item) =>
-              item.id === id ? { ...item, has_voted: data.has_voted, vote_count: data.vote_count } : item
-            )
-            .sort((firstItem, secondItem) => {
-              if (secondItem.vote_count !== firstItem.vote_count) return secondItem.vote_count - firstItem.vote_count
-              return new Date(secondItem.created_at).getTime() - new Date(firstItem.created_at).getTime()
-            })
+          oldData?.map((item) => (item.id === id ? { ...item, has_voted: data.has_voted } : item))
       )
     },
   })

--- a/frontend/src/hooks/featureRequests/useToggleFeatureRequestVote.ts
+++ b/frontend/src/hooks/featureRequests/useToggleFeatureRequestVote.ts
@@ -1,16 +1,21 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toggleFeatureRequestVote } from '../../apis/featureRequestAPI'
 import { FeatureRequest } from '../../types/featureRequestType'
+import { useAuthStore } from '../../stores/authStore'
 import { QUERY_KEYS } from '../queryKeys'
 
 export const useToggleFeatureRequestVote = () => {
   const queryClient = useQueryClient()
+  const userId = useAuthStore((state) => state.user?.id)
 
   return useMutation({
     mutationFn: (id: number) => toggleFeatureRequestVote(id),
     onSuccess: (data, id) => {
       queryClient.setQueriesData<FeatureRequest[]>(
-        { queryKey: [QUERY_KEYS.FEATURE_REQUESTS] },
+        {
+          queryKey: [QUERY_KEYS.FEATURE_REQUESTS],
+          predicate: (query) => query.queryKey[2] === (userId ?? 'anonymous'),
+        },
         (oldData) =>
           oldData
             ?.map((item) =>

--- a/frontend/src/hooks/featureRequests/useToggleFeatureRequestVote.ts
+++ b/frontend/src/hooks/featureRequests/useToggleFeatureRequestVote.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toggleFeatureRequestVote } from '../../apis/featureRequestAPI'
+import { FeatureRequest } from '../../types/featureRequestType'
+import { QUERY_KEYS } from '../queryKeys'
+
+export const useToggleFeatureRequestVote = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (id: number) => toggleFeatureRequestVote(id),
+    onSuccess: (data, id) => {
+      queryClient.setQueriesData<FeatureRequest[]>(
+        { queryKey: [QUERY_KEYS.FEATURE_REQUESTS] },
+        (oldData) =>
+          oldData?.map((item) =>
+            item.id === id ? { ...item, has_voted: data.has_voted, vote_count: data.vote_count } : item
+          )
+      )
+    },
+  })
+}

--- a/frontend/src/hooks/featureRequests/useUpdateFeatureRequestAdminReply.ts
+++ b/frontend/src/hooks/featureRequests/useUpdateFeatureRequestAdminReply.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { updateFeatureRequestAdminReply } from '../../apis/featureRequestAPI'
+import { QUERY_KEYS } from '../queryKeys'
+
+export const useUpdateFeatureRequestAdminReply = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, admin_reply }: { id: number; admin_reply: string }) =>
+      updateFeatureRequestAdminReply(id, admin_reply),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.FEATURE_REQUESTS] })
+    },
+  })
+}

--- a/frontend/src/hooks/featureRequests/useUpdateFeatureRequestStatus.ts
+++ b/frontend/src/hooks/featureRequests/useUpdateFeatureRequestStatus.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { updateFeatureRequestStatus } from '../../apis/featureRequestAPI'
+import { FeatureRequestStatus } from '../../types/featureRequestType'
+import { QUERY_KEYS } from '../queryKeys'
+
+export const useUpdateFeatureRequestStatus = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, status }: { id: number; status: FeatureRequestStatus }) =>
+      updateFeatureRequestStatus(id, status),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.FEATURE_REQUESTS] })
+    },
+  })
+}

--- a/frontend/src/hooks/queryKeys.ts
+++ b/frontend/src/hooks/queryKeys.ts
@@ -23,6 +23,8 @@ export const QUERY_KEYS = {
   
   PLATFORM_STATS: 'platform_stats',
   ADMIN_RELATED_POSTS_OVERVIEW: 'admin_related_posts_overview',
+
+  FEATURE_REQUESTS: 'feature_requests',
   
   // NOTE: 暫時移除此功能
   POPULAR_COURSES: 'popular_courses',

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -22,6 +22,7 @@ import OAuthCallbackPage from './pages/OAuthCallbackPage.tsx'
 import MailErrorPage from './pages/MailErrorPage.tsx'
 import ProfilePage from './pages/ProfilePage.tsx'
 import VersionsPage from './pages/VersionsPage.tsx'
+import WishlistPage from './pages/WishlistPage.tsx'
 import ProtectedRoute from './pages/ProtectedRoute.tsx'
 import AdminRoute from './pages/AdminRoute.tsx'
 import AdminRelatedPostsPage from './pages/AdminRelatedPostsPage.tsx'
@@ -82,6 +83,11 @@ const router = createBrowserRouter([
         path: 'versions',
         element: <VersionsPage />,
         handle: { seo: { title: buildTitleStatic('版本更新紀錄') } },
+      },
+      {
+        path: 'wishlist',
+        element: <WishlistPage />,
+        handle: { seo: { title: buildTitleStatic('功能許願') } },
       },
 
       // 受保護的 route（未登入無法瀏覽）

--- a/frontend/src/pages/WishlistPage.tsx
+++ b/frontend/src/pages/WishlistPage.tsx
@@ -1,0 +1,169 @@
+import { useMemo, useState } from 'react'
+import { Button, Card, Container, Group, Loader, Stack, Tabs, Text, Textarea, Title } from '@mantine/core'
+import { notifications } from '@mantine/notifications'
+import { FaPlus } from 'react-icons/fa'
+
+import { useAuthStore } from '../stores/authStore'
+import { useGetAdminStatus } from '../hooks/admin/useGetAdminStatus'
+import { useGetFeatureRequests } from '../hooks/featureRequests/useGetFeatureRequests'
+import { useCreateFeatureRequest } from '../hooks/featureRequests/useCreateFeatureRequest'
+import { useDeleteFeatureRequest } from '../hooks/featureRequests/useDeleteFeatureRequest'
+import { FeatureRequest, FeatureRequestStatus } from '../types/featureRequestType'
+import LoginModal from '../components/LoginModal'
+import ConfirmModal from '../components/ConfirmModal'
+import FeatureRequestCard from '../components/FeatureRequestCard'
+import styles from '../styles/pages/WishlistPage.module.css'
+
+const MAX_CONTENT_LENGTH = 500
+
+type TabValue = FeatureRequestStatus | 'all'
+
+const TABS: { value: TabValue; label: string }[] = [
+  { value: 'all', label: '全部' },
+  { value: 'pending', label: '許願中' },
+  { value: 'in_progress', label: '進行中' },
+  { value: 'completed', label: '已完成' },
+]
+
+const WishlistPage: React.FC = () => {
+  const { isAuthenticated } = useAuthStore()
+  const { data: adminStatus } = useGetAdminStatus()
+  const isAdmin = Boolean(adminStatus?.isAdmin)
+
+  const [activeTab, setActiveTab] = useState<TabValue>('all')
+  const [content, setContent] = useState('')
+  const [isComposerOpen, setIsComposerOpen] = useState(false)
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<FeatureRequest | null>(null)
+
+  const status = activeTab === 'all' ? undefined : activeTab
+  const { data: featureRequests, isLoading } = useGetFeatureRequests(status)
+
+  const { mutate: createFeatureRequest, isPending: isCreating } = useCreateFeatureRequest()
+  const { mutate: removeFeatureRequest, isPending: isDeleting } = useDeleteFeatureRequest()
+
+  const items = useMemo(() => featureRequests ?? [], [featureRequests])
+
+  const handleOpenComposer = () => {
+    if (!isAuthenticated) {
+      setIsLoginModalOpen(true)
+      return
+    }
+    setIsComposerOpen(true)
+  }
+
+  const handleSubmit = () => {
+    const trimmed = content.trim()
+    if (!trimmed) {
+      notifications.show({ title: '無法送出', message: '請輸入許願內容', color: 'red' })
+      return
+    }
+    if (trimmed.length > MAX_CONTENT_LENGTH) {
+      notifications.show({ title: '無法送出', message: `許願內容最多 ${MAX_CONTENT_LENGTH} 字`, color: 'red' })
+      return
+    }
+
+    createFeatureRequest(trimmed, {
+      onSuccess: () => {
+        setContent('')
+        setIsComposerOpen(false)
+        notifications.show({ title: '許願成功', message: '感謝你的建議！', color: 'green' })
+      },
+      onError: (error) => {
+        notifications.show({ title: '送出失敗', message: error instanceof Error ? error.message : '請稍後再試', color: 'red' })
+      },
+    })
+  }
+
+  const handleConfirmDelete = () => {
+    if (!deleteTarget) return
+    removeFeatureRequest(deleteTarget.id, {
+      onSuccess: () => setDeleteTarget(null),
+      onError: (error) => {
+        notifications.show({ title: '刪除失敗', message: error instanceof Error ? error.message : '請稍後再試', color: 'red' })
+      },
+    })
+  }
+
+  return (
+    <Container size='md' py='lg'>
+      <Stack gap='md'>
+        <Stack gap={6} className={styles.heading}>
+          <Title order={2}>功能許願</Title>
+          <Text c='dimmed' size='sm'>提出你想要的功能，或幫其他人的許願按讚支持！</Text>
+        </Stack>
+
+        {isComposerOpen ? (
+          <Card className={styles.composer}>
+            <Textarea
+              placeholder='想新增什麼功能呢？'
+              minRows={3}
+              autosize
+              maxLength={MAX_CONTENT_LENGTH}
+              value={content}
+              autoFocus
+              onChange={(event) => setContent(event.currentTarget.value)}
+            />
+            <Group justify='flex-end' mt='sm' gap='xs'>
+              <Button variant='subtle' onClick={() => setIsComposerOpen(false)}>取消</Button>
+              <Button onClick={handleSubmit} loading={isCreating}>送出許願</Button>
+            </Group>
+          </Card>
+        ) : (
+          <Button
+            variant='light'
+            color='brick-red.6'
+            leftSection={<FaPlus size={14} />}
+            onClick={handleOpenComposer}
+            className={styles.composerToggle}
+          >
+            {isAuthenticated ? '新增許願' : '登入後即可許願'}
+          </Button>
+        )}
+
+        <Tabs value={activeTab} onChange={(value) => setActiveTab((value as TabValue) ?? 'all')}>
+          <Tabs.List>
+            {TABS.map((tab) => (
+              <Tabs.Tab key={tab.value} value={tab.value}>{tab.label}</Tabs.Tab>
+            ))}
+          </Tabs.List>
+        </Tabs>
+
+        {isLoading ? (
+          <Group justify='center' py='xl'>
+            <Loader size='sm' />
+          </Group>
+        ) : items.length === 0 ? (
+          <Text c='dimmed' ta='center' py='xl'>目前還沒有許願，快來許下第一個吧！</Text>
+        ) : (
+          <Stack gap='sm'>
+            {items.map((item) => (
+              <FeatureRequestCard
+                key={item.id}
+                item={item}
+                isAuthenticated={isAuthenticated}
+                isAdmin={isAdmin}
+                onRequireLogin={() => setIsLoginModalOpen(true)}
+                onRequestDelete={setDeleteTarget}
+              />
+            ))}
+          </Stack>
+        )}
+      </Stack>
+
+      <LoginModal opened={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} title='登入 / 註冊' />
+      <ConfirmModal
+        opened={Boolean(deleteTarget)}
+        onClose={() => setDeleteTarget(null)}
+        title='刪除許願'
+        message='確定要刪除這則許願嗎？一經刪除將無法復原。'
+        confirmText='刪除'
+        cancelText='取消'
+        loading={isDeleting}
+        onConfirm={handleConfirmDelete}
+      />
+    </Container>
+  )
+}
+
+export default WishlistPage

--- a/frontend/src/pages/WishlistPage.tsx
+++ b/frontend/src/pages/WishlistPage.tsx
@@ -44,6 +44,13 @@ const WishlistPage: React.FC = () => {
 
   const items = useMemo(() => featureRequests ?? [], [featureRequests])
 
+  const EMPTY_MESSAGES: Record<TabValue, string> = {
+    all: '目前還沒有許願，快來許下第一個吧！',
+    pending: '目前沒有「許願中」的功能建議，快來提出你的想法吧！',
+    in_progress: '目前沒有進行中的許願，開發中功能會顯示在這裡。',
+    completed: '目前尚未有已完成的許願。',
+  }
+
   const handleOpenComposer = () => {
     if (!isAuthenticated) {
       setIsLoginModalOpen(true)
@@ -134,7 +141,7 @@ const WishlistPage: React.FC = () => {
             <Loader size='sm' />
           </Group>
         ) : items.length === 0 ? (
-          <Text c='dimmed' ta='center' py='xl'>目前還沒有許願，快來許下第一個吧！</Text>
+          <Text c='dimmed' ta='center' py='xl'>{EMPTY_MESSAGES[activeTab]}</Text>
         ) : (
           <Stack gap='sm'>
             {items.map((item) => (

--- a/frontend/src/pages/WishlistPage.tsx
+++ b/frontend/src/pages/WishlistPage.tsx
@@ -37,7 +37,7 @@ const WishlistPage: React.FC = () => {
   const [deleteTarget, setDeleteTarget] = useState<FeatureRequest | null>(null)
 
   const status = activeTab === 'all' ? undefined : activeTab
-  const { data: featureRequests, isLoading } = useGetFeatureRequests(status)
+  const { data: featureRequests, isLoading, isError, isFetching, refetch } = useGetFeatureRequests(status)
 
   const { mutate: createFeatureRequest, isPending: isCreating } = useCreateFeatureRequest()
   const { mutate: removeFeatureRequest, isPending: isDeleting } = useDeleteFeatureRequest()
@@ -140,6 +140,18 @@ const WishlistPage: React.FC = () => {
           <Group justify='center' py='xl'>
             <Loader size='sm' />
           </Group>
+        ) : isError ? (
+          <Stack align='center' gap='xs' py='xl'>
+            <Text c='red.6' ta='center'>載入功能許願失敗，請稍後再試。</Text>
+            <Button
+              variant='light'
+              color='brick-red.6'
+              loading={isFetching}
+              onClick={() => void refetch()}
+            >
+              重新載入
+            </Button>
+          </Stack>
         ) : items.length === 0 ? (
           <Text c='dimmed' ta='center' py='xl'>{EMPTY_MESSAGES[activeTab]}</Text>
         ) : (

--- a/frontend/src/styles/pages/WishlistPage.module.css
+++ b/frontend/src/styles/pages/WishlistPage.module.css
@@ -1,0 +1,62 @@
+.heading {
+  padding-left: 12px;
+  border-left: 4px solid var(--mantine-color-brick-red-5);
+  text-align: left;
+}
+
+.composer {
+  border: 2px solid black;
+  border-radius: 10px;
+  background: #ffffff;
+  box-shadow: 3px 3px 0 black;
+  padding: 16px;
+}
+
+.card {
+  border: 2px solid black;
+  border-radius: 10px;
+  background: #ffffff;
+  box-shadow: 3px 3px 0 black;
+  padding: 16px;
+  text-align: left;
+}
+
+.headerRow {
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.userInfo {
+  flex: 1;
+  min-width: 0;
+  align-items: center;
+}
+
+.userMeta {
+  min-width: 0;
+}
+
+.contentText {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.statusSelect {
+  width: 96px;
+}
+
+.composerToggle {
+  align-self: flex-start;
+}
+
+.replyBox {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--mantine-color-brick-red-0);
+  border: 1px solid var(--mantine-color-brick-red-2);
+}
+
+.replyEditBox {
+  margin-top: 10px;
+}

--- a/frontend/src/types/featureRequestType.ts
+++ b/frontend/src/types/featureRequestType.ts
@@ -1,0 +1,22 @@
+export type FeatureRequestStatus = 'pending' | 'in_progress' | 'completed'
+
+export interface FeatureRequest {
+  id: number;
+  content: string;
+  status: FeatureRequestStatus;
+  admin_reply: string | null;
+  vote_count: number;
+  has_voted: boolean;
+  is_owner: boolean;
+  created_at: string;
+  updated_at: string;
+  UserModel: {
+    name: string;
+    avatar: string;
+  };
+}
+
+export interface ToggleFeatureRequestVoteResult {
+  has_voted: boolean;
+  vote_count: number;
+}


### PR DESCRIPTION
## 標題

feat(wishlist): add feature request page and voting flow

---

## 摘要

新增完整的功能許願流程，讓使用者可以提交功能建議、依狀態瀏覽許願並按讚支持；管理員可更新處理狀態、留下官方回覆及刪除內容。

---

## 背景／問題

目前平台缺少站內功能建議管道，使用者的需求容易分散在站外，開發者也不容易依支持度與處理狀態追蹤優先順序。本次新增功能許願頁面與投票機制，集中管理使用者需求。

---

## 變更內容

- 新增 `backend/migrations/20260619000000-create-feature-requests.js`，建立 `FeatureRequests`、`FeatureRequestVotes`、索引及防止重複投票的 unique constraint。
- 新增 `FeatureRequest.ts` 與 `FeatureRequestVote.ts` Sequelize models。
- 新增功能許願 repository、service、controller、型別與 routes，提供列表、新增、投票、狀態更新、官方回覆及刪除 API。
- 新增前端功能許願型別、API client 與 React Query hooks。
- 新增 `WishlistPage.tsx`、`FeatureRequestCard.tsx` 與對應樣式，支援狀態分頁、投稿、投票、管理員操作與刪除確認。
- 在 `Header.tsx` 加入桌機與手機版「功能許願」入口，並於 `main.tsx` 註冊 `/wishlist` route。

---

## 測試方式

- 執行 `cd backend && npx tsc --noEmit`，TypeScript 檢查通過。
- 執行 `cd frontend && npm run build`，production build 通過。
- `cd frontend && npm run lint` 目前會因既有 `TimetableGridTable.tsx:72` 的 irregular whitespace 失敗，與本次變更無關。
- 建議套用 migration 後，手動驗證未登入瀏覽、登入投稿與投票、本人刪除，以及管理員狀態切換與官方回覆流程。

---

## 備註

- 關聯並完成 #51。
- 合併前建議補強使用者切換時的功能許願 query cache 更新，以及投票 mutation 進行中的重複點擊防護。
- 此 PR 以 draft 建立，方便先進行完整 review。