### PR TITLE
建立可區分每次登入的 session scope，並防止跨分頁驗證競爭

### DIFF
--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -1,5 +1,6 @@
 import { RequestHandler } from "express";
-import { verifyJwtToken } from "../utils/jwt";
+import jwt from "jsonwebtoken";
+import { getJwtSessionScope, verifyJwtToken } from "../utils/jwt";
 import userService from "../services/userService";
 
 export const statusController: RequestHandler = async (
@@ -12,8 +13,21 @@ export const statusController: RequestHandler = async (
     return;
   }
 
+  let userDetail;
   try {
-    const userDetail = verifyJwtToken(token);
+    userDetail = verifyJwtToken(token);
+  } catch (err) {
+    if (err instanceof jwt.JsonWebTokenError) {
+      res.status(401).json({ authenticated: false, message: "驗證失敗" });
+      return;
+    }
+
+    console.error("登入驗證設定異常:", err);
+    res.status(500).json({ message: "無法確認登入狀態" });
+    return;
+  }
+
+  try {
     const user = await userService.getUserByGoogleSub(userDetail.sub);
     if (!user) {
       res.status(404).json({ authenticated: false, message: "用戶未找到" });
@@ -22,6 +36,7 @@ export const statusController: RequestHandler = async (
     const { id, name, detail, avatar, is_admin, created_at, updated_at } = user;
     res.status(200).json({
       authenticated: true,
+      session_scope: getJwtSessionScope(token),
       user: {
         id,
         name,
@@ -33,7 +48,8 @@ export const statusController: RequestHandler = async (
       },
     });
   } catch (err) {
-    res.status(401).json({ authenticated: false, message: "驗證失敗" });
+    console.error("讀取登入使用者失敗:", err);
+    res.status(500).json({ message: "無法確認登入狀態" });
   }
 };
 
@@ -45,17 +61,44 @@ export const checkAuthStatus: RequestHandler = async (req, res) => {
     return;
   }
 
+  let userDetail;
   try {
-    const userDetail = verifyJwtToken(token);
+    userDetail = verifyJwtToken(token);
+  } catch (err) {
+    if (err instanceof jwt.JsonWebTokenError) {
+      res.json({ authenticated: false });
+      return;
+    }
+
+    console.error("登入驗證設定異常:", err);
+    res.status(500).json({ message: "無法確認登入狀態" });
+    return;
+  }
+
+  try {
     const user = await userService.getUserByGoogleSub(userDetail.sub);
     if (!user) {
       res.json({ authenticated: false });
       return;
     }
 
-    res.json({ authenticated: true });
+    const { id, name, detail, avatar, is_admin, created_at, updated_at } = user;
+    res.json({
+      authenticated: true,
+      session_scope: getJwtSessionScope(token),
+      user: {
+        id,
+        name,
+        detail,
+        avatar,
+        is_admin,
+        created_at,
+        updated_at,
+      },
+    });
   } catch (err) {
-    res.json({ authenticated: false });
+    console.error("讀取登入使用者失敗:", err);
+    res.status(500).json({ message: "無法確認登入狀態" });
   }
 };
 

--- a/backend/middlewares/authMiddleware.ts
+++ b/backend/middlewares/authMiddleware.ts
@@ -1,5 +1,6 @@
 import { RequestHandler } from "express";
-import { verifyJwtToken } from "../utils/jwt.js";
+import jwt from "jsonwebtoken";
+import { getJwtSessionScope, verifyJwtToken } from "../utils/jwt.js";
 
 export const authenticateJWT: RequestHandler = (req, res, next): void => {
   const authHeader = req.headers.authorization;
@@ -20,10 +21,27 @@ export const authenticateJWT: RequestHandler = (req, res, next): void => {
 
   try {
     const decoded = verifyJwtToken(token);
+    const expectedSessionScope = req.header("x-expected-session-scope");
+    if (
+      expectedSessionScope
+      && expectedSessionScope !== `session:${getJwtSessionScope(token)}`
+    ) {
+      res.status(409).json({
+        code: "SESSION_CHANGED",
+        message: "登入帳號已變更，請重新開始操作",
+      });
+      return;
+    }
     req.user = decoded; // 將解碼的 payload 添加到 req.user
     next();
   } catch (err) {
-    res.status(403).json({ error: "Invalid token" });
+    if (err instanceof jwt.JsonWebTokenError) {
+      res.status(401).json({ error: "Invalid token" });
+      return;
+    }
+
+    console.error("登入驗證設定異常:", err);
+    res.status(500).json({ error: "無法確認登入狀態" });
   }
 };
 
@@ -50,7 +68,13 @@ export const getCookie: RequestHandler = (req, res, next): void => {
     
     next();
   } catch (err) {
-    req.user = undefined;
-    next();
+    if (err instanceof jwt.JsonWebTokenError) {
+      req.user = undefined;
+      next();
+      return;
+    }
+
+    console.error("登入驗證設定異常:", err);
+    res.status(500).json({ error: "無法確認登入狀態" });
   }
 };

--- a/backend/repositories/interestRepository.ts
+++ b/backend/repositories/interestRepository.ts
@@ -1,10 +1,10 @@
 import { Transaction } from "sequelize";
 import InterestModel from "../models/Interest";
-import { AllInterestsResponse, Interest } from "../types/interest";
+import { AllInterestsResponse } from "../types/interest";
 import CourseModel from "../models/Course";
 
 class InterestRepository {
-  async findInterest(user_id: number, course_id: number): Promise<Interest | null> {
+  async findInterest(user_id: number, course_id: number): Promise<InterestModel | null> {
     return await InterestModel.findOne({
       where: { user_id, course_id }
     })
@@ -24,6 +24,7 @@ class InterestRepository {
   async getAllInterests(user_id: number, limit: number, offset: number): Promise<AllInterestsResponse[]> {
     const interests = await InterestModel.findAll({
       where: { user_id },
+      attributes: ["id", "course_id", "created_at"],
       limit,
       offset,
       order: [['created_at', 'DESC']],
@@ -48,6 +49,7 @@ class InterestRepository {
   async getAllInterestsByUserId(user_id: number): Promise<AllInterestsResponse[]> {
     const interests = await InterestModel.findAll({
       where: { user_id },
+      attributes: ["id", "course_id", "created_at"],
       order: [["created_at", "DESC"]],
       include: [
         {

--- a/backend/routes/auth.ts
+++ b/backend/routes/auth.ts
@@ -2,6 +2,14 @@ import express, { Router } from "express";
 import passport from "passport";
 import { generateJwtToken } from "../utils/jwt";
 import { checkAuthStatus, logoutController, statusController } from "../controllers/authController";
+import {
+  cancelOAuthAttempt,
+  completeOAuthAttempt,
+  failClaimedOAuthAttempt,
+  getOAuthOwner,
+  getOAuthStateCookieName,
+  getOAuthStateCookieOptions,
+} from "../utils/oauthStateStore";
 
 const router: Router = express.Router();
 const isProd = process.env.NODE_ENV === "production";
@@ -9,22 +17,55 @@ const isProd = process.env.NODE_ENV === "production";
 // google oAuth + passport
 router.get(
   "/google",
-  passport.authenticate("google", {
-    scope: ["email", "profile"],
-    prompt: 'select_account', // 這個參數會強制 Google 彈出選擇帳號的視窗
-  })
+  (req, res, next) => {
+    if (!getOAuthOwner(req)) {
+      res.status(400).json({ message: "無效的 OAuth 登入識別碼" });
+      return;
+    }
+
+    passport.authenticate("google", {
+      scope: ["email", "profile"],
+      prompt: "select_account", // 這個參數會強制 Google 彈出選擇帳號的視窗
+    })(req, res, next);
+  },
 );
 router.get("/google/callback", (req, res, next) => {
   passport.authenticate("google", { session: false }, (err, user, info) => {
+    const state = typeof req.query.state === "string" ? req.query.state : "";
     if (err || !user) {
+      const stateHash = (
+        req as typeof req & { oauthStateClaimed?: boolean }
+      ).oauthStateClaimed
+        ? failClaimedOAuthAttempt(state)
+        : null;
+      if (stateHash) {
+        res.clearCookie(
+          getOAuthStateCookieName(stateHash),
+          getOAuthStateCookieOptions(),
+        );
+      }
+
       // 若發生錯誤或無使用者，導向錯誤頁
-      return res.redirect(
-        `${process.env.FRONTEND_BASE_URL}/auth/google/callback?error=invalid_email`
+      const error = info?.message === "invalid_oauth_state"
+        ? "invalid_oauth_state"
+        : req.query.error === "access_denied"
+          ? "oauth_cancelled"
+          : "invalid_email";
+      res.redirect(
+        `${process.env.FRONTEND_BASE_URL}/auth/google/callback?error=${error}`
       );
+      return;
+    }
+
+    const jwtToken = generateJwtToken(user);
+    if (!state || !completeOAuthAttempt(state)) {
+      res.redirect(
+        `${process.env.FRONTEND_BASE_URL}/auth/google/callback?error=invalid_oauth_state`
+      );
+      return;
     }
 
     // 產生 JWT 並存入 Cookie
-    const jwtToken = generateJwtToken(user);
     res.cookie("token", jwtToken, {
       httpOnly: true,
       secure: isProd,
@@ -35,6 +76,18 @@ router.get("/google/callback", (req, res, next) => {
 
     res.redirect(`${process.env.FRONTEND_BASE_URL}/auth/google/callback`);
   })(req, res, next);
+});
+
+router.post("/google/cancel", (req, res) => {
+  const owner = typeof req.body?.owner === "string" ? req.body.owner : "";
+  const result = cancelOAuthAttempt(owner);
+  if (result.stateHash) {
+    res.clearCookie(
+      getOAuthStateCookieName(result.stateHash),
+      getOAuthStateCookieOptions(),
+    );
+  }
+  res.json({ status: result.status });
 });
 
 // 驗證登入狀態

--- a/backend/routes/interests.ts
+++ b/backend/routes/interests.ts
@@ -1,10 +1,10 @@
 import express, { Router } from 'express';
 import { getAllInterests, toggleInterest } from '../controllers/interestController';
-import { authenticateJWT, getCookie } from '../middlewares/authMiddleware';
+import { authenticateJWT } from '../middlewares/authMiddleware';
 
 const router: Router = express.Router();
 
-router.post("/toggleInterest",getCookie,  toggleInterest);
+router.post("/toggleInterest", authenticateJWT, toggleInterest);
 router.get("/getAllInterests", authenticateJWT, getAllInterests);
 
 export default router;

--- a/backend/types/interest.ts
+++ b/backend/types/interest.ts
@@ -2,7 +2,6 @@ import CourseModel from "../models/Course"
 
 export interface Interest{
     id: number,
-    user_id: number,
     course_id: number,
     created_at: Date
 }

--- a/backend/utils/jwt.ts
+++ b/backend/utils/jwt.ts
@@ -1,4 +1,5 @@
 import jwt from "jsonwebtoken";
+import { createHash, randomUUID } from "node:crypto";
 import UserModel from "../models/Users";
 
 const JWT_SECRET = process.env.JWT_SECRET;
@@ -16,7 +17,7 @@ export const generateJwtToken = (user: UserModel) => {
     return jwt.sign(
         {id: user.id, uuid: user.uuid, sub: user.google_sub},
         JWT_SECRET,
-        {expiresIn: "7d"}
+        {expiresIn: "7d", jwtid: randomUUID()}
     )
 }
 
@@ -26,3 +27,6 @@ export const verifyJwtToken = (jwtToken: string): JwtPayload => {
     }
     return jwt.verify(jwtToken, JWT_SECRET) as JwtPayload;
 }
+
+export const getJwtSessionScope = (jwtToken: string): string =>
+    createHash("sha256").update(jwtToken).digest("base64url").slice(0, 24);

--- a/backend/utils/oauthStateStore.ts
+++ b/backend/utils/oauthStateStore.ts
@@ -1,0 +1,226 @@
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import type { Request } from "express";
+import type OAuth2Strategy from "passport-oauth2";
+
+const OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
+const MAX_OAUTH_ATTEMPTS = 10_000;
+const OWNER_PATTERN = /^[A-Za-z0-9-]{20,128}$/;
+const isProd = process.env.NODE_ENV === "production";
+
+type StoreCallback = OAuth2Strategy.StateStoreStoreCallback;
+type VerifyCallback = OAuth2Strategy.StateStoreVerifyCallback;
+type StateMetadata = OAuth2Strategy.Metadata;
+type OAuthAttemptStatus = "pending" | "processing" | "completed";
+
+type OAuthAttempt = {
+  stateHash: string;
+  ownerHash: string;
+  status: OAuthAttemptStatus;
+  expiresAt: number;
+};
+
+export type OAuthAttemptResult = {
+  status: "completed" | "cancelled" | "expired" | "not_found";
+  stateHash?: string;
+};
+
+const attemptsByStateHash = new Map<string, OAuthAttempt>();
+const stateHashByOwnerHash = new Map<string, string>();
+
+const hashValue = (value: string): string =>
+  createHash("sha256").update(value).digest("hex");
+
+const statesMatch = (first: string, second: string): boolean => {
+  const firstBuffer = Buffer.from(first);
+  const secondBuffer = Buffer.from(second);
+  return firstBuffer.length === secondBuffer.length
+    && timingSafeEqual(firstBuffer, secondBuffer);
+};
+
+const deleteAttempt = (attempt: OAuthAttempt): void => {
+  attemptsByStateHash.delete(attempt.stateHash);
+  if (stateHashByOwnerHash.get(attempt.ownerHash) === attempt.stateHash) {
+    stateHashByOwnerHash.delete(attempt.ownerHash);
+  }
+};
+
+const cleanupExpiredAttempts = (now = Date.now()): void => {
+  for (const attempt of attemptsByStateHash.values()) {
+    if (attempt.expiresAt <= now) deleteAttempt(attempt);
+  }
+};
+
+const createOAuthAttempt = (req: Request): { state: string; stateHash: string } => {
+  cleanupExpiredAttempts();
+  if (attemptsByStateHash.size >= MAX_OAUTH_ATTEMPTS) {
+    throw new Error("OAUTH_STATE_CAPACITY_REACHED");
+  }
+
+  const owner = getOAuthOwner(req);
+  if (!owner) throw new Error("INVALID_OAUTH_OWNER");
+
+  const ownerHash = hashValue(owner);
+  if (stateHashByOwnerHash.has(ownerHash)) {
+    throw new Error("OAUTH_ATTEMPT_ALREADY_EXISTS");
+  }
+
+  const state = randomBytes(32).toString("base64url");
+  const stateHash = hashValue(state);
+  const attempt: OAuthAttempt = {
+    stateHash,
+    ownerHash,
+    status: "pending",
+    expiresAt: Date.now() + OAUTH_STATE_TTL_MS,
+  };
+  attemptsByStateHash.set(stateHash, attempt);
+  stateHashByOwnerHash.set(ownerHash, stateHash);
+  return { state, stateHash };
+};
+
+const claimOAuthAttempt = (state: string): boolean => {
+  const stateHash = hashValue(state);
+  const attempt = attemptsByStateHash.get(stateHash);
+  if (!attempt) return false;
+  if (attempt.expiresAt <= Date.now()) {
+    deleteAttempt(attempt);
+    return false;
+  }
+  if (attempt.status !== "pending") return false;
+
+  attempt.status = "processing";
+  return true;
+};
+
+export const getOAuthOwner = (req: Request): string | null => {
+  const owner = typeof req.query.owner === "string" ? req.query.owner : "";
+  return OWNER_PATTERN.test(owner) ? owner : null;
+};
+
+export const completeOAuthAttempt = (state: string): boolean => {
+  if (!state) return false;
+  const attempt = attemptsByStateHash.get(hashValue(state));
+  if (!attempt) return false;
+  if (attempt.expiresAt <= Date.now()) {
+    deleteAttempt(attempt);
+    return false;
+  }
+  if (attempt.status !== "processing") return false;
+
+  attempt.status = "completed";
+  attempt.expiresAt = Date.now() + OAUTH_STATE_TTL_MS;
+  return true;
+};
+
+export const failClaimedOAuthAttempt = (state: string): string | null => {
+  if (!state) return null;
+  const stateHash = hashValue(state);
+  const attempt = attemptsByStateHash.get(stateHash);
+  if (!attempt || attempt.status !== "processing") return null;
+  deleteAttempt(attempt);
+  return attempt.stateHash;
+};
+
+export const cancelOAuthAttempt = (owner: string): OAuthAttemptResult => {
+  if (!OWNER_PATTERN.test(owner)) return { status: "not_found" };
+
+  const ownerHash = hashValue(owner);
+  const stateHash = stateHashByOwnerHash.get(ownerHash);
+  if (!stateHash) return { status: "not_found" };
+
+  const attempt = attemptsByStateHash.get(stateHash);
+  if (!attempt) {
+    stateHashByOwnerHash.delete(ownerHash);
+    return { status: "not_found" };
+  }
+  if (attempt.expiresAt <= Date.now()) {
+    deleteAttempt(attempt);
+    return { status: "expired", stateHash };
+  }
+  if (attempt.status === "completed") {
+    return { status: "completed", stateHash };
+  }
+
+  deleteAttempt(attempt);
+  return { status: "cancelled", stateHash };
+};
+
+export const getOAuthStateCookieName = (stateHash: string): string =>
+  `oauth_state_${stateHash.slice(0, 16)}`;
+
+export const getOAuthStateCookieOptions = () => ({
+  httpOnly: true,
+  secure: isProd,
+  sameSite: "lax" as const,
+  path: "/api/auth/google/callback",
+});
+
+export class OAuthStateStore {
+  store(req: Request, callback: StoreCallback): void;
+  store(req: Request, metadata: StateMetadata, callback: StoreCallback): void;
+  store(
+    req: Request,
+    metadataOrCallback: StateMetadata | StoreCallback,
+    providedCallback?: StoreCallback,
+  ): void {
+    const callback = typeof metadataOrCallback === "function"
+      ? metadataOrCallback
+      : providedCallback;
+    if (!callback) return;
+
+    try {
+      const { state, stateHash } = createOAuthAttempt(req);
+      req.res?.cookie(getOAuthStateCookieName(stateHash), state, {
+        ...getOAuthStateCookieOptions(),
+        maxAge: OAUTH_STATE_TTL_MS,
+      });
+      callback(null, state);
+    } catch (error) {
+      callback(
+        error instanceof Error ? error : new Error("OAUTH_STATE_CREATE_FAILED"),
+        undefined,
+      );
+    }
+  }
+
+  verify(req: Request, state: string, callback: VerifyCallback): void;
+  verify(
+    req: Request,
+    state: string,
+    metadata: StateMetadata,
+    callback: VerifyCallback,
+  ): void;
+  verify(
+    req: Request,
+    state: string,
+    metadataOrCallback: StateMetadata | VerifyCallback,
+    providedCallback?: VerifyCallback,
+  ): void {
+    const callback = typeof metadataOrCallback === "function"
+      ? metadataOrCallback
+      : providedCallback;
+    if (!callback) return;
+
+    const stateHash = typeof state === "string" ? hashValue(state) : "";
+    const cookieName = getOAuthStateCookieName(stateHash);
+    const cookieState = req.cookies?.[cookieName];
+    if (
+      typeof state !== "string"
+      || typeof cookieState !== "string"
+      || !statesMatch(state, cookieState)
+    ) {
+      callback(null as unknown as Error, false, { message: "invalid_oauth_state" });
+      return;
+    }
+
+    req.res?.clearCookie(cookieName, getOAuthStateCookieOptions());
+    const claimed = claimOAuthAttempt(state);
+    if (claimed) {
+      (req as Request & { oauthStateClaimed?: boolean }).oauthStateClaimed = true;
+    }
+    callback(
+      null as unknown as Error,
+      claimed,
+      claimed ? undefined : { message: "invalid_oauth_state" },
+    );
+  }
+}

--- a/backend/utils/passport.ts
+++ b/backend/utils/passport.ts
@@ -2,6 +2,7 @@ import passport from "passport";
 import { Strategy as GoogleStrategy } from "passport-google-oauth20";
 import userService from "../services/userService";
 import whitelistService from "../services/whitelistService";
+import { OAuthStateStore } from "./oauthStateStore";
 
 function normalizeEmail(email: unknown) {
   return String(email ?? "").trim().toLowerCase();
@@ -18,6 +19,7 @@ passport.use(
     clientID: process.env.GOOGLE_CLIENT_ID!,
     clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
     callbackURL: `${process.env.BACKEND_BASE_URL}/auth/google/callback`,
+    store: new OAuthStateStore(),
   },
     async (accessToken: string, refreshToken: string, profile: any, done: any) => {
       try {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,11 +11,17 @@ import Header from './components/Header'
 import Footer from './components/Footer'
 import {
   applyAuthStatusResponse,
+  clearOAuthAuthSessionTransitionOwner,
   getAuthSessionRecord,
+  getOAuthAuthSessionTransitionOwner,
   isAuthSessionRecordCurrent,
   recoverExpiredAuthSessionTransition,
   subscribeAuthSessionRecord,
 } from './utils/userCacheScope'
+import { reconcileOAuthTransition } from './utils/oauthTransition'
+
+const OAUTH_RETURN_GRACE_MS = 2_000
+const OAUTH_TRANSITION_TIMEOUT_MS = 10 * 60 * 1000
 
 function App() {
   const { login, logout, markAuthUnresolved, isLogoutInProgress } = useAuthStore()
@@ -61,16 +67,37 @@ function App() {
 
   useEffect(() => {
     const synchronizeSharedSession = async (): Promise<void> => {
+      const initialRecord = getAuthSessionRecord()
+      const transitionAge = initialRecord?.status === 'transition'
+        ? Date.now() - initialRecord.startedAt
+        : 0
+      if (
+        initialRecord?.status === 'transition'
+        && initialRecord.transitionKind === 'oauth'
+        && (
+          transitionAge >= OAUTH_TRANSITION_TIMEOUT_MS
+          || (
+            transitionAge >= OAUTH_RETURN_GRACE_MS
+            && getOAuthAuthSessionTransitionOwner() === initialRecord.owner
+            && !window.location.pathname.includes('/auth/google/callback')
+          )
+        )
+      ) {
+        await reconcileOAuthTransition(initialRecord.owner)
+      }
       const recoveredTransition = await recoverExpiredAuthSessionTransition()
       if (recoveredTransition) {
+        clearOAuthAuthSessionTransitionOwner()
         void refetch()
       }
       const sharedRecord = getAuthSessionRecord()
       if (sharedRecord?.status === 'guest') {
+        clearOAuthAuthSessionTransitionOwner()
         logout()
         return
       }
       if (sharedRecord?.status === 'authenticated') {
+        clearOAuthAuthSessionTransitionOwner()
         const currentUserCacheScope = useAuthStore.getState().user?.cacheScope
         if (currentUserCacheScope !== `session:${sharedRecord.sessionScope}`) {
           void refetch()
@@ -92,6 +119,27 @@ function App() {
       window.clearInterval(recoveryTimer)
     }
   }, [logout, refetch])
+
+  useEffect(() => {
+    const cancelReturnedOAuthTransition = (): void => {
+      if (window.location.pathname.includes('/auth/google/callback')) return
+      const owner = getOAuthAuthSessionTransitionOwner()
+      if (!owner) return
+
+      void reconcileOAuthTransition(owner).then((settled) => {
+        if (settled) void refetch()
+      })
+    }
+
+    const handlePageShow = (event: PageTransitionEvent): void => {
+      if (event.persisted) cancelReturnedOAuthTransition()
+    }
+    window.addEventListener('pageshow', handlePageShow)
+
+    cancelReturnedOAuthTransition()
+
+    return () => window.removeEventListener('pageshow', handlePageShow)
+  }, [refetch])
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { Outlet, ScrollRestoration } from 'react-router-dom'
 import { useEffect } from 'react'
+import { Alert, Button, Group, Text } from '@mantine/core'
 
 import { useAuthStore } from './stores/authStore'
 import { useCheckAuthStatus } from './hooks/auth/useCheckAuthStatus'
@@ -8,23 +9,111 @@ import RouteHeadTitle from './seo/RouteHeadTitle'
 
 import Header from './components/Header'
 import Footer from './components/Footer'
+import {
+  applyAuthStatusResponse,
+  getAuthSessionRecord,
+  isAuthSessionRecordCurrent,
+  recoverExpiredAuthSessionTransition,
+  subscribeAuthSessionRecord,
+} from './utils/userCacheScope'
 
 function App() {
-  const { logout } = useAuthStore()
-  const { data } = useCheckAuthStatus()
+  const { login, logout, markAuthUnresolved, isLogoutInProgress } = useAuthStore()
+  const {
+    data,
+    isError,
+    isFetching,
+    errorUpdatedAt,
+    dataUpdatedAt,
+    refetch,
+  } = useCheckAuthStatus()
+  const hasCurrentAuthError = isError && errorUpdatedAt >= dataUpdatedAt
 
   useEffect(() => {
-    if (data && !data.authenticated) {
-      localStorage.removeItem('auth-storage')
-      logout()
+    if (isLogoutInProgress) return
+
+    if (hasCurrentAuthError) {
+      markAuthUnresolved()
+      return
     }
-  }, [data, logout])
+
+    if (!data) return
+
+    let disposed = false
+    void applyAuthStatusResponse(data.requestSnapshot, data.authStatus).then((result) => {
+      if (disposed || !result.applied || !isAuthSessionRecordCurrent(result.record)) return
+
+      if (
+        data.authStatus.authenticated
+        && result.record?.status === 'authenticated'
+        && result.record.sessionScope === data.authStatus.session_scope
+      ) {
+        login(data.authStatus.user, data.authStatus.session_scope)
+      } else if (!data.authStatus.authenticated && result.record?.status === 'guest') {
+        logout()
+      }
+    })
+
+    return () => {
+      disposed = true
+    }
+  }, [data, hasCurrentAuthError, isLogoutInProgress, login, logout, markAuthUnresolved])
+
+  useEffect(() => {
+    const synchronizeSharedSession = async (): Promise<void> => {
+      const recoveredTransition = await recoverExpiredAuthSessionTransition()
+      if (recoveredTransition) {
+        void refetch()
+      }
+      const sharedRecord = getAuthSessionRecord()
+      if (sharedRecord?.status === 'guest') {
+        logout()
+        return
+      }
+      if (sharedRecord?.status === 'authenticated') {
+        const currentUserCacheScope = useAuthStore.getState().user?.cacheScope
+        if (currentUserCacheScope !== `session:${sharedRecord.sessionScope}`) {
+          void refetch()
+        }
+      }
+    }
+
+    const unsubscribe = subscribeAuthSessionRecord(() => {
+      void synchronizeSharedSession()
+    })
+    const recoveryTimer = window.setInterval(
+      () => void synchronizeSharedSession(),
+      30_000,
+    )
+    void synchronizeSharedSession()
+
+    return () => {
+      unsubscribe()
+      window.clearInterval(recoveryTimer)
+    }
+  }, [logout, refetch])
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
       <ScrollRestoration />
       <RouteHeadTitle />
       <Header />
+      {hasCurrentAuthError && (
+        <Alert color='red' title='無法確認登入狀態' radius={0}>
+          <Group justify='space-between' align='center' gap='sm'>
+            <Text size='sm'>已登入狀態不會因連線異常切換成訪客。</Text>
+            <Button
+              variant='light'
+              color='red'
+              size='xs'
+              loading={isFetching}
+              onClick={() => void refetch()}
+            >
+              重新確認
+            </Button>
+          </Group>
+        </Alert>
+      )}
       <main style={{ flex: 1 }}>
         <Outlet />
       </main>

--- a/frontend/src/apis/authAPI.ts
+++ b/frontend/src/apis/authAPI.ts
@@ -11,6 +11,21 @@ export const checkAuthStatus = async (signal?: AbortSignal): Promise<AuthStatusR
   return response.data
 }
 
+export type OAuthAttemptStatus =
+  | 'completed'
+  | 'cancelled'
+  | 'expired'
+  | 'not_found'
+
+export const cancelOAuthAttempt = async (owner: string): Promise<OAuthAttemptStatus> => {
+  const response = await axiosInstance.post(
+    '/auth/google/cancel',
+    { owner },
+    { timeout: 15_000 },
+  )
+  return response.data.status
+}
+
 export const logoutUser = async (): Promise<void> => {
   await axiosInstance.post('/auth/logout')
 }

--- a/frontend/src/apis/authAPI.ts
+++ b/frontend/src/apis/authAPI.ts
@@ -1,13 +1,13 @@
 import { AuthStatusResponse } from '../types/authType'
 import { axiosInstance } from './axiosInstance'
 
-export const getAuthStatus = async (): Promise<AuthStatusResponse> => {
-  const response = await axiosInstance.get('/auth/status')
+export const getAuthStatus = async (signal?: AbortSignal): Promise<AuthStatusResponse> => {
+  const response = await axiosInstance.get('/auth/status', { signal, timeout: 15_000 })
   return response.data
 }
 
-export const checkAuthStatus = async (): Promise<{ authenticated: boolean }> => {
-  const response = await axiosInstance.get('/auth/checkStatus')
+export const checkAuthStatus = async (signal?: AbortSignal): Promise<AuthStatusResponse> => {
+  const response = await axiosInstance.get('/auth/checkStatus', { signal, timeout: 15_000 })
   return response.data
 }
 

--- a/frontend/src/apis/axiosInstance.ts
+++ b/frontend/src/apis/axiosInstance.ts
@@ -1,5 +1,10 @@
 import axios from 'axios'
 import { useAuthStore } from '../stores/authStore'
+import {
+  captureAuthStatusRequestSnapshot,
+  forceGuestAuthSessionRecord,
+} from '../utils/userCacheScope'
+import type { AuthStatusRequestSnapshot } from '../utils/userCacheScope'
 
 export type ApiError = Error & {
   status?: number
@@ -11,19 +16,64 @@ export const axiosInstance = axios.create({
   withCredentials: true,
 })
 
+const requestAuthSessionSnapshots = new WeakMap<object, AuthStatusRequestSnapshot>()
+
+axiosInstance.interceptors.request.use((config) => {
+  const requestSnapshot = captureAuthStatusRequestSnapshot()
+  requestAuthSessionSnapshots.set(config, requestSnapshot)
+
+  const persistedSessionScope = useAuthStore.getState().user?.cacheScope
+  const expectedSessionScope = persistedSessionScope?.startsWith('session:')
+    ? persistedSessionScope
+    : null
+  const method = config.method?.toLowerCase()
+  const changesServerState = method !== 'get' && method !== 'head' && method !== 'options'
+  if (
+    changesServerState
+    && expectedSessionScope
+    && !config.headers.has('X-Expected-Session-Scope')
+  ) {
+    config.headers.set(
+      'X-Expected-Session-Scope',
+      expectedSessionScope,
+    )
+  }
+  return config
+})
+
 axiosInstance.interceptors.response.use(
-  (response) => response,
-  (error) => {
+  (response) => {
+    requestAuthSessionSnapshots.delete(response.config)
+    return response
+  },
+  async (error) => {
+    const requestConfig = error.config as object | undefined
+    const hasRequestSnapshot = requestConfig
+      ? requestAuthSessionSnapshots.has(requestConfig)
+      : false
+    const requestSnapshot = requestConfig
+      ? requestAuthSessionSnapshots.get(requestConfig)
+      : undefined
+    if (requestConfig) requestAuthSessionSnapshots.delete(requestConfig)
     const { logout, isLogoutInProgress, setIsLogoutInProgress } = useAuthStore.getState()
 
     const currentPath = window.location.pathname
     const isOAuthCallback = currentPath.includes('/auth/google/callback')
     const isMailError = currentPath.includes('/mailError')
 
-    if (error.response?.status === 401 && !isLogoutInProgress && !isOAuthCallback && !isMailError) {
-      setIsLogoutInProgress(true) // 設置標誌，防止再次登出
-      logout()
-      window.location.href = '/'
+    if (
+      error.response?.status === 401
+      && !isLogoutInProgress
+      && !isOAuthCallback
+      && !isMailError
+      && hasRequestSnapshot
+    ) {
+      const changedToGuest = await forceGuestAuthSessionRecord(requestSnapshot ?? null)
+      if (changedToGuest) {
+        setIsLogoutInProgress(true) // 設置標誌，防止再次登出
+        logout()
+        window.location.href = '/'
+      }
     }
 
     const message = error.response?.data?.message || '發生錯誤，請稍後再試'

--- a/frontend/src/apis/timetableAPI.ts
+++ b/frontend/src/apis/timetableAPI.ts
@@ -7,15 +7,34 @@ import {
   TimetableResponse
 } from '../types/timetableType'
 
-export const getTimetableBySemester = async (semester: string): Promise<TimetableResponse> => {
+type TimetableRequestContext = {
+  signal?: AbortSignal
+  expectedSessionScope: string
+}
+
+const getSessionHeaders = (expectedSessionScope?: string) => expectedSessionScope
+  ? { 'X-Expected-Session-Scope': expectedSessionScope }
+  : undefined
+
+export const getTimetableBySemester = async (
+  semester: string,
+  context: TimetableRequestContext,
+): Promise<TimetableResponse> => {
   const response = await axiosInstance.get('/timetables', {
     params: { semester },
+    signal: context.signal,
+    headers: getSessionHeaders(context.expectedSessionScope),
   })
   return response.data
 }
 
-export const getAllTimetableItems = async (): Promise<{ items: AddedCourseItem[] }> => {
-  const response = await axiosInstance.get('/timetables/items')
+export const getAllTimetableItems = async (
+  context: TimetableRequestContext,
+): Promise<{ items: AddedCourseItem[] }> => {
+  const response = await axiosInstance.get('/timetables/items', {
+    signal: context.signal,
+    headers: getSessionHeaders(context.expectedSessionScope),
+  })
   return response.data
 }
 
@@ -24,13 +43,31 @@ export const batchAddTimetableFromInterests = async (timetableId: number): Promi
   return response.data
 }
 
-export const addTimetableCourse = async (timetableId: number, courseId: number): Promise<AddTimetableCourseResponse> => {
-  const response = await axiosInstance.post(`/timetables/${timetableId}/items`, { courseId })
+export const addTimetableCourse = async (
+  timetableId: number,
+  courseId: number,
+  context: TimetableRequestContext,
+): Promise<AddTimetableCourseResponse> => {
+  const response = await axiosInstance.post(
+    `/timetables/${timetableId}/items`,
+    { courseId },
+    {
+      signal: context.signal,
+      headers: getSessionHeaders(context.expectedSessionScope),
+    },
+  )
   return response.data
 }
 
-export const removeTimetableCourse = async (timetableId: number, courseId: number): Promise<void> => {
-  await axiosInstance.delete(`/timetables/${timetableId}/items/${courseId}`)
+export const removeTimetableCourse = async (
+  timetableId: number,
+  courseId: number,
+  context: TimetableRequestContext,
+): Promise<void> => {
+  await axiosInstance.delete(`/timetables/${timetableId}/items/${courseId}`, {
+    signal: context.signal,
+    headers: getSessionHeaders(context.expectedSessionScope),
+  })
 }
 
 export const swapTimetableCourse = async (timetableId: number, courseId: number): Promise<SwapTimetableCourseResponse> => {

--- a/frontend/src/components/AuthButton.tsx
+++ b/frontend/src/components/AuthButton.tsx
@@ -13,20 +13,12 @@ interface AuthButtonProps {
 
 const AuthButton: React.FC<AuthButtonProps> = ({ className, onClick }) => {
   const { isAuthenticated, user } = useAuthStore()
-  const { mutate: logoutUser } = useLogoutUser()
+  const { mutate: logoutUser, isPending: isLoggingOut } = useLogoutUser()
 
-  const [isLoggingOut, setIsLoggingOut] = useState(false)
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false)
 
-  const handleLogout = async () => {
-    setIsLoggingOut(true)
-    try {
-      logoutUser()
-    } catch (error) {
-      console.error('登出失敗', error)
-    } finally {
-      setIsLoggingOut(false)
-    }
+  const handleLogout = () => {
+    logoutUser()
   }
 
   return (
@@ -34,7 +26,13 @@ const AuthButton: React.FC<AuthButtonProps> = ({ className, onClick }) => {
       {isAuthenticated ? (
         <>
           <Text component={Link} to='/profile' onClick={onClick}>{user?.name}</Text>
-          <Button onClick={handleLogout} variant='outline' color='brick-red.6' className={styles.logoutButton}>
+          <Button
+            onClick={handleLogout}
+            loading={isLoggingOut}
+            variant='outline'
+            color='brick-red.6'
+            className={styles.logoutButton}
+          >
             {isLoggingOut ? '登出中...' : '登出'}
           </Button>
         </>

--- a/frontend/src/components/LoginModal.tsx
+++ b/frontend/src/components/LoginModal.tsx
@@ -1,5 +1,7 @@
 import { Accordion, Anchor, Button, Group, Modal, Stack, Text } from '@mantine/core'
 import { useLocation } from 'react-router-dom'
+import { notifications } from '@mantine/notifications'
+import { beginOAuthAuthSessionTransition } from '../utils/userCacheScope'
 
 interface LoginModalProps {
   opened: boolean;
@@ -11,10 +13,22 @@ const LoginModal: React.FC<LoginModalProps> = ({ opened, onClose, title }) => {
   const location = useLocation()
   const blockedRedirectPaths = ['/mailError']
   const path = blockedRedirectPaths.includes(location.pathname) ? '/' : location.pathname
-  const handleLogin = () => {
+  const handleLogin = async (): Promise<void> => {
+    const transitionOwner = await beginOAuthAuthSessionTransition()
+    if (!transitionOwner) {
+      notifications.show({
+        title: '登入狀態正在更新',
+        message: '其他分頁正在處理登入或登出，請稍後再試。',
+        color: 'orange',
+      })
+      return
+    }
+
     onClose()
-    localStorage.setItem('redirect_path', path)
-    window.location.href = `${import.meta.env.VITE_API_BASE_URL}/auth/google`
+    sessionStorage.setItem('redirect_path', path)
+    const loginUrl = new URL(`${import.meta.env.VITE_API_BASE_URL}/auth/google`)
+    loginUrl.searchParams.set('owner', transitionOwner)
+    window.location.href = loginUrl.toString()
   }
 
   return (
@@ -63,7 +77,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ opened, onClose, title }) => {
         <Button variant='light' onClick={onClose}>
           取消
         </Button>
-        <Button variant='filled' onClick={handleLogin}>
+        <Button variant='filled' onClick={() => void handleLogin()}>
           確定
         </Button>
       </Group>

--- a/frontend/src/hooks/admin/useGetAdminStatus.ts
+++ b/frontend/src/hooks/admin/useGetAdminStatus.ts
@@ -2,15 +2,17 @@ import { useQuery } from '@tanstack/react-query'
 import { getAdminStatus } from '../../apis/adminAPI'
 import { QUERY_KEYS } from '../queryKeys'
 import { useAuthStore } from '../../stores/authStore'
+import { getUserCacheScope } from '../../utils/userCacheScope'
 
 export const useGetAdminStatus = () => {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
-  const userId = useAuthStore((state) => state.user?.id)
+  const isAuthResolved = useAuthStore((state) => state.isAuthResolved)
+  const userCacheScope = useAuthStore((state) => getUserCacheScope(state.user))
 
   return useQuery({
-    queryKey: [QUERY_KEYS.ADMIN_STATUS, userId],
+    queryKey: [QUERY_KEYS.ADMIN_STATUS, userCacheScope],
     queryFn: getAdminStatus,
-    enabled: isAuthenticated && Number.isInteger(userId),
+    enabled: isAuthResolved && isAuthenticated,
     retry: false,
     staleTime: 5 * 60 * 1000,
   })

--- a/frontend/src/hooks/admin/useGetRelatedPostOverview.ts
+++ b/frontend/src/hooks/admin/useGetRelatedPostOverview.ts
@@ -2,18 +2,20 @@ import { useQuery } from '@tanstack/react-query'
 import { getRelatedPostOverview } from '../../apis/adminAPI'
 import { QUERY_KEYS } from '../queryKeys'
 import { useAuthStore } from '../../stores/authStore'
+import { getUserCacheScope } from '../../utils/userCacheScope'
 
 export const useGetRelatedPostOverview = (params: {
   recentPostsPage: number;
   recentImportsPage: number;
 }) => {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
-  const userId = useAuthStore((state) => state.user?.id)
+  const isAuthResolved = useAuthStore((state) => state.isAuthResolved)
+  const userCacheScope = useAuthStore((state) => getUserCacheScope(state.user))
 
   return useQuery({
-    queryKey: [QUERY_KEYS.ADMIN_RELATED_POSTS_OVERVIEW, userId, params],
+    queryKey: [QUERY_KEYS.ADMIN_RELATED_POSTS_OVERVIEW, userCacheScope, params],
     queryFn: () => getRelatedPostOverview(params),
-    enabled: isAuthenticated && Number.isInteger(userId),
+    enabled: isAuthResolved && isAuthenticated,
     placeholderData: (previousData) => previousData,
   })
 }

--- a/frontend/src/hooks/auth/useCheckAuthStatus.ts
+++ b/frontend/src/hooks/auth/useCheckAuthStatus.ts
@@ -1,10 +1,16 @@
 import { useQuery } from '@tanstack/react-query'
 import { QUERY_KEYS } from '../queryKeys'
 import { checkAuthStatus } from '../../apis/authAPI'
+import { captureAuthStatusRequestSnapshot } from '../../utils/userCacheScope'
 
 export const useCheckAuthStatus = () => {
     return useQuery({
         queryKey: [QUERY_KEYS.CHECK_AUTH_STATUS],
-        queryFn: () => checkAuthStatus()
+        queryFn: async ({ signal }) => {
+            const requestSnapshot = captureAuthStatusRequestSnapshot()
+            const authStatus = await checkAuthStatus(signal)
+            return { authStatus, requestSnapshot }
+        },
+        retry: 1,
     })
 }

--- a/frontend/src/hooks/auth/useGetAuthStatus.ts
+++ b/frontend/src/hooks/auth/useGetAuthStatus.ts
@@ -2,6 +2,11 @@ import { useQuery } from '@tanstack/react-query'
 import { QUERY_KEYS } from '../queryKeys'
 import { getAuthStatus } from '../../apis/authAPI'
 import { useAuthStore } from '../../stores/authStore'
+import {
+    applyAuthStatusResponse,
+    captureAuthStatusRequestSnapshot,
+    isAuthSessionRecordCurrent,
+} from '../../utils/userCacheScope'
 
 export const useGetAuthStatus = () => {
     const login = useAuthStore((state) => state.login)
@@ -9,14 +14,26 @@ export const useGetAuthStatus = () => {
 
     return useQuery({
         queryKey: [QUERY_KEYS.AUTH_STATUS],
-        queryFn: async() => {
-            const { authenticated, user } = await getAuthStatus()
-            if(authenticated){
-                login(user)
-            }else{
-                logout()
+        queryFn: async({ signal }) => {
+            const requestSnapshot = captureAuthStatusRequestSnapshot()
+            const authStatus = await getAuthStatus(signal)
+            if (useAuthStore.getState().isLogoutInProgress) return null
+            const result = await applyAuthStatusResponse(requestSnapshot, authStatus)
+            if (!result.applied || !isAuthSessionRecordCurrent(result.record)) return null
+
+            if (authStatus.authenticated) {
+                if (
+                    result.record?.status === 'authenticated'
+                    && result.record.sessionScope === authStatus.session_scope
+                ) {
+                    login(authStatus.user, authStatus.session_scope)
+                }
+                return authStatus.user
             }
-            return user
-        }
+
+            if (result.record?.status === 'guest') logout()
+            return null
+        },
+        retry: 1,
     })
 }

--- a/frontend/src/hooks/auth/useGetAuthStatus.ts
+++ b/frontend/src/hooks/auth/useGetAuthStatus.ts
@@ -8,17 +8,22 @@ import {
     isAuthSessionRecordCurrent,
 } from '../../utils/userCacheScope'
 
-export const useGetAuthStatus = () => {
+export const useGetAuthStatus = (oauthTransitionOwner: string | null) => {
     const login = useAuthStore((state) => state.login)
     const logout = useAuthStore((state) => state.logout)
 
     return useQuery({
-        queryKey: [QUERY_KEYS.AUTH_STATUS],
+        queryKey: [QUERY_KEYS.AUTH_STATUS, oauthTransitionOwner ?? 'missing-owner'],
         queryFn: async({ signal }) => {
             const requestSnapshot = captureAuthStatusRequestSnapshot()
             const authStatus = await getAuthStatus(signal)
             if (useAuthStore.getState().isLogoutInProgress) return null
-            const result = await applyAuthStatusResponse(requestSnapshot, authStatus)
+            if (!oauthTransitionOwner) return null
+
+            const result = await applyAuthStatusResponse(requestSnapshot, authStatus, {
+                transitionOwner: oauthTransitionOwner,
+                transitionKind: 'oauth',
+            })
             if (!result.applied || !isAuthSessionRecordCurrent(result.record)) return null
 
             if (authStatus.authenticated) {
@@ -31,9 +36,10 @@ export const useGetAuthStatus = () => {
                 return authStatus.user
             }
 
-            if (result.record?.status === 'guest') logout()
+            if (!authStatus.authenticated && result.record?.status === 'guest') logout()
             return null
         },
+        enabled: Boolean(oauthTransitionOwner),
         retry: 1,
     })
 }

--- a/frontend/src/hooks/auth/useLogoutUser.ts
+++ b/frontend/src/hooks/auth/useLogoutUser.ts
@@ -1,22 +1,100 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { notifications } from '@mantine/notifications'
 import { useAuthStore } from '../../stores/authStore'
 import { logoutUser } from '../../apis/authAPI'
 import { QUERY_KEYS } from '../queryKeys'
+import {
+    beginAuthSessionTransition,
+    cancelAuthSessionTransition,
+    captureAuthStatusRequestSnapshot,
+    completeLogoutAuthSessionTransition,
+    getUserCacheScope,
+} from '../../utils/userCacheScope'
+
+const USER_SCOPED_QUERY_KEYS = new Set([
+    QUERY_KEYS.TIMETABLE,
+    QUERY_KEYS.TIMETABLE_ALL_ITEMS,
+    QUERY_KEYS.COURSE,
+    QUERY_KEYS.REVIEWS,
+    QUERY_KEYS.REVIEW_COMMENTS,
+    QUERY_KEYS.LATEST_REVIEWS,
+    QUERY_KEYS.INFINITY_REVIEWS,
+    QUERY_KEYS.INTERESTS,
+    QUERY_KEYS.INFINITY_INTERESTS,
+    QUERY_KEYS.FEATURE_REQUESTS,
+    QUERY_KEYS.ADMIN_STATUS,
+    QUERY_KEYS.ADMIN_RELATED_POSTS_OVERVIEW,
+])
 
 export const useLogoutUser = () => {
     const logout = useAuthStore((state) => state.logout)
+    const setIsLogoutInProgress = useAuthStore((state) => state.setIsLogoutInProgress)
     const queryClient = useQueryClient()
+
+    const cancelAuthQueries = () => Promise.all([
+        queryClient.cancelQueries({ queryKey: [QUERY_KEYS.AUTH_STATUS] }),
+        queryClient.cancelQueries({ queryKey: [QUERY_KEYS.CHECK_AUTH_STATUS] }),
+    ])
 
     return useMutation({
         mutationFn: () => logoutUser(),
-        onSuccess: () => {
-            logout()
-            queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.REVIEWS] })
-            queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.COURSE] })
-            queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.AUTH_STATUS] })
-            queryClient.removeQueries({ queryKey: [QUERY_KEYS.ADMIN_STATUS] })
-            queryClient.removeQueries({ queryKey: [QUERY_KEYS.ADMIN_RELATED_POSTS_OVERVIEW] })
+        onMutate: async () => {
+            const userCacheScope = getUserCacheScope(useAuthStore.getState().user)
+            const transition = await beginAuthSessionTransition('logout')
+            if (!transition) {
+                throw new Error('AUTH_TRANSITION_IN_PROGRESS')
+            }
+            setIsLogoutInProgress(true)
+            await cancelAuthQueries()
+            return { userCacheScope, transitionOwner: transition.owner }
         },
-        onError: () => console.error('登出失敗')
+        onSuccess: async (_data, _variables, context) => {
+            const completed = await completeLogoutAuthSessionTransition(context.transitionOwner)
+            if (!completed) {
+                setIsLogoutInProgress(false)
+                return
+            }
+
+            await cancelAuthQueries()
+            const matchesLoggedOutUserScope = (query: { queryKey: readonly unknown[] }) => (
+                USER_SCOPED_QUERY_KEYS.has(String(query.queryKey[0]))
+                && query.queryKey.includes(context.userCacheScope)
+            )
+            await queryClient.cancelQueries({ predicate: matchesLoggedOutUserScope })
+            queryClient.removeQueries({ predicate: matchesLoggedOutUserScope })
+            queryClient.setQueryData(
+                [QUERY_KEYS.CHECK_AUTH_STATUS],
+                {
+                    authStatus: { authenticated: false as const },
+                    requestSnapshot: captureAuthStatusRequestSnapshot(),
+                },
+            )
+            logout()
+        },
+        onError: async (error, _variables, context) => {
+            if (context?.transitionOwner) {
+                await cancelAuthSessionTransition(context.transitionOwner)
+            }
+            setIsLogoutInProgress(false)
+            if (error instanceof Error && error.message === 'AUTH_TRANSITION_IN_PROGRESS') {
+                notifications.show({
+                    title: '登入狀態正在更新',
+                    message: '目前正在處理登入，請稍後再登出。',
+                    color: 'orange',
+                })
+                return
+            }
+            console.error('登出失敗')
+            await Promise.all([
+                queryClient.refetchQueries({
+                    queryKey: [QUERY_KEYS.AUTH_STATUS],
+                    type: 'active',
+                }),
+                queryClient.refetchQueries({
+                    queryKey: [QUERY_KEYS.CHECK_AUTH_STATUS],
+                    type: 'active',
+                }),
+            ])
+        },
     })
 }

--- a/frontend/src/hooks/courses/useGetCourse.ts
+++ b/frontend/src/hooks/courses/useGetCourse.ts
@@ -1,10 +1,14 @@
 import { useQuery } from '@tanstack/react-query'
 import { QUERY_KEYS } from '../queryKeys'
 import { getCourse } from '../../apis/courseAPI'
+import { useAuthStore } from '../../stores/authStore'
+import { getUserCacheScope } from '../../utils/userCacheScope'
 
 export const useGetCourse = (course_id: string) => {
+    const userCacheScope = useAuthStore((state) => getUserCacheScope(state.user))
+
     return useQuery({
-        queryKey: [QUERY_KEYS.COURSE, course_id],
+        queryKey: [QUERY_KEYS.COURSE, course_id, userCacheScope],
         queryFn: () => getCourse(course_id),
         enabled: !!course_id,
         staleTime: 5 * 60 * 1000,

--- a/frontend/src/hooks/featureRequests/useGetFeatureRequests.ts
+++ b/frontend/src/hooks/featureRequests/useGetFeatureRequests.ts
@@ -3,12 +3,13 @@ import { getFeatureRequests } from '../../apis/featureRequestAPI'
 import { FeatureRequestStatus } from '../../types/featureRequestType'
 import { QUERY_KEYS } from '../queryKeys'
 import { useAuthStore } from '../../stores/authStore'
+import { getUserCacheScope } from '../../utils/userCacheScope'
 
 export const useGetFeatureRequests = (status?: FeatureRequestStatus) => {
-  const userId = useAuthStore((state) => state.user?.id)
+  const userCacheScope = useAuthStore((state) => getUserCacheScope(state.user))
 
   return useQuery({
-    queryKey: [QUERY_KEYS.FEATURE_REQUESTS, status ?? 'all', userId ?? 'anonymous'],
+    queryKey: [QUERY_KEYS.FEATURE_REQUESTS, status ?? 'all', userCacheScope],
     queryFn: () => getFeatureRequests(status),
     staleTime: 1000 * 60,
   })

--- a/frontend/src/hooks/featureRequests/useToggleFeatureRequestVote.ts
+++ b/frontend/src/hooks/featureRequests/useToggleFeatureRequestVote.ts
@@ -3,13 +3,14 @@ import { toggleFeatureRequestVote } from '../../apis/featureRequestAPI'
 import { FeatureRequest } from '../../types/featureRequestType'
 import { useAuthStore } from '../../stores/authStore'
 import { QUERY_KEYS } from '../queryKeys'
+import { getUserCacheScope } from '../../utils/userCacheScope'
 
 export const useToggleFeatureRequestVote = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (id: number) => toggleFeatureRequestVote(id),
-    onMutate: () => ({ userKey: useAuthStore.getState().user?.id ?? 'anonymous' }),
+    onMutate: () => ({ userKey: getUserCacheScope(useAuthStore.getState().user) }),
     onSuccess: (data, id, context) => {
       queryClient.setQueriesData<FeatureRequest[]>(
         { queryKey: [QUERY_KEYS.FEATURE_REQUESTS] },

--- a/frontend/src/hooks/interests/useGetAllInterests.ts
+++ b/frontend/src/hooks/interests/useGetAllInterests.ts
@@ -1,11 +1,18 @@
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { QUERY_KEYS } from '../queryKeys'
 import { getAllInterests } from '../../apis/interestAPI'
+import { useAuthStore } from '../../stores/authStore'
+import { getUserCacheScope } from '../../utils/userCacheScope'
 
 export const useGetAllInterests = () => {
+    const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
+    const isAuthResolved = useAuthStore((state) => state.isAuthResolved)
+    const userCacheScope = useAuthStore((state) => getUserCacheScope(state.user))
+
     return useInfiniteQuery({
-        queryKey: [QUERY_KEYS.INFINITY_INTERESTS],
+        queryKey: [QUERY_KEYS.INFINITY_INTERESTS, userCacheScope],
         queryFn: getAllInterests,
+        enabled: isAuthResolved && isAuthenticated,
         initialPageParam: 0,
         getNextPageParam: (lastPage, allPages) => {
             const loadedCount = allPages.reduce((total, page) => total + page.items.length, 0)

--- a/frontend/src/hooks/interests/useToggleInterest.ts
+++ b/frontend/src/hooks/interests/useToggleInterest.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toggleInterest } from '../../apis/interestAPI'
 import { CourseDetailResponse } from '../../types/courseType'
+import { useAuthStore } from '../../stores/authStore'
+import { getUserCacheScope } from '../../utils/userCacheScope'
 import { QUERY_KEYS } from '../queryKeys'
 
 export const useToggleInterest = () => {
@@ -8,16 +10,23 @@ export const useToggleInterest = () => {
 
 	return useMutation({
 		mutationFn: (course_id: number) => toggleInterest(course_id),
-		onSuccess: (data, course_id) => {
+		onMutate: () => ({
+			userCacheScope: getUserCacheScope(useAuthStore.getState().user),
+		}),
+		onSuccess: (data, course_id, context) => {
 			const courseIdKey = String(course_id)
-			queryClient.setQueryData([QUERY_KEYS.COURSE, courseIdKey], (oldData: CourseDetailResponse | undefined) => {
+			queryClient.setQueryData(
+				[QUERY_KEYS.COURSE, courseIdKey, context.userCacheScope],
+				(oldData: CourseDetailResponse | undefined) => {
 				if (!oldData) return oldData
 				return {
 					...oldData,
 					hasUserAddInterest: data.isInterest
 				}
 			})
-			queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.COURSE, courseIdKey] })
+			queryClient.invalidateQueries({
+				queryKey: [QUERY_KEYS.COURSE, courseIdKey, context.userCacheScope],
+			})
 			queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.INTERESTS] })
 			queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.INFINITY_INTERESTS] })
 			queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TIMETABLE_INTEREST_OPTIONS] })

--- a/frontend/src/hooks/reviews/useGetAllReviewsByCourseId.ts
+++ b/frontend/src/hooks/reviews/useGetAllReviewsByCourseId.ts
@@ -1,10 +1,15 @@
 import { useQuery } from '@tanstack/react-query'
 import { QUERY_KEYS } from '../queryKeys'
 import { getAllReviewsByCourseId } from '../../apis/reviewAPI'
+import { useAuthStore } from '../../stores/authStore'
+import { getUserCacheScope } from '../../utils/userCacheScope'
 
 export const useGetAllReviewsByCourseId = (course_id: string) => {
+    const userCacheScope = useAuthStore((state) => getUserCacheScope(state.user))
+
     return useQuery({
-        queryKey: [QUERY_KEYS.REVIEWS],
-        queryFn: () => getAllReviewsByCourseId(course_id)
+        queryKey: [QUERY_KEYS.REVIEWS, course_id, userCacheScope],
+        queryFn: () => getAllReviewsByCourseId(course_id),
+        enabled: Boolean(course_id),
     })
 }

--- a/frontend/src/hooks/reviews/useGetAllReviewsByUserId.ts
+++ b/frontend/src/hooks/reviews/useGetAllReviewsByUserId.ts
@@ -1,11 +1,18 @@
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { getAllReviewsByUserId } from '../../apis/reviewAPI'
 import { QUERY_KEYS } from '../queryKeys'
+import { useAuthStore } from '../../stores/authStore'
+import { getUserCacheScope } from '../../utils/userCacheScope'
 
 export const useGetAllReviewsByUserId = () => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
+  const isAuthResolved = useAuthStore((state) => state.isAuthResolved)
+  const userCacheScope = useAuthStore((state) => getUserCacheScope(state.user))
+
   return useInfiniteQuery({
-    queryKey: [QUERY_KEYS.INFINITY_REVIEWS],
+    queryKey: [QUERY_KEYS.INFINITY_REVIEWS, userCacheScope],
     queryFn: getAllReviewsByUserId,
+    enabled: isAuthResolved && isAuthenticated,
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => {
       const loadedCount = allPages.reduce((total, page) => total + page.items.length, 0)

--- a/frontend/src/hooks/reviews/useGetLatestReiviews.ts
+++ b/frontend/src/hooks/reviews/useGetLatestReiviews.ts
@@ -1,10 +1,14 @@
 import { useQuery } from '@tanstack/react-query'
 import { QUERY_KEYS } from '../queryKeys'
 import { getLatestReviews } from '../../apis/reviewAPI'
+import { useAuthStore } from '../../stores/authStore'
+import { getUserCacheScope } from '../../utils/userCacheScope'
 
 export const useGetLatestReviews = () => {
+    const userCacheScope = useAuthStore((state) => getUserCacheScope(state.user))
+
     return useQuery({
-        queryKey: [QUERY_KEYS.LATEST_REVIEWS],
+        queryKey: [QUERY_KEYS.LATEST_REVIEWS, userCacheScope],
         queryFn: () => getLatestReviews()
     })
 }

--- a/frontend/src/hooks/reviews/useGetReviewComments.ts
+++ b/frontend/src/hooks/reviews/useGetReviewComments.ts
@@ -2,12 +2,13 @@ import { useQuery } from '@tanstack/react-query'
 import { getReviewComments } from '../../apis/reviewAPI'
 import { QUERY_KEYS } from '../queryKeys'
 import { useAuthStore } from '../../stores/authStore'
+import { getUserCacheScope } from '../../utils/userCacheScope'
 
 export const useGetReviewComments = (review_id: number, enabled: boolean) => {
-  const userId = useAuthStore((state) => state.user?.id ?? 'guest')
+  const userCacheScope = useAuthStore((state) => getUserCacheScope(state.user))
 
   return useQuery({
-    queryKey: [QUERY_KEYS.REVIEW_COMMENTS, review_id, userId],
+    queryKey: [QUERY_KEYS.REVIEW_COMMENTS, review_id, userCacheScope],
     queryFn: () => getReviewComments(review_id),
     enabled,
   })

--- a/frontend/src/hooks/timetables/useAddTimetableCourse.ts
+++ b/frontend/src/hooks/timetables/useAddTimetableCourse.ts
@@ -3,6 +3,8 @@ import { notifications } from '@mantine/notifications'
 import { addTimetableCourse } from '../../apis/timetableAPI'
 import { ApiError } from '../../apis/axiosInstance'
 import { QUERY_KEYS } from '../queryKeys'
+import { useAuthStore } from '../../stores/authStore'
+import { getUserCacheScope } from '../../utils/userCacheScope'
 
 type AddPayload = {
   timetableId: number
@@ -14,10 +16,20 @@ export const useAddTimetableCourse = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: ({ timetableId, courseId }: AddPayload) => addTimetableCourse(timetableId, courseId),
-    onSuccess: (data, variables) => {
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TIMETABLE, variables.semester] })
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TIMETABLE_ALL_ITEMS] })
+    mutationFn: async ({ timetableId, courseId }: AddPayload) => {
+      const userCacheScope = getUserCacheScope(useAuthStore.getState().user)
+      const result = await addTimetableCourse(timetableId, courseId, {
+        expectedSessionScope: userCacheScope,
+      })
+      return { result, userCacheScope }
+    },
+    onSuccess: ({ result: data, userCacheScope }, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.TIMETABLE, variables.semester, userCacheScope],
+      })
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.TIMETABLE_ALL_ITEMS, userCacheScope],
+      })
 
       if (data.added) {
         notifications.show({

--- a/frontend/src/hooks/timetables/useGetAllTimetableItems.ts
+++ b/frontend/src/hooks/timetables/useGetAllTimetableItems.ts
@@ -1,12 +1,22 @@
 import { useQuery } from '@tanstack/react-query'
 import { getAllTimetableItems } from '../../apis/timetableAPI'
 import { QUERY_KEYS } from '../queryKeys'
+import { useAuthStore } from '../../stores/authStore'
+import { getUserCacheScope } from '../../utils/userCacheScope'
 
 export const useGetAllTimetableItems = (enabled: boolean) => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
+  const isAuthResolved = useAuthStore((state) => state.isAuthResolved)
+  const userCacheScope = useAuthStore((state) => getUserCacheScope(state.user))
+  const isAccountQueryEnabled = enabled && isAuthResolved && isAuthenticated
+
   return useQuery({
-    queryKey: [QUERY_KEYS.TIMETABLE_ALL_ITEMS],
-    queryFn: getAllTimetableItems,
-    enabled,
+    queryKey: [QUERY_KEYS.TIMETABLE_ALL_ITEMS, userCacheScope],
+    queryFn: ({ signal }) => getAllTimetableItems({
+      signal,
+      expectedSessionScope: userCacheScope,
+    }),
+    enabled: isAccountQueryEnabled,
     staleTime: 1000 * 60 * 2,
     gcTime: 1000 * 60 * 30,
   })

--- a/frontend/src/hooks/timetables/useGetTimetable.ts
+++ b/frontend/src/hooks/timetables/useGetTimetable.ts
@@ -1,12 +1,22 @@
 import { useQuery } from '@tanstack/react-query'
 import { getTimetableBySemester } from '../../apis/timetableAPI'
 import { QUERY_KEYS } from '../queryKeys'
+import { useAuthStore } from '../../stores/authStore'
+import { getUserCacheScope } from '../../utils/userCacheScope'
 
 export const useGetTimetable = (semester: string | null, enabled: boolean) => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
+  const isAuthResolved = useAuthStore((state) => state.isAuthResolved)
+  const userCacheScope = useAuthStore((state) => getUserCacheScope(state.user))
+  const isAccountQueryEnabled = enabled && isAuthResolved && isAuthenticated
+
   return useQuery({
-    queryKey: [QUERY_KEYS.TIMETABLE, semester],
-    queryFn: () => getTimetableBySemester(semester as string),
-    enabled: enabled && Boolean(semester),
+    queryKey: [QUERY_KEYS.TIMETABLE, semester, userCacheScope],
+    queryFn: ({ signal }) => getTimetableBySemester(semester as string, {
+      signal,
+      expectedSessionScope: userCacheScope,
+    }),
+    enabled: isAccountQueryEnabled && Boolean(semester),
     staleTime: 1000 * 60 * 2,
     gcTime: 1000 * 60 * 30,
   })

--- a/frontend/src/hooks/timetables/useRemoveTimetableCourse.ts
+++ b/frontend/src/hooks/timetables/useRemoveTimetableCourse.ts
@@ -1,6 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { notifications } from '@mantine/notifications'
 import { removeTimetableCourse } from '../../apis/timetableAPI'
+import { useAuthStore } from '../../stores/authStore'
+import type { AddedCourseItem, TimetableResponse } from '../../types/timetableType'
+import { getUserCacheScope } from '../../utils/userCacheScope'
 import { QUERY_KEYS } from '../queryKeys'
 
 type RemovePayload = {
@@ -13,10 +16,38 @@ export const useRemoveTimetableCourse = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: ({ timetableId, courseId }: RemovePayload) => removeTimetableCourse(timetableId, courseId),
-    onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TIMETABLE, variables.semester] })
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TIMETABLE_ALL_ITEMS] })
+    mutationFn: async ({ timetableId, courseId }: RemovePayload) => {
+      const userCacheScope = getUserCacheScope(useAuthStore.getState().user)
+      await removeTimetableCourse(timetableId, courseId, {
+        expectedSessionScope: userCacheScope,
+      })
+      return { userCacheScope }
+    },
+    onSuccess: ({ userCacheScope }, variables) => {
+      queryClient.setQueryData<TimetableResponse>(
+        [QUERY_KEYS.TIMETABLE, variables.semester, userCacheScope],
+        (current) => current ? {
+          ...current,
+          items: current.items.filter((item) => item.course.id !== variables.courseId),
+        } : current,
+      )
+      queryClient.setQueryData<{ items: AddedCourseItem[] }>(
+        [QUERY_KEYS.TIMETABLE_ALL_ITEMS, userCacheScope],
+        (current) => current ? {
+          items: current.items.filter((item) => !(
+            item.semester === variables.semester
+            && item.course.id === variables.courseId
+          )),
+        } : current,
+      )
+      void Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: [QUERY_KEYS.TIMETABLE, variables.semester, userCacheScope],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [QUERY_KEYS.TIMETABLE_ALL_ITEMS, userCacheScope],
+        }),
+      ])
       notifications.show({
         title: '已移除課程',
         message: '課程已從課表移除',

--- a/frontend/src/hooks/users/useUpdateUser.ts
+++ b/frontend/src/hooks/users/useUpdateUser.ts
@@ -3,18 +3,25 @@ import { notifications } from '@mantine/notifications'
 
 import { updateUser } from '../../apis/userAPI'
 import { useAuthStore } from '../../stores/authStore'
+import { getUserCacheScope } from '../../utils/userCacheScope'
 import { QUERY_KEYS } from '../queryKeys'
 
 const useUpdateUserBase = (successMessage: string) => {
-  const login = useAuthStore((state) => state.login)
+  const updateStoredUser = useAuthStore((state) => state.updateUser)
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: updateUser,
-    onSuccess: ({ name, avatar }) => {
+    onMutate: () => ({
+      userCacheScope: getUserCacheScope(useAuthStore.getState().user),
+    }),
+    onSuccess: ({ name, avatar }, _variables, context) => {
       const latestUser = useAuthStore.getState().user
-      if (latestUser) {
-        login({ ...latestUser, name, avatar })
+      if (
+        latestUser
+        && getUserCacheScope(latestUser) === context.userCacheScope
+      ) {
+        updateStoredUser({ ...latestUser, name, avatar })
       }
 
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.INFINITY_REVIEWS] })

--- a/frontend/src/pages/AdminRoute.tsx
+++ b/frontend/src/pages/AdminRoute.tsx
@@ -1,12 +1,14 @@
 import { Loader, Text } from '@mantine/core'
 import { Navigate, Outlet, useLocation } from 'react-router-dom'
 import { useGetAdminStatus } from '../hooks/admin/useGetAdminStatus'
+import { useAuthStore } from '../stores/authStore'
 
 const AdminRoute: React.FC = () => {
   const location = useLocation()
+  const isAuthResolved = useAuthStore((state) => state.isAuthResolved)
   const { data, isLoading, isError } = useGetAdminStatus()
 
-  if (isLoading) {
+  if (!isAuthResolved || isLoading) {
     return <Loader mt='xl' />
   }
 

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -1,38 +1,92 @@
 import { useEffect, useRef } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { useGetAuthStatus } from '../hooks/auth/useGetAuthStatus'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { Container, Loader } from '@mantine/core'
+import {
+  clearOAuthAuthSessionTransitionOwner,
+  getOAuthAuthSessionTransitionOwner,
+} from '../utils/userCacheScope'
+import { QUERY_KEYS } from '../hooks/queryKeys'
+import { reconcileOAuthTransition } from '../utils/oauthTransition'
 
 const OAuthCallbackPage: React.FC = () => {
-  const { data: user } = useGetAuthStatus()
-  const navigate = useNavigate()
+  const oauthTransitionOwner = useRef(getOAuthAuthSessionTransitionOwner()).current
   const location = useLocation()
+  const oauthError = new URLSearchParams(location.search).get('error')
+  const { data: user, isFetching, isError } = useGetAuthStatus(
+    oauthError ? null : oauthTransitionOwner,
+  )
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const hasRedirected = useRef(false)
+
+  useEffect(() => () => {
+    if (!oauthTransitionOwner || hasRedirected.current) return
+
+    sessionStorage.removeItem('redirect_path')
+    void reconcileOAuthTransition(oauthTransitionOwner).then(() => {
+      void queryClient.refetchQueries({
+        queryKey: [QUERY_KEYS.CHECK_AUTH_STATUS],
+        type: 'active',
+      })
+    })
+  }, [oauthTransitionOwner, queryClient])
 
   useEffect(() => {
     if (hasRedirected.current) return
-  
-    const searchParams = new URLSearchParams(location.search)
-    const error = searchParams.get('error')
-  
-    if (error === 'invalid_email') {
+
+    const cancelAndRevalidate = (redirectPath: string): void => {
+      if (!oauthTransitionOwner) return
       hasRedirected.current = true
-      localStorage.removeItem('redirect_path')
-      navigate('/mailError')
+      void reconcileOAuthTransition(oauthTransitionOwner).then(() => {
+        void queryClient.refetchQueries({
+          queryKey: [QUERY_KEYS.CHECK_AUTH_STATUS],
+          type: 'active',
+        })
+      })
+      sessionStorage.removeItem('redirect_path')
+      navigate(redirectPath, { replace: true })
+    }
+
+    if (!oauthTransitionOwner) {
+      hasRedirected.current = true
+      sessionStorage.removeItem('redirect_path')
+      void queryClient.refetchQueries({
+        queryKey: [QUERY_KEYS.CHECK_AUTH_STATUS],
+        type: 'active',
+      })
+      navigate('/', { replace: true })
+      return
+    }
+
+    if (oauthError === 'invalid_email') {
+      cancelAndRevalidate('/mailError')
+      return
+    }
+
+    if (oauthError) {
+      cancelAndRevalidate('/')
       return
     }
   
     if (user) {
       hasRedirected.current = true
-      const redirect_path = localStorage.getItem('redirect_path')
+      clearOAuthAuthSessionTransitionOwner()
+      const redirect_path = sessionStorage.getItem('redirect_path')
       if (redirect_path) {
-        localStorage.removeItem('redirect_path')
+        sessionStorage.removeItem('redirect_path')
         navigate(redirect_path)
       } else {
         navigate('/')
       }
+      return
     }
-  }, [location.search, navigate, user])
+
+    if (isError || (!isFetching && user === null)) {
+      cancelAndRevalidate('/')
+    }
+  }, [isError, isFetching, navigate, oauthError, oauthTransitionOwner, queryClient, user])
   return (
     <Container>
       <Loader/>

--- a/frontend/src/pages/ProtectedRoute.tsx
+++ b/frontend/src/pages/ProtectedRoute.tsx
@@ -2,24 +2,29 @@ import { useEffect } from 'react'
 import { useAuthStore } from '../stores/authStore'
 import { Navigate, Outlet, useLocation } from 'react-router-dom'
 import { notifications } from '@mantine/notifications'
+import { Loader } from '@mantine/core'
 
 const ProtectedRoute: React.FC = () => {
-  const { isAuthenticated } = useAuthStore()  // 使用zustand管理的認證狀態
+  const { isAuthenticated, isAuthResolved } = useAuthStore()
   const location = useLocation()
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (isAuthResolved && !isAuthenticated) {
       notifications.show({
         title: '尚未登入',
         message: '請先登入帳號',
         color: 'red',
-    })
+      })
     }
-  }, [isAuthenticated])
+  }, [isAuthenticated, isAuthResolved])
+
+  if (!isAuthResolved) {
+    return <Loader mt='xl' />
+  }
 
   if (!isAuthenticated) {
     return <Navigate to='/' state={{ from: location }} />
-}
+  }
 
   return (
     <Outlet />

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,31 +1,87 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { User } from '../types/userType'
+import { createAuthenticatedUserCacheScope } from '../utils/userCacheScope'
+
+type AuthenticatedUser = User & {
+  cacheScope: string
+}
 
 interface AuthState {
   isAuthenticated: boolean;
+  isAuthResolved: boolean;
   isLogoutInProgress: boolean; // 設置一個標誌，避免重複登出
-  user: User | null;
-  login: (user: User) => void;
+  user: AuthenticatedUser | null;
+  login: (user: User, sessionScope: string) => void;
+  updateUser: (user: User) => void;
   logout: () => void;
+  markAuthUnresolved: () => void;
   setIsLogoutInProgress: (status: boolean) => void;
 }
 
-export const useAuthStore = create(
-  persist<AuthState>(
+export const useAuthStore = create<AuthState>()(
+  persist(
     (set) => ({
       isAuthenticated: false,
+      isAuthResolved: false,
       isLogoutInProgress: false,
       user: null,
-      login: (user) => set({ isAuthenticated: true, user }),
+      login: (user, sessionScope) => {
+        const cacheScope = createAuthenticatedUserCacheScope(sessionScope)
+        set({
+          isAuthenticated: true,
+          isAuthResolved: true,
+          isLogoutInProgress: false,
+          user: {
+            ...user,
+            cacheScope,
+          },
+        })
+      },
+      updateUser: (user) => set((state) => ({
+        user: state.user
+          ? { ...user, cacheScope: state.user.cacheScope }
+          : null,
+      })),
       logout: () => {
-        set({ isAuthenticated: false, user: null })
+        set({
+          isAuthenticated: false,
+          isAuthResolved: true,
+          isLogoutInProgress: false,
+          user: null,
+        })
         localStorage.removeItem('auth-storage')
       },
+      markAuthUnresolved: () => set((state) => {
+        // 驗證服務暫時失敗時沿用已知模式，避免卸載使用者正在操作的畫面。
+        return state.isAuthenticated && state.user
+          ? { isAuthResolved: true }
+          : {
+            isAuthenticated: false,
+            isAuthResolved: true,
+            isLogoutInProgress: false,
+            user: null,
+          }
+      }),
       setIsLogoutInProgress: (status) => set({ isLogoutInProgress: status }),
     }),
     {
       name: 'auth-storage', // key for localStorage/sessionStorage
+      partialize: (state) => ({
+        isAuthenticated: state.isAuthenticated,
+        user: state.user
+          ? {
+            id: state.user.id,
+            name: state.user.name,
+            detail: state.user.detail,
+            avatar: state.user.avatar,
+            is_admin: state.user.is_admin,
+            created_at: state.user.created_at,
+            updated_at: state.user.updated_at,
+            cacheScope: state.user.cacheScope,
+          }
+          : null,
+      }),
     }
   )
 )

--- a/frontend/src/types/authType.ts
+++ b/frontend/src/types/authType.ts
@@ -1,6 +1,12 @@
 import { User } from './userType'
 
-export interface AuthStatusResponse{
-    authenticated: boolean,
+export type AuthStatusResponse =
+  | {
+    authenticated: true
+    session_scope: string
     user: User
-}
+  }
+  | {
+    authenticated: false
+    user?: never
+  }

--- a/frontend/src/types/interestType.ts
+++ b/frontend/src/types/interestType.ts
@@ -2,7 +2,6 @@ import { Course } from './courseType'
 
 export interface Interest{
     id: number,
-    user_id: number,
     course_id: number,
     created_at: Date
 }

--- a/frontend/src/types/reviewType.ts
+++ b/frontend/src/types/reviewType.ts
@@ -3,7 +3,6 @@ import { ReviewReactionSummary } from './reactionType'
 
 export interface ReviewsResponse {
   id: number,
-  user_id: number,
   course_id: number;
   gain: number;
   sweetness: number;

--- a/frontend/src/utils/oauthTransition.ts
+++ b/frontend/src/utils/oauthTransition.ts
@@ -1,0 +1,94 @@
+import { cancelOAuthAttempt, checkAuthStatus } from '../apis/authAPI'
+import type { AuthStatusResponse } from '../types/authType'
+import { useAuthStore } from '../stores/authStore'
+import {
+  applyAuthStatusResponse,
+  captureAuthStatusRequestSnapshot,
+  clearOAuthAuthSessionTransitionOwner,
+  getAuthSessionRecord,
+  getOAuthAuthSessionTransitionOwner,
+  isAuthSessionRecordCurrent,
+} from './userCacheScope'
+
+const activeReconciliations = new Map<string, Promise<boolean>>()
+
+const clearOwnedSessionData = (owner: string): void => {
+  if (getOAuthAuthSessionTransitionOwner() !== owner) return
+  clearOAuthAuthSessionTransitionOwner()
+  sessionStorage.removeItem('redirect_path')
+}
+
+const hasPublishedOAuthSession = (
+  owner: string,
+  authStatus: AuthStatusResponse,
+): boolean => {
+  const record = getAuthSessionRecord()
+  if (
+    record?.status !== 'transition'
+    || record.transitionKind !== 'oauth'
+    || record.owner !== owner
+  ) {
+    return true
+  }
+
+  if (!authStatus.authenticated) return false
+  if (record.previous.status === 'guest') return true
+  return authStatus.session_scope !== record.previous.sessionScope
+}
+
+const reconcileOAuthTransitionOnce = async (owner: string): Promise<boolean> => {
+  try {
+    const attemptStatus = await cancelOAuthAttempt(owner)
+    const requestSnapshot = captureAuthStatusRequestSnapshot()
+    const authStatus = await checkAuthStatus()
+
+    if (
+      attemptStatus === 'completed'
+      && !hasPublishedOAuthSession(owner, authStatus)
+    ) {
+      return false
+    }
+
+    const result = await applyAuthStatusResponse(requestSnapshot, authStatus, {
+      transitionOwner: owner,
+      transitionKind: 'oauth',
+    })
+    if (!result.applied) {
+      const currentRecord = getAuthSessionRecord()
+      if (currentRecord?.status === 'transition' && currentRecord.owner === owner) {
+        return false
+      }
+      clearOwnedSessionData(owner)
+      return true
+    }
+    if (!isAuthSessionRecordCurrent(result.record)) return false
+
+    const { login, logout } = useAuthStore.getState()
+    if (
+      authStatus.authenticated
+      && result.record?.status === 'authenticated'
+      && result.record.sessionScope === authStatus.session_scope
+    ) {
+      login(authStatus.user, authStatus.session_scope)
+    } else if (!authStatus.authenticated && result.record?.status === 'guest') {
+      logout()
+    }
+    clearOwnedSessionData(owner)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export const reconcileOAuthTransition = (owner: string): Promise<boolean> => {
+  const activeReconciliation = activeReconciliations.get(owner)
+  if (activeReconciliation) return activeReconciliation
+
+  const reconciliation = reconcileOAuthTransitionOnce(owner).finally(() => {
+    if (activeReconciliations.get(owner) === reconciliation) {
+      activeReconciliations.delete(owner)
+    }
+  })
+  activeReconciliations.set(owner, reconciliation)
+  return reconciliation
+}

--- a/frontend/src/utils/userCacheScope.ts
+++ b/frontend/src/utils/userCacheScope.ts
@@ -5,6 +5,7 @@ export const GUEST_USER_CACHE_SCOPE = 'guest'
 export const UNKNOWN_AUTHENTICATED_USER_CACHE_SCOPE = 'user:unknown'
 
 const AUTH_SESSION_RECORD_STORAGE_KEY = 'tainan-select:auth-session-epoch:v1'
+const OAUTH_TRANSITION_OWNER_SESSION_KEY = 'tainan-select:oauth-transition-owner:v1'
 const AUTH_SESSION_RECORD_CHANGE_EVENT = 'tainan-select:auth-session-record:change'
 const AUTH_SESSION_RECORD_LOCK = 'tainan-select:auth-session-record:lock'
 const AUTH_TRANSITION_TIMEOUT_MS = 10 * 60 * 1000
@@ -176,6 +177,35 @@ export const beginAuthSessionTransition = async (
   writeAuthSessionRecord(nextRecord)
   return nextRecord
 })
+
+export const beginOAuthAuthSessionTransition = async (): Promise<string | null> => {
+  const transition = await beginAuthSessionTransition('oauth')
+  if (!transition) return null
+  if (typeof window !== 'undefined') {
+    window.sessionStorage.setItem(OAUTH_TRANSITION_OWNER_SESSION_KEY, transition.owner)
+  }
+  return transition.owner
+}
+
+export const getOAuthAuthSessionTransitionOwner = (): string | null => {
+  if (typeof window === 'undefined') return null
+
+  try {
+    return window.sessionStorage.getItem(OAUTH_TRANSITION_OWNER_SESSION_KEY)
+  } catch {
+    return null
+  }
+}
+
+export const clearOAuthAuthSessionTransitionOwner = (): void => {
+  if (typeof window === 'undefined') return
+
+  try {
+    window.sessionStorage.removeItem(OAUTH_TRANSITION_OWNER_SESSION_KEY)
+  } catch {
+    return
+  }
+}
 
 const restoreTransitionPreviousState = (
   transition: TransitionAuthSessionRecord,

--- a/frontend/src/utils/userCacheScope.ts
+++ b/frontend/src/utils/userCacheScope.ts
@@ -1,0 +1,327 @@
+import type { AuthStatusResponse } from '../types/authType'
+import type { User } from '../types/userType'
+
+export const GUEST_USER_CACHE_SCOPE = 'guest'
+export const UNKNOWN_AUTHENTICATED_USER_CACHE_SCOPE = 'user:unknown'
+
+const AUTH_SESSION_RECORD_STORAGE_KEY = 'tainan-select:auth-session-epoch:v1'
+const AUTH_SESSION_RECORD_CHANGE_EVENT = 'tainan-select:auth-session-record:change'
+const AUTH_SESSION_RECORD_LOCK = 'tainan-select:auth-session-record:lock'
+const AUTH_TRANSITION_TIMEOUT_MS = 10 * 60 * 1000
+
+type CacheScopedUser = User & {
+  cacheScope?: string
+}
+
+type CacheScopedAuthState = {
+  isAuthenticated: boolean
+  isAuthResolved: boolean
+  user: CacheScopedUser | null | undefined
+}
+
+type StableAuthSessionSnapshot =
+  | { status: 'authenticated'; sessionScope: string }
+  | { status: 'guest'; sessionScope: null }
+
+type StableAuthSessionRecord = StableAuthSessionSnapshot & {
+  epoch: string
+}
+
+export type TransitionAuthSessionRecord = {
+  status: 'transition'
+  sessionScope: null
+  transitionKind: 'oauth' | 'logout'
+  owner: string
+  startedAt: number
+  previous: StableAuthSessionSnapshot
+  epoch: string
+}
+
+export type AuthSessionRecord = StableAuthSessionRecord | TransitionAuthSessionRecord
+
+export type AuthStatusRequestSnapshot = AuthSessionRecord | null
+
+type ApplyAuthStatusOptions = {
+  transitionOwner?: string | null
+  transitionKind?: 'oauth' | 'logout'
+}
+
+type ApplyAuthStatusResult = {
+  applied: boolean
+  record: AuthSessionRecord | null
+}
+
+let authSessionRecordQueue = Promise.resolve()
+
+export const createAuthenticatedUserCacheScope = (sessionScope: string): string =>
+  `session:${sessionScope}`
+
+export const getUserCacheScope = (user: CacheScopedUser | null | undefined): string => {
+  if (!user) return GUEST_USER_CACHE_SCOPE
+
+  return user.cacheScope ?? UNKNOWN_AUTHENTICATED_USER_CACHE_SCOPE
+}
+
+const createOpaqueId = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+const createStableRecord = (
+  snapshot: StableAuthSessionSnapshot,
+): AuthSessionRecord => ({
+  ...snapshot,
+  epoch: createOpaqueId(),
+})
+
+const isStableSnapshot = (value: unknown): value is StableAuthSessionSnapshot => {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<StableAuthSessionSnapshot>
+  return candidate.status === 'guest'
+    ? candidate.sessionScope === null
+    : candidate.status === 'authenticated'
+      && typeof candidate.sessionScope === 'string'
+      && candidate.sessionScope.length > 0
+}
+
+const isAuthSessionRecord = (value: unknown): value is AuthSessionRecord => {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<AuthSessionRecord>
+  if (typeof candidate.epoch !== 'string' || candidate.epoch.length === 0) return false
+  if (isStableSnapshot(candidate)) return true
+  if (candidate.status !== 'transition') return false
+
+  return candidate.sessionScope === null
+    && (candidate.transitionKind === 'oauth' || candidate.transitionKind === 'logout')
+    && typeof candidate.owner === 'string'
+    && candidate.owner.length > 0
+    && typeof candidate.startedAt === 'number'
+    && Number.isFinite(candidate.startedAt)
+    && isStableSnapshot(candidate.previous)
+}
+
+const dispatchAuthSessionRecordChange = (): void => {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new Event(AUTH_SESSION_RECORD_CHANGE_EVENT))
+}
+
+const writeAuthSessionRecord = (record: AuthSessionRecord): void => {
+  if (typeof window === 'undefined') return
+
+  window.localStorage.setItem(AUTH_SESSION_RECORD_STORAGE_KEY, JSON.stringify(record))
+  dispatchAuthSessionRecordChange()
+}
+
+export const getAuthSessionRecord = (): AuthSessionRecord | null => {
+  if (typeof window === 'undefined') return null
+
+  try {
+    const rawRecord = window.localStorage.getItem(AUTH_SESSION_RECORD_STORAGE_KEY)
+    if (!rawRecord) return null
+    const parsedRecord: unknown = JSON.parse(rawRecord)
+    return isAuthSessionRecord(parsedRecord) ? parsedRecord : null
+  } catch {
+    return null
+  }
+}
+
+const recordsMatch = (
+  first: AuthStatusRequestSnapshot,
+  second: AuthStatusRequestSnapshot,
+): boolean => first === null || second === null
+  ? first === second
+  : first.epoch === second.epoch
+    && first.status === second.status
+    && first.sessionScope === second.sessionScope
+
+const withAuthSessionRecordLock = async <Result>(
+  operation: () => Result | Promise<Result>,
+): Promise<Result> => {
+  if (typeof navigator !== 'undefined' && navigator.locks) {
+    return navigator.locks.request(AUTH_SESSION_RECORD_LOCK, operation)
+  }
+
+  const queuedOperation = authSessionRecordQueue.then(operation, operation)
+  authSessionRecordQueue = queuedOperation.then(() => undefined, () => undefined)
+  return queuedOperation
+}
+
+const getStableSnapshot = (
+  record: AuthSessionRecord | null,
+): StableAuthSessionSnapshot => {
+  if (!record) return { status: 'guest', sessionScope: null }
+  if (record.status === 'transition') return record.previous
+  return record
+}
+
+export const beginAuthSessionTransition = async (
+  transitionKind: 'oauth' | 'logout',
+): Promise<TransitionAuthSessionRecord | null> => withAuthSessionRecordLock(() => {
+  const currentRecord = getAuthSessionRecord()
+  if (currentRecord?.status === 'transition') return null
+
+  const owner = createOpaqueId()
+  const nextRecord: TransitionAuthSessionRecord = {
+    status: 'transition',
+    sessionScope: null,
+    transitionKind,
+    owner,
+    startedAt: Date.now(),
+    previous: getStableSnapshot(currentRecord),
+    epoch: createOpaqueId(),
+  }
+  writeAuthSessionRecord(nextRecord)
+  return nextRecord
+})
+
+const restoreTransitionPreviousState = (
+  transition: TransitionAuthSessionRecord,
+): AuthSessionRecord => createStableRecord(transition.previous)
+
+export const cancelAuthSessionTransition = async (owner: string): Promise<boolean> => (
+  withAuthSessionRecordLock(() => {
+    const currentRecord = getAuthSessionRecord()
+    if (currentRecord?.status !== 'transition' || currentRecord.owner !== owner) {
+      return false
+    }
+
+    writeAuthSessionRecord(restoreTransitionPreviousState(currentRecord))
+    return true
+  })
+)
+
+export const recoverExpiredAuthSessionTransition = async (): Promise<boolean> => (
+  withAuthSessionRecordLock(() => {
+    const currentRecord = getAuthSessionRecord()
+    if (
+      currentRecord?.status !== 'transition'
+      || currentRecord.transitionKind === 'oauth'
+      || Date.now() - currentRecord.startedAt < AUTH_TRANSITION_TIMEOUT_MS
+    ) {
+      return false
+    }
+
+    writeAuthSessionRecord(restoreTransitionPreviousState(currentRecord))
+    return true
+  })
+)
+
+export const subscribeAuthSessionRecord = (
+  listener: () => void,
+): (() => void) => {
+  if (typeof window === 'undefined') return () => undefined
+
+  const handleStorage = (event: StorageEvent): void => {
+    if (event.key === AUTH_SESSION_RECORD_STORAGE_KEY) listener()
+  }
+  window.addEventListener('storage', handleStorage)
+  window.addEventListener(AUTH_SESSION_RECORD_CHANGE_EVENT, listener)
+
+  return () => {
+    window.removeEventListener('storage', handleStorage)
+    window.removeEventListener(AUTH_SESSION_RECORD_CHANGE_EVENT, listener)
+  }
+}
+
+export const captureAuthStatusRequestSnapshot = (): AuthStatusRequestSnapshot =>
+  getAuthSessionRecord()
+
+export const isAuthSessionRecordCurrent = (
+  expectedRecord: AuthStatusRequestSnapshot,
+): boolean => recordsMatch(expectedRecord, getAuthSessionRecord())
+
+export const applyAuthStatusResponse = async (
+  requestSnapshot: AuthStatusRequestSnapshot,
+  authStatus: AuthStatusResponse,
+  options: ApplyAuthStatusOptions = {},
+): Promise<ApplyAuthStatusResult> => withAuthSessionRecordLock(() => {
+  const currentRecord = getAuthSessionRecord()
+  if (!recordsMatch(requestSnapshot, currentRecord)) {
+    return { applied: false, record: currentRecord }
+  }
+
+  const requiresOwnedTransition = options.transitionOwner !== undefined
+    || options.transitionKind !== undefined
+  if (requiresOwnedTransition && currentRecord?.status !== 'transition') {
+    return { applied: false, record: currentRecord }
+  }
+
+  if (currentRecord?.status === 'transition') {
+    const ownsTransition = options.transitionKind === currentRecord.transitionKind
+      && options.transitionOwner === currentRecord.owner
+    if (!ownsTransition) return { applied: false, record: currentRecord }
+  }
+
+  let nextRecord: AuthSessionRecord
+  if (authStatus.authenticated) {
+    if (
+      currentRecord?.status === 'authenticated'
+      && currentRecord.sessionScope === authStatus.session_scope
+    ) {
+      nextRecord = currentRecord
+    } else {
+      nextRecord = createStableRecord({
+        status: 'authenticated',
+        sessionScope: authStatus.session_scope,
+      })
+    }
+  } else if (currentRecord?.status === 'guest') {
+    nextRecord = currentRecord
+  } else if (currentRecord?.status === 'transition') {
+    nextRecord = restoreTransitionPreviousState(currentRecord)
+  } else {
+    nextRecord = createStableRecord({ status: 'guest', sessionScope: null })
+  }
+
+  if (nextRecord !== currentRecord) writeAuthSessionRecord(nextRecord)
+  return { applied: true, record: nextRecord }
+})
+
+export const completeLogoutAuthSessionTransition = async (
+  owner: string,
+): Promise<boolean> => withAuthSessionRecordLock(() => {
+  const currentRecord = getAuthSessionRecord()
+  if (
+    currentRecord?.status !== 'transition'
+    || currentRecord.transitionKind !== 'logout'
+    || currentRecord.owner !== owner
+  ) {
+    return false
+  }
+
+  writeAuthSessionRecord(createStableRecord({ status: 'guest', sessionScope: null }))
+  return true
+})
+
+export const forceGuestAuthSessionRecord = async (
+  requestSnapshot: AuthStatusRequestSnapshot,
+): Promise<boolean> => (
+  withAuthSessionRecordLock(() => {
+    const currentRecord = getAuthSessionRecord()
+    if (!recordsMatch(requestSnapshot, currentRecord)) return false
+    if (currentRecord?.status === 'transition') return false
+    if (currentRecord?.status === 'guest') return true
+    writeAuthSessionRecord(createStableRecord({ status: 'guest', sessionScope: null }))
+    return true
+  })
+)
+
+export const captureAuthSessionEpoch = (): string =>
+  getAuthSessionRecord()?.epoch ?? ''
+
+export const isAuthenticatedUserCacheScopeCurrent = (
+  authState: CacheScopedAuthState,
+  expectedUserCacheScope: string,
+  expectedAuthSessionEpoch: string,
+): boolean => {
+  const currentRecord = getAuthSessionRecord()
+  return authState.isAuthResolved
+    && authState.isAuthenticated
+    && currentRecord?.status === 'authenticated'
+    && currentRecord.epoch === expectedAuthSessionEpoch
+    && createAuthenticatedUserCacheScope(currentRecord.sessionScope) === expectedUserCacheScope
+    && getUserCacheScope(authState.user) === expectedUserCacheScope
+}


### PR DESCRIPTION
## 標題

建立可區分每次登入的 session scope，並防止跨分頁驗證競爭

---

## 摘要

這個 PR 是整組課表功能的 Auth foundation，重點不是單純替 JWT 增加欄位，而是讓前後端能辨識「目前是哪一次登入」，並阻止舊分頁、舊 request、舊 OAuth callback 或舊 query cache 覆蓋新的登入狀態。

共包含 6 個 commits、43 個檔案：

| Commit | 目的 |
| --- | --- |
| `feat(auth): expose unique server session scopes` | 讓每次簽發的 JWT 都能對應唯一 session scope |
| `fix(auth): arbitrate browser auth state across tabs` | 建立跨分頁 auth record、transition ownership 與 stale response 防護 |
| `fix(oauth): bind callbacks to owned browser attempts` | 將 OAuth callback／取消操作綁定到發起登入的瀏覽器 attempt |
| `fix(cache): partition user-sensitive queries by session` | 避免不同登入 session 共用個人化 query cache |
| `fix(timetable): fence requests to the active session` | 防止舊 session 的課表 request 修改新 session 的資料 |
| `fix(privacy): omit internal user identifiers` | 不再把內部 `user_id` 放進前端 contract |

---

## 背景／問題

原本前端主要用「目前 user」與 Zustand state 判斷登入狀態，但這不足以處理以下情境：

1. **同一個帳號重新登入**
   - user ID 沒變，但已經是另一個 JWT／另一個瀏覽器 session。
   - 舊 request 若較晚完成，仍可能被當成目前 session 的結果。
2. **多分頁同時登入、登出或驗證**
   - A 分頁開始登出時，B 分頁可能剛完成 auth status request。
   - 如果直接以最後回來的 response 更新 store，較舊的 response 可能把新狀態蓋掉。
3. **OAuth popup／callback 被取消或重複返回**
   - callback、使用者取消、popup 關閉與頁面恢復可能同時發生。
   - 無法確認 callback 是否屬於目前瀏覽器發起的登入流程時，可能錯誤發布登入結果。
4. **React Query cache 跨 session 沿用**
   - `is_owner`、`has_voted`、`hasUserAddInterest`、`myReactions`、管理員資料與課表都與登入 session 有關。
   - 只以資源 ID 當 query key，重新登入後可能短暫顯示前一個 session 的個人化結果。
5. **舊 session mutation 寫入新 session**
   - 使用者切換帳號後，舊分頁仍可能送出加入／刪除課表等 mutation。
   - Cookie 已切到新帳號時，伺服器若只驗證「有登入」，就可能替錯誤的 session 執行操作。

---

## 變更內容

### 1. 每次登入都有唯一 session scope

後端在簽發 JWT 時加入隨機 `jti`，因此即使同一位使用者重新登入，每次取得的 token 仍不相同。

`/auth/status` 與 `/auth/checkStatus` 會回傳由完整 JWT 雜湊產生的 `session_scope`。前端使用 `session:<scope>` 作為本次登入的 cache／request 身分，不再只依賴 user ID。

這個 scope：

- 不包含原始 JWT。
- 不會暴露資料庫 user ID。
- 同一顆 token 期間保持穩定。
- 重新登入或重新簽發 JWT 時會改變。

### 2. Server-side session fence

Authenticated mutation 可帶：

```http
X-Expected-Session-Scope: session:<scope>
```

後端 middleware 會比較 header 與目前 cookie／Bearer token 的 scope：

- 相同：繼續執行 request。
- 不同：回傳 `409 SESSION_CHANGED`，不執行 mutation。
- JWT 無效：回傳 401。
- JWT server 設定異常：回傳 500，不再誤判成一般未登入。

Axios 會替一般非 GET／HEAD／OPTIONS request 自動補上這個 header；課表 API 也會從 mutation context 明確傳入預期 scope。

### 3. 跨分頁 auth session record

`frontend/src/utils/userCacheScope.ts` 新增瀏覽器共用的 auth record，狀態分為：

- `guest`
- `authenticated`
- `transition`（`oauth` 或 `logout`）

每筆 record 都有版本／epoch 與 transition owner。更新時會先取得鎖並重新讀取最新 record；支援 Web Locks 的瀏覽器使用 `navigator.locks`，否則至少在目前頁面內序列化操作。

各分頁透過 storage event 與同頁 custom event 同步。Auth status response 套用前會比較 request 發出時的 snapshot，確定期間沒有較新的登入狀態或 transition；過期 response 會被忽略。

### 4. Logout 與 stale 401 不再覆蓋新登入

Logout 流程現在會：

1. 建立 owned logout transition。
2. 取消仍在執行的 auth queries。
3. 呼叫 server logout。
4. 只有 transition owner 仍有效時，才發布 guest 狀態。
5. 取消並移除舊 session scope 的私人 queries。

Axios 收到 401 時也不會直接清空 auth store。它會比對 request 開始時的 auth snapshot；只有該 snapshot 仍是目前狀態時，才允許切換為 guest。這可避免舊 request 的 401 把剛完成的新登入登出。

### 5. OAuth attempt ownership 與 reconciliation

登入開始時，前端會建立 opaque transition owner，並將 owner 帶到 Google OAuth start request。

後端 `oauthStateStore.ts` 會：

- 驗證 owner 格式。
- 每個 owner 同時間只允許一個有效 attempt。
- 僅保存 state／owner 的雜湊索引。
- 使用 state 專屬、HttpOnly、SameSite=Lax cookie。
- 將 attempt 依序從 `pending` claim 為 `processing`，完成後標記 `completed`。
- 提供 cancel endpoint，讓 popup 關閉或使用者取消時使 attempt 失效。
- 阻止同一 state 的 callback 與 cancel 同時成功。

Callback 頁、popup 關閉、BFCache `pageshow` 與 timeout 都會走同一個 reconciliation 流程：

1. 嘗試取消或確認 attempt 狀態。
2. 重新向 server 驗證 auth cookie。
3. 確認回來的是新的 session scope。
4. 只有目前 transition owner 仍相同時，才發布 stable authenticated／guest record。

### 6. 使用者敏感 query 依 session 隔離

以下 query 會把 session cache scope 納入 query key：

- 管理員狀態與管理員資料
- Course detail 的個人化欄位
- Feature request vote
- Interests
- Review ownership、reaction 與 comment
- Timetable 與 timetable items

切換登入 session 後不會再直接沿用前一顆 token 的個人化 cache。

### 7. 課表 request 綁定 active session

課表取得、加入、移除與全部課表項目 hooks 會：

- 在 query／mutation 開始時擷取目前 session scope。
- 將 scope 放入 query key。
- 將預期 scope 傳給 timetable API。
- mutation 完成後只 invalidation 同一個 scope 的 cache。
- 若操作期間 session 已切換，避免把舊結果寫回目前畫面。

### 8. 移除內部使用者識別欄位

Interest repository 明確排除 `user_id`，前後端 interest／review types 也移除不應提供給 client 的內部欄位。

---

## 測試方式

已執行：

- Backend TypeScript：
  ```bash
  cd backend
  npx tsc --noEmit
  ```
- Frontend production build：
  ```bash
  cd frontend
  npm run build
  ```
- Frontend ESLint：
  ```bash
  cd frontend
  npm run lint
  ```
- Diff whitespace：
  ```bash
  git diff --check
  ```

建議人工驗證：

1. 開兩個分頁，以同一帳號登入後在其中一頁登出，確認另一頁同步成訪客。
2. A 分頁發出 auth request 後，在 B 分頁重新登入，確認 A 的舊 response 不會覆蓋新 session。
3. 開啟 OAuth popup 後取消，確認原本已登入的 session 不會被錯誤切成 guest。
4. OAuth callback 完成後重新整理／返回 BFCache，確認不會重複發布登入狀態。
5. 切換 session 後操作舊分頁課表，確認 server 回傳 `409 SESSION_CHANGED` 且資料未被修改。
6. 切換帳號後查看 interests、reviews、feature requests 與 timetable，確認不會短暫顯示前一個 session 的個人化資料。

---

## 備註

- 此 PR **沒有資料庫 migration，也沒有新增 table／欄位**。
- OAuth attempt 目前仍保存於單一 Node process 的記憶體 `Map`，適用目前單 instance 部署。若未來改成多 instance、非 sticky routing，或要求 process restart 後仍可完成既有 callback，需再改成 shared store；本 PR 沒有為這個 edge case 增加資料表。
- OAuth start 現在要求新版前端提供 owner，因此 frontend／backend 應一起部署。
- 此為 stacked PR 1/6，也是後續 guest timetable PR 的 session／cache 基礎。
- 建議 reviewer 依 6 個 commits 順序閱讀，優先確認：
  1. auth record 的 CAS／transition ownership；
  2. OAuth cancel 與 callback 是否只能有一方成功；
  3. `X-Expected-Session-Scope` 的 409 行為；
  4. query key 是否完整涵蓋使用者敏感資料。