### PR TITLE
Fix/scraper course time parser

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "start": "nodemon --exec tsx server.ts",
     "scrape": "tsx scraper/scraper.ts",
     "scrape:ewant": "tsx scraper/scraperEwant.ts",
+    "test:course-time": "tsx --test utils/parseCourseTime.test.ts",
     "backfill:schedules": "tsx scripts/backfillCourseSchedules.ts",
     "backfill:dcard-related-post-counts": "tsx scripts/backfillDcardRelatedPostCounts.ts",
     "migrate": "sequelize-cli db:migrate --config config/config.cjs"

--- a/backend/scraper/scraper.ts
+++ b/backend/scraper/scraper.ts
@@ -162,7 +162,9 @@ async function runScraper(): Promise<void> {
           const coursePage$ = cheerio.load(res.data);
 
           // 抓取課程頁面中的資料
-          const rawCourseTime = coursePage$("#Label10").text();
+          const courseTimeElement = coursePage$("#Label10").clone();
+          courseTimeElement.find("br").replaceWith("\n");
+          const rawCourseTime = courseTimeElement.text();
           const courseTime = normalizeCourseTime(rawCourseTime);
           const courseRoom = coursePage$("#Label11").text();
           const rawCourseType = coursePage$("#Label16").text();

--- a/backend/utils/parseCourseTime.test.ts
+++ b/backend/utils/parseCourseTime.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { normalizeCourseTime, parseCourseTime } from "./parseCourseTime";
+
+test("不將英文星期錯字的字母解析為節次", () => {
+  assert.equal(
+    normalizeCourseTime("星期五，節次8\nFir, Period 8、9、A"),
+    "星期五，節次8、9、A"
+  );
+  assert.equal(
+    normalizeCourseTime("星期五，節次CFir, Period C、D、E"),
+    "星期五，節次C、D、E"
+  );
+});
+
+test("節次間沒有分隔符時不會把後續文字視為節次", () => {
+  assert.equal(normalizeCourseTime("星期五，節次8Fir"), "星期五，節次8");
+});
+
+test("保留中文與英文單一格式的相容性", () => {
+  assert.equal(normalizeCourseTime("星期五，節次8、9、A"), "星期五，節次8、9、A");
+  assert.equal(normalizeCourseTime("Fri, Period 8、9、A"), "星期五，節次8、9、A");
+});
+
+test("以中文星期分隔多個上課時段", () => {
+  const rawCourseTime = [
+    "星期二，節次3Tue, Period 3、4",
+    "星期五，節次8Fir, Period 8、9、A",
+  ].join("");
+
+  assert.equal(
+    normalizeCourseTime(rawCourseTime),
+    "星期二，節次3、4；星期五，節次8、9、A"
+  );
+});
+
+test("產生正確的課程節次範圍", () => {
+  assert.deepEqual(parseCourseTime("星期五，節次8\nFir, Period 8、9、A"), [
+    { day: 5, startPeriod: "8", span: 3 },
+  ]);
+});

--- a/backend/utils/parseCourseTime.ts
+++ b/backend/utils/parseCourseTime.ts
@@ -40,30 +40,39 @@ interface CourseScheduleParsed {
   span: number;        // 節數長度
 }
 
-const PERIOD_SEPARATORS = new Set(["、", "，", ",", "/", "-", "~"]);
+const PERIOD_SEPARATOR_PATTERN = /[、，,/\-~]/;
+const PERIOD_LIST_PATTERN = /^[1-9A-G](?:[、，,/\-~][1-9A-G])*/i;
 
 const extractLeadingPeriodTokens = (sectionAfterMarker: string): string[] => {
   const source = sectionAfterMarker.trim().toUpperCase();
+  const periodListMatch = source.match(PERIOD_LIST_PATTERN);
+  if (!periodListMatch) return [];
 
-  // Require a valid period token at the beginning; this avoids notes like "第10週".
-  if (!/^[1-9A-G]/.test(source)) return [];
-
-  const tokens: string[] = [];
-  for (const ch of source) {
-    if (PERIOD_ORDER_MAP[ch]) {
-      tokens.push(ch);
-      continue;
-    }
-
-    if (PERIOD_SEPARATORS.has(ch)) {
-      continue;
-    }
-
-    // Stop at the first non-period/non-separator char (annotation boundary).
-    break;
-  }
+  const tokens = periodListMatch[0].split(PERIOD_SEPARATOR_PATTERN);
 
   return tokens.filter((token, index, arr) => index === 0 || token !== arr[index - 1]);
+};
+
+const normalizeChineseCourseTime = (courseTime: string): string => {
+  const chunks = courseTime.split(/(?=星期[一二三四五六日])/);
+  const normalizedChunks: string[] = [];
+
+  for (const chunk of chunks) {
+    const normalizedChunk = chunk.replace(/\s+/g, "");
+    const dayMatch = normalizedChunk.match(/星期([一二三四五六日])/);
+    if (!dayMatch) continue;
+
+    // 中文星期決定日期，完整節次優先取自明確的 Period 欄位，不解析前方的英文星期。
+    const fullPeriodMatch = normalizedChunk.match(/Period([1-9A-G](?:[、，,/\-~][1-9A-G])*)/i);
+    const sectionAfterMarker = fullPeriodMatch?.[1]
+      ?? (normalizedChunk.includes("節次") ? normalizedChunk.split("節次")[1] : "");
+    const periodTokens = extractLeadingPeriodTokens(sectionAfterMarker);
+    if (periodTokens.length === 0) continue;
+
+    normalizedChunks.push(`星期${dayMatch[1]}，節次${periodTokens.join("、")}`);
+  }
+
+  return normalizedChunks.join("；");
 };
 
 const normalizeEnglishCourseTime = (courseTime: string): string => {
@@ -87,29 +96,13 @@ const normalizeEnglishCourseTime = (courseTime: string): string => {
 export const normalizeCourseTime = (courseTime?: string): string => {
   if (!courseTime) return "";
 
+  const chineseCourseTime = normalizeChineseCourseTime(courseTime);
+  if (chineseCourseTime) return chineseCourseTime;
+
   const englishCourseTime = normalizeEnglishCourseTime(courseTime);
   if (englishCourseTime) return englishCourseTime;
 
-  const chunks = courseTime
-    .replace(/\s+/g, "")
-    .split(/[；;]/)
-    .map((chunk) => chunk.trim())
-    .filter(Boolean);
-
-  const normalizedChunks = chunks
-    .map((chunk) => {
-      const dayMatch = chunk.match(/星期([一二三四五六日])/);
-      if (!dayMatch) return "";
-
-      const sectionAfterMarker = chunk.includes("節次") ? chunk.split("節次")[1] : "";
-      const periodTokens = extractLeadingPeriodTokens(sectionAfterMarker);
-      if (periodTokens.length === 0) return "";
-
-      return `星期${dayMatch[1]}，節次${periodTokens.join("、")}`;
-    })
-    .filter(Boolean);
-
-  return normalizedChunks.join("；");
+  return "";
 };
 
 export const parseCourseTime = (courseTime?: string): CourseScheduleParsed[] => {


### PR DESCRIPTION
## 標題

fix(scraper): safely parse bilingual course periods

---

## 摘要

修正南大課程大綱中英文星期文字異常時的節次解析，避免將 `Fir` 的 `F` 誤判為夜間第 F 節，並保留純中文、正常英文及多上課日格式的相容性。

---

## 背景／問題

校方部分星期五課程會輸出 `星期五，節次8<br/>Fir, Period 8、9、A`。原本 scraper 使用 `.text()` 取值後會移除 `<br/>` 邊界，解析器再逐字掃描 `節次8Fir`，因此把 `F` 當成合法節次，錯誤儲存為 `星期五，節次8、F`，前端便顯示相隔數小時的兩個時段。

---

## 變更內容

- 調整 `backend/scraper/scraper.ts`，保留課程時段欄位中的 `<br>` 換行結構。
- 調整 `backend/utils/parseCourseTime.ts`，以中文星期決定日期，並優先從同一區塊明確的 `Period` 欄位取得完整節次，不解析前方的英文星期文字。
- 收緊節次 token 規則，要求多個節次之間必須有合法分隔符，避免一般文字中的字母被誤判為節次。
- 新增 `backend/utils/parseCourseTime.test.ts`，涵蓋 `Fir`、尾隨文字、純中文、純英文、多上課日與排課範圍。
- 在 `backend/package.json` 新增 `test:course-time` 測試指令。

---

## 測試方式

- 執行 `cd backend && npm run test:course-time`，5 個解析測試全部通過。
- 執行 `cd backend && npx tsc --noEmit`，TypeScript 檢查通過。
- 使用修正版主 scraper 重新抓取 115-1 課程，確認課程 `5866`「演算法」更新為 `星期五，節次8、9、A`。
- 確認該課程的 `CourseSchedules` 為星期五、第 8 節開始、`span = 3`。

---

## 備註

- `scraperEwant.ts` 沒有 `course_time` 或 `CourseSchedules` 資料流，因此不受此問題影響，未做不必要的修改。
- 合併後需在目標環境重新執行主 scraper，既有錯誤資料才會重新寫入正確節次。
- 此 PR 以 draft 建立，方便先進行 review。
