### PR TITLE
建立訪客課表本機儲存與安全 mutation

### DIFF
--- a/frontend/src/hooks/timetables/useGuestTimetable.ts
+++ b/frontend/src/hooks/timetables/useGuestTimetable.ts
@@ -1,0 +1,118 @@
+import { useCallback, useMemo, useSyncExternalStore } from 'react'
+import type {
+  GuestTimetableItem,
+  GuestTimetableStorage,
+} from '../../types/timetableType'
+import {
+  addGuestCourse,
+  clearGuestSemester,
+  clearGuestTimetable,
+  createEmptyGuestTimetableStorage,
+  getGuestTimetableSummary,
+  GuestTimetableStorageError,
+  parseGuestTimetableStorage,
+  readGuestTimetableRawValue,
+  removeGuestCourse,
+  subscribeGuestTimetable,
+  swapGuestCourse,
+} from '../../utils/guestTimetableStorage'
+import type {
+  AddGuestCourseResult,
+  GuestTimetableClearResult,
+  GuestTimetableSummary,
+  SwapGuestCourseResult,
+} from '../../utils/guestTimetableStorage'
+
+const EMPTY_STORAGE_SNAPSHOT = ''
+const READ_ERROR_STORAGE_SNAPSHOT = '\u0000guest-timetable-read-error'
+
+const getStorageSnapshot = (): string => {
+  try {
+    return readGuestTimetableRawValue() ?? EMPTY_STORAGE_SNAPSHOT
+  } catch {
+    return READ_ERROR_STORAGE_SNAPSHOT
+  }
+}
+
+const getServerStorageSnapshot = (): string => EMPTY_STORAGE_SNAPSHOT
+
+export type UseGuestTimetableResult = {
+  storage: GuestTimetableStorage
+  semesters: string[]
+  summary: GuestTimetableSummary
+  error: GuestTimetableStorageError | null
+  getItemsBySemester: (semester: string) => GuestTimetableItem[]
+  isCourseAdded: (semester: string, courseId: number) => boolean
+  addCourse: (item: GuestTimetableItem) => Promise<AddGuestCourseResult>
+  removeCourse: (
+    semester: string,
+    courseId: number,
+    canRemove?: () => boolean,
+  ) => Promise<boolean>
+  clearSemester: (
+    semester: string,
+    expectedCourseIds: readonly number[],
+  ) => Promise<GuestTimetableClearResult>
+  clearAll: (expectedStorage: GuestTimetableStorage) => Promise<GuestTimetableClearResult>
+  swapCourse: (
+    item: GuestTimetableItem,
+    conflictCourseIds: readonly number[],
+  ) => Promise<SwapGuestCourseResult>
+}
+
+export const useGuestTimetable = (): UseGuestTimetableResult => {
+  const rawSnapshot = useSyncExternalStore(
+    subscribeGuestTimetable,
+    getStorageSnapshot,
+    getServerStorageSnapshot,
+  )
+
+  const { storage, error } = useMemo(() => {
+    if (rawSnapshot === READ_ERROR_STORAGE_SNAPSHOT) {
+      return {
+        storage: createEmptyGuestTimetableStorage(),
+        error: new GuestTimetableStorageError(
+          'READ_FAILED',
+          '無法讀取本機課表，請確認瀏覽器是否允許使用本機儲存空間。',
+        ),
+      }
+    }
+
+    return {
+      storage: parseGuestTimetableStorage(rawSnapshot || null),
+      error: null,
+    }
+  }, [rawSnapshot])
+
+  const semesters = useMemo(
+    () => Object.entries(storage.semesters)
+      .filter(([, items]) => items.length > 0)
+      .map(([semester]) => semester),
+    [storage],
+  )
+  const summary = useMemo(() => getGuestTimetableSummary(storage), [storage])
+  const getItemsBySemester = useCallback(
+    (semester: string) => storage.semesters[semester] ?? [],
+    [storage],
+  )
+  const isCourseAdded = useCallback(
+    (semester: string, courseId: number) => getItemsBySemester(semester).some(
+      (item) => item.course.id === courseId,
+    ),
+    [getItemsBySemester],
+  )
+
+  return {
+    storage,
+    semesters,
+    summary,
+    error,
+    getItemsBySemester,
+    isCourseAdded,
+    addCourse: addGuestCourse,
+    removeCourse: removeGuestCourse,
+    clearSemester: clearGuestSemester,
+    clearAll: clearGuestTimetable,
+    swapCourse: swapGuestCourse,
+  }
+}

--- a/frontend/src/types/timetableType.ts
+++ b/frontend/src/types/timetableType.ts
@@ -21,6 +21,15 @@ export interface TimetableItem {
   timeslots: Timeslot[]
 }
 
+export interface GuestTimetableItem extends TimetableItem {
+  addedAt: string
+}
+
+export interface GuestTimetableStorage {
+  version: 1
+  semesters: Record<string, GuestTimetableItem[]>
+}
+
 export interface TimetableGridCell {
   courseId: number
   courseName: string

--- a/frontend/src/types/timetableType.ts
+++ b/frontend/src/types/timetableType.ts
@@ -13,12 +13,22 @@ export interface TimetableCourse {
   department: string
   instructor: string
   room?: string
+  courseTime?: string
 }
 
 export interface TimetableItem {
   course: TimetableCourse
   timeslots: Timeslot[]
 }
+
+export interface TimetableGridCell {
+  courseId: number
+  courseName: string
+  instructor: string
+  room?: string
+}
+
+export type TimetableGrid = Record<string, Partial<Record<number, TimetableGridCell[]>>>
 
 export interface TimetableResponse {
   timetable: {

--- a/frontend/src/utils/guestTimetableStorage.ts
+++ b/frontend/src/utils/guestTimetableStorage.ts
@@ -1,0 +1,204 @@
+import type {
+  GuestTimetableItem,
+  GuestTimetableStorage,
+  Timeslot,
+} from '../types/timetableType'
+import {
+  getPeriodsInRange,
+  isTimetablePeriod,
+  isValidDayOfWeek,
+  TIMETABLE_PERIOD_TIME_RANGES,
+} from './timetable'
+
+export const GUEST_TIMETABLE_STORAGE_KEY = 'tainan-select:guest-timetable:v1'
+export const GUEST_TIMETABLE_STORAGE_VERSION = 1 as const
+export const GUEST_TIMETABLE_CHANGE_EVENT = 'tainan-select:guest-timetable:change'
+
+export type GuestTimetableStorageErrorCode =
+  | 'READ_FAILED'
+  | 'WRITE_FAILED'
+  | 'REMOVE_FAILED'
+  | 'INVALID_ITEM'
+  | 'CONFLICTS_CHANGED'
+
+export class GuestTimetableStorageError extends Error {
+  readonly code: GuestTimetableStorageErrorCode
+  readonly originalError?: unknown
+
+  constructor(
+    code: GuestTimetableStorageErrorCode,
+    message: string,
+    originalError?: unknown,
+  ) {
+    super(message)
+    this.name = 'GuestTimetableStorageError'
+    this.code = code
+    this.originalError = originalError
+  }
+}
+
+export type GuestTimetableSummary = {
+  totalCourses: number
+  semesterCount: number
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0
+
+const isString = (value: unknown): value is string => typeof value === 'string'
+
+const isOptionalString = (value: unknown): value is string | undefined =>
+  value === undefined || typeof value === 'string'
+
+const isValidIsoDate = (value: unknown): value is string =>
+  typeof value === 'string' && !Number.isNaN(Date.parse(value))
+
+const isValidCourseId = (value: unknown): value is number =>
+  Number.isSafeInteger(value) && Number(value) > 0
+
+export const createEmptyGuestTimetableStorage = (): GuestTimetableStorage => ({
+  version: GUEST_TIMETABLE_STORAGE_VERSION,
+  semesters: {},
+})
+
+export const isGuestTimetableTimeslot = (value: unknown): value is Timeslot => {
+  if (!isRecord(value)) return false
+
+  const startPeriod = isTimetablePeriod(value.startPeriod) ? value.startPeriod : null
+  const endPeriod = isTimetablePeriod(value.endPeriod) ? value.endPeriod : null
+  if (!startPeriod || !endPeriod) return false
+
+  return isValidDayOfWeek(value.dayOfWeek)
+    && getPeriodsInRange(startPeriod, endPeriod).length > 0
+    && Number.isInteger(value.startMin)
+    && Number.isInteger(value.endMin)
+    && value.startMin === TIMETABLE_PERIOD_TIME_RANGES[startPeriod].startMin
+    && value.endMin === TIMETABLE_PERIOD_TIME_RANGES[endPeriod].endMin
+}
+
+export const isGuestTimetableItem = (value: unknown): value is GuestTimetableItem => {
+  if (!isRecord(value) || !isRecord(value.course) || !Array.isArray(value.timeslots)) {
+    return false
+  }
+
+  const course = value.course
+
+  return isValidCourseId(course.id)
+    && isNonEmptyString(course.name)
+    && isNonEmptyString(course.semester)
+    && isString(course.department)
+    && isString(course.instructor)
+    && isOptionalString(course.room)
+    && isOptionalString(course.courseTime)
+    && value.timeslots.every(isGuestTimetableTimeslot)
+    && isValidIsoDate(value.addedAt)
+}
+
+export const isGuestTimetableStorage = (value: unknown): value is GuestTimetableStorage => {
+  if (
+    !isRecord(value)
+    || value.version !== GUEST_TIMETABLE_STORAGE_VERSION
+    || !isRecord(value.semesters)
+  ) {
+    return false
+  }
+
+  return Object.entries(value.semesters).every(([semester, items]) =>
+    isNonEmptyString(semester)
+    && Array.isArray(items)
+    && items.every(
+      (item) => isGuestTimetableItem(item) && item.course.semester === semester,
+    ))
+}
+
+const normalizeGuestTimetableStorage = (
+  storage: GuestTimetableStorage,
+): GuestTimetableStorage => ({
+  version: GUEST_TIMETABLE_STORAGE_VERSION,
+  semesters: Object.fromEntries(
+    Object.entries(storage.semesters).map(([semester, items]) => {
+      const seenCourseIds = new Set<number>()
+      const deduplicatedItems = items.filter((item) => {
+        if (seenCourseIds.has(item.course.id)) return false
+        seenCourseIds.add(item.course.id)
+        return true
+      })
+      return [semester, deduplicatedItems]
+    }),
+  ),
+})
+
+export const parseGuestTimetableStorage = (
+  rawValue: string | null,
+): GuestTimetableStorage => {
+  if (!rawValue) return createEmptyGuestTimetableStorage()
+
+  try {
+    const parsedValue: unknown = JSON.parse(rawValue)
+    if (!isGuestTimetableStorage(parsedValue)) {
+      return createEmptyGuestTimetableStorage()
+    }
+    return normalizeGuestTimetableStorage(parsedValue)
+  } catch {
+    return createEmptyGuestTimetableStorage()
+  }
+}
+
+export const readGuestTimetableRawValue = (): string | null => {
+  if (typeof window === 'undefined') return null
+
+  try {
+    return window.localStorage.getItem(GUEST_TIMETABLE_STORAGE_KEY)
+  } catch (error) {
+    throw new GuestTimetableStorageError(
+      'READ_FAILED',
+      '無法讀取本機課表，請確認瀏覽器是否允許使用本機儲存空間。',
+      error,
+    )
+  }
+}
+
+export const getGuestTimetable = (): GuestTimetableStorage =>
+  parseGuestTimetableStorage(readGuestTimetableRawValue())
+
+export const getGuestItemsBySemester = (
+  semester: string,
+): GuestTimetableItem[] => getGuestTimetable().semesters[semester] ?? []
+
+export const isGuestCourseAdded = (
+  semester: string,
+  courseId: number,
+): boolean => getGuestItemsBySemester(semester).some((item) => item.course.id === courseId)
+
+export const getGuestTimetableSummary = (
+  storage: GuestTimetableStorage = getGuestTimetable(),
+): GuestTimetableSummary => {
+  const nonEmptySemesters = Object.values(storage.semesters).filter((items) => items.length > 0)
+
+  return {
+    totalCourses: nonEmptySemesters.reduce((total, items) => total + items.length, 0),
+    semesterCount: nonEmptySemesters.length,
+  }
+}
+
+export const subscribeGuestTimetable = (listener: () => void): (() => void) => {
+  if (typeof window === 'undefined') return () => undefined
+
+  const handleSameTabChange = (): void => listener()
+  const handleStorageChange = (event: StorageEvent): void => {
+    if (event.key === GUEST_TIMETABLE_STORAGE_KEY || event.key === null) {
+      listener()
+    }
+  }
+
+  window.addEventListener(GUEST_TIMETABLE_CHANGE_EVENT, handleSameTabChange)
+  window.addEventListener('storage', handleStorageChange)
+
+  return () => {
+    window.removeEventListener(GUEST_TIMETABLE_CHANGE_EVENT, handleSameTabChange)
+    window.removeEventListener('storage', handleStorageChange)
+  }
+}

--- a/frontend/src/utils/guestTimetableStorage.ts
+++ b/frontend/src/utils/guestTimetableStorage.ts
@@ -4,6 +4,7 @@ import type {
   Timeslot,
 } from '../types/timetableType'
 import {
+  findConflictCourseIds,
   getPeriodsInRange,
   isTimetablePeriod,
   isValidDayOfWeek,
@@ -13,6 +14,9 @@ import {
 export const GUEST_TIMETABLE_STORAGE_KEY = 'tainan-select:guest-timetable:v1'
 export const GUEST_TIMETABLE_STORAGE_VERSION = 1 as const
 export const GUEST_TIMETABLE_CHANGE_EVENT = 'tainan-select:guest-timetable:change'
+const GUEST_TIMETABLE_WRITE_LOCK = 'tainan-select:guest-timetable:write'
+
+let guestTimetableWriteQueue: Promise<void> = Promise.resolve()
 
 export type GuestTimetableStorageErrorCode =
   | 'READ_FAILED'
@@ -37,10 +41,22 @@ export class GuestTimetableStorageError extends Error {
   }
 }
 
+export type AddGuestCourseResult = {
+  added: boolean
+  alreadyExists: boolean
+  conflictCourseIds: number[]
+}
+
+export type SwapGuestCourseResult = AddGuestCourseResult & {
+  removedCourseIds: number[]
+}
+
 export type GuestTimetableSummary = {
   totalCourses: number
   semesterCount: number
 }
+
+export type GuestTimetableClearResult = 'cleared' | 'already-empty' | 'changed'
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -131,6 +147,26 @@ const normalizeGuestTimetableStorage = (
   ),
 })
 
+const haveSameGuestTimetableCourses = (
+  firstStorage: GuestTimetableStorage,
+  secondStorage: GuestTimetableStorage,
+): boolean => {
+  const firstSemesters = Object.entries(firstStorage.semesters)
+    .filter(([, items]) => items.length > 0)
+  const secondSemesters = Object.entries(secondStorage.semesters)
+    .filter(([, items]) => items.length > 0)
+
+  if (firstSemesters.length !== secondSemesters.length) return false
+
+  return firstSemesters.every(([semester, firstItems]) => {
+    const secondItems = secondStorage.semesters[semester]
+    if (!secondItems || firstItems.length !== secondItems.length) return false
+
+    const secondCourseIds = new Set(secondItems.map((item) => item.course.id))
+    return firstItems.every((item) => secondCourseIds.has(item.course.id))
+  })
+}
+
 export const parseGuestTimetableStorage = (
   rawValue: string | null,
 ): GuestTimetableStorage => {
@@ -182,6 +218,236 @@ export const getGuestTimetableSummary = (
     totalCourses: nonEmptySemesters.reduce((total, items) => total + items.length, 0),
     semesterCount: nonEmptySemesters.length,
   }
+}
+
+const dispatchGuestTimetableChange = (): void => {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new Event(GUEST_TIMETABLE_CHANGE_EVENT))
+}
+
+const writeGuestTimetable = (storage: GuestTimetableStorage): void => {
+  if (typeof window === 'undefined') {
+    throw new GuestTimetableStorageError(
+      'WRITE_FAILED',
+      '目前環境無法保存本機課表。',
+    )
+  }
+
+  try {
+    window.localStorage.setItem(GUEST_TIMETABLE_STORAGE_KEY, JSON.stringify(storage))
+  } catch (error) {
+    throw new GuestTimetableStorageError(
+      'WRITE_FAILED',
+      '無法保存本機課表，請確認瀏覽器是否允許使用本機儲存空間。',
+      error,
+    )
+  }
+
+  dispatchGuestTimetableChange()
+}
+
+const assertValidGuestTimetableItem = (item: GuestTimetableItem): void => {
+  if (isGuestTimetableItem(item)) return
+
+  throw new GuestTimetableStorageError(
+    'INVALID_ITEM',
+    '課程資料格式不正確，無法加入本機課表。',
+  )
+}
+
+const withGuestTimetableWriteLock = async <Result>(
+  mutation: () => Result,
+): Promise<Result> => {
+  if (typeof navigator !== 'undefined' && navigator.locks) {
+    return navigator.locks.request(GUEST_TIMETABLE_WRITE_LOCK, mutation)
+  }
+
+  // 不支援 Web Locks 的瀏覽器至少要避免同一分頁內的寫入互相覆蓋。
+  const queuedMutation = guestTimetableWriteQueue.then(mutation, mutation)
+  guestTimetableWriteQueue = queuedMutation.then(() => undefined, () => undefined)
+  return queuedMutation
+}
+
+export const addGuestCourse = (
+  item: GuestTimetableItem,
+): Promise<AddGuestCourseResult> => {
+  assertValidGuestTimetableItem(item)
+
+  return withGuestTimetableWriteLock(() => {
+    const storage = getGuestTimetable()
+    const semester = item.course.semester
+    const currentItems = storage.semesters[semester] ?? []
+    const alreadyExists = currentItems.some(
+      (currentItem) => currentItem.course.id === item.course.id,
+    )
+
+    if (alreadyExists) {
+      return { added: false, alreadyExists: true, conflictCourseIds: [] }
+    }
+
+    const conflictCourseIds = findConflictCourseIds(item, currentItems)
+    if (conflictCourseIds.length > 0) {
+      return {
+        added: false,
+        alreadyExists: false,
+        conflictCourseIds,
+      }
+    }
+
+    writeGuestTimetable({
+      ...storage,
+      semesters: {
+        ...storage.semesters,
+        [semester]: [...currentItems, item],
+      },
+    })
+
+    return { added: true, alreadyExists: false, conflictCourseIds: [] }
+  })
+}
+
+export const removeGuestCourse = (
+  semester: string,
+  courseId: number,
+  canRemove?: () => boolean,
+): Promise<boolean> => withGuestTimetableWriteLock(() => {
+  if (canRemove && !canRemove()) return false
+
+  const storage = getGuestTimetable()
+  const currentItems = storage.semesters[semester] ?? []
+  const nextItems = currentItems.filter((item) => item.course.id !== courseId)
+
+  if (nextItems.length === currentItems.length) return false
+
+  const nextSemesters = { ...storage.semesters }
+  if (nextItems.length === 0) {
+    delete nextSemesters[semester]
+  } else {
+    nextSemesters[semester] = nextItems
+  }
+
+  writeGuestTimetable({ ...storage, semesters: nextSemesters })
+
+  return true
+})
+
+export const clearGuestSemester = (
+  semester: string,
+  expectedCourseIds: readonly number[],
+): Promise<GuestTimetableClearResult> => withGuestTimetableWriteLock(() => {
+  const storage = getGuestTimetable()
+  const currentItems = storage.semesters[semester]
+  if (!currentItems || currentItems.length === 0) return 'already-empty'
+
+  const expectedCourseIdSet = new Set(expectedCourseIds)
+  const snapshotMatches = currentItems.length === expectedCourseIdSet.size
+    && currentItems.every((item) => expectedCourseIdSet.has(item.course.id))
+  if (!snapshotMatches) return 'changed'
+
+  const nextSemesters = { ...storage.semesters }
+  delete nextSemesters[semester]
+  writeGuestTimetable({ ...storage, semesters: nextSemesters })
+  return 'cleared'
+})
+
+export const clearGuestTimetable = (
+  expectedStorage: GuestTimetableStorage,
+): Promise<GuestTimetableClearResult> => withGuestTimetableWriteLock(() => {
+  if (typeof window === 'undefined') {
+    throw new GuestTimetableStorageError(
+      'REMOVE_FAILED',
+      '目前環境無法清除本機課表。',
+    )
+  }
+
+  const currentStorage = getGuestTimetable()
+  const hasCurrentCourses = Object.values(currentStorage.semesters)
+    .some((items) => items.length > 0)
+  if (!hasCurrentCourses) return 'already-empty'
+
+  if (!haveSameGuestTimetableCourses(expectedStorage, currentStorage)) {
+    return 'changed'
+  }
+
+  try {
+    window.localStorage.removeItem(GUEST_TIMETABLE_STORAGE_KEY)
+  } catch (error) {
+    throw new GuestTimetableStorageError(
+      'REMOVE_FAILED',
+      '無法清除本機課表，請確認瀏覽器是否允許使用本機儲存空間。',
+      error,
+    )
+  }
+
+  dispatchGuestTimetableChange()
+  return 'cleared'
+})
+
+export const swapGuestCourse = (
+  item: GuestTimetableItem,
+  conflictCourseIds: readonly number[],
+): Promise<SwapGuestCourseResult> => {
+  assertValidGuestTimetableItem(item)
+
+  return withGuestTimetableWriteLock(() => {
+    const storage = getGuestTimetable()
+    const semester = item.course.semester
+    const currentItems = storage.semesters[semester] ?? []
+    const alreadyExists = currentItems.some(
+      (currentItem) => currentItem.course.id === item.course.id,
+    )
+
+    if (alreadyExists) {
+      return {
+        added: false,
+        alreadyExists: true,
+        conflictCourseIds: [],
+        removedCourseIds: [],
+      }
+    }
+
+    const latestConflictCourseIds = findConflictCourseIds(item, currentItems)
+    const latestConflictCourseIdSet = new Set(latestConflictCourseIds)
+    const confirmedConflictCourseIdSet = new Set(
+      conflictCourseIds.filter((courseId) => courseId !== item.course.id),
+    )
+    const conflictsChanged = latestConflictCourseIdSet.size !== confirmedConflictCourseIdSet.size
+      || [...latestConflictCourseIdSet].some(
+        (courseId) => !confirmedConflictCourseIdSet.has(courseId),
+      )
+
+    if (conflictsChanged) {
+      throw new GuestTimetableStorageError(
+        'CONFLICTS_CHANGED',
+        '本機課表已在其他分頁變更，請重新確認衝堂課程。',
+      )
+    }
+
+    const conflictCourseIdSet = latestConflictCourseIdSet
+    const removedCourseIds = Array.from(new Set(
+      currentItems
+        .filter((currentItem) => conflictCourseIdSet.has(currentItem.course.id))
+        .map((currentItem) => currentItem.course.id),
+    ))
+    const nextItems = currentItems.filter(
+      (currentItem) => !conflictCourseIdSet.has(currentItem.course.id),
+    )
+
+    writeGuestTimetable({
+      ...storage,
+      semesters: {
+        ...storage.semesters,
+        [semester]: [...nextItems, item],
+      },
+    })
+
+    return {
+      added: true,
+      alreadyExists: false,
+      conflictCourseIds: [],
+      removedCourseIds,
+    }
+  })
 }
 
 export const subscribeGuestTimetable = (listener: () => void): (() => void) => {

--- a/frontend/src/utils/timetable.ts
+++ b/frontend/src/utils/timetable.ts
@@ -1,0 +1,228 @@
+import type {
+  TimetableConflict,
+  TimetableCourse,
+  TimetableGrid,
+  TimetableItem,
+  Timeslot,
+} from '../types/timetableType'
+
+export const EWANT_DEPARTMENT = '校外遠距(EWANT)'
+
+export const TIMETABLE_PERIOD_ORDER = [
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  'A',
+  'B',
+  'C',
+  'D',
+  'E',
+  'F',
+  'G',
+] as const
+
+export type TimetablePeriod = (typeof TIMETABLE_PERIOD_ORDER)[number]
+
+export type OccupiedPeriod = {
+  dayOfWeek: number
+  period: TimetablePeriod
+}
+
+export const TIMETABLE_PERIOD_TIME_RANGES: Record<
+  TimetablePeriod,
+  { startMin: number; endMin: number }
+> = {
+  '1': { startMin: 430, endMin: 480 },
+  '2': { startMin: 480, endMin: 530 },
+  '3': { startMin: 540, endMin: 590 },
+  '4': { startMin: 600, endMin: 650 },
+  '5': { startMin: 660, endMin: 710 },
+  '6': { startMin: 720, endMin: 770 },
+  '7': { startMin: 780, endMin: 830 },
+  '8': { startMin: 840, endMin: 890 },
+  '9': { startMin: 900, endMin: 950 },
+  A: { startMin: 960, endMin: 1010 },
+  B: { startMin: 1020, endMin: 1070 },
+  C: { startMin: 1110, endMin: 1160 },
+  D: { startMin: 1160, endMin: 1210 },
+  E: { startMin: 1210, endMin: 1260 },
+  F: { startMin: 1260, endMin: 1310 },
+  G: { startMin: 1310, endMin: 1360 },
+}
+
+const timetablePeriodSet = new Set<string>(TIMETABLE_PERIOD_ORDER)
+const timetablePeriodIndexMap = new Map<string, number>(
+  TIMETABLE_PERIOD_ORDER.map((period, index) => [period, index]),
+)
+
+export const isTimetablePeriod = (value: unknown): value is TimetablePeriod =>
+  typeof value === 'string' && timetablePeriodSet.has(value)
+
+export const isValidDayOfWeek = (value: unknown): value is number =>
+  Number.isInteger(value) && Number(value) >= 1 && Number(value) <= 7
+
+export const getPeriodsInRange = (
+  startPeriod: string,
+  endPeriod: string,
+): TimetablePeriod[] => {
+  const startIndex = timetablePeriodIndexMap.get(startPeriod)
+  const endIndex = timetablePeriodIndexMap.get(endPeriod)
+
+  if (startIndex === undefined || endIndex === undefined || endIndex < startIndex) {
+    return []
+  }
+
+  return TIMETABLE_PERIOD_ORDER.slice(startIndex, endIndex + 1)
+}
+
+export const getOccupiedPeriods = (
+  item: Pick<TimetableItem, 'timeslots'>,
+): OccupiedPeriod[] => {
+  const occupiedPeriods: OccupiedPeriod[] = []
+  const occupiedPeriodKeys = new Set<string>()
+
+  item.timeslots.forEach((timeslot) => {
+    if (!isValidDayOfWeek(timeslot.dayOfWeek)) return
+
+    getPeriodsInRange(timeslot.startPeriod, timeslot.endPeriod).forEach((period) => {
+      const key = `${timeslot.dayOfWeek}:${period}`
+      if (occupiedPeriodKeys.has(key)) return
+
+      occupiedPeriodKeys.add(key)
+      occupiedPeriods.push({ dayOfWeek: timeslot.dayOfWeek, period })
+    })
+  })
+
+  return occupiedPeriods
+}
+
+export const isEwantCourse = (
+  course: Pick<TimetableCourse, 'department'>,
+): boolean => course.department === EWANT_DEPARTMENT
+
+export const buildTimetableGrid = (
+  items: readonly TimetableItem[],
+): TimetableGrid => {
+  const grid = Object.fromEntries(
+    TIMETABLE_PERIOD_ORDER.map((period) => [period, {}]),
+  ) as TimetableGrid
+
+  items.forEach((item) => {
+    if (isEwantCourse(item.course)) return
+
+    getOccupiedPeriods(item).forEach(({ dayOfWeek, period }) => {
+      const currentCourses = grid[period][dayOfWeek] ?? []
+      currentCourses.push({
+        courseId: item.course.id,
+        courseName: item.course.name,
+        instructor: item.course.instructor,
+        room: item.course.room,
+      })
+      grid[period][dayOfWeek] = currentCourses
+    })
+  })
+
+  return grid
+}
+
+export const hasTimeslotOverlap = (first: Timeslot, second: Timeslot): boolean =>
+  first.dayOfWeek === second.dayOfWeek
+  && first.startMin < second.endMin
+  && second.startMin < first.endMin
+
+const buildTimetableConflict = (
+  courseId: number,
+  conflictWithCourseId: number,
+  candidateTimeslot: Timeslot,
+  existingTimeslot: Timeslot,
+): TimetableConflict => {
+  const overlapStart = Math.max(candidateTimeslot.startMin, existingTimeslot.startMin)
+  const overlapEnd = Math.min(candidateTimeslot.endMin, existingTimeslot.endMin)
+  const overlapStartPeriod = candidateTimeslot.startMin >= existingTimeslot.startMin
+    ? candidateTimeslot.startPeriod
+    : existingTimeslot.startPeriod
+  const overlapEndPeriod = candidateTimeslot.endMin <= existingTimeslot.endMin
+    ? candidateTimeslot.endPeriod
+    : existingTimeslot.endPeriod
+
+  return {
+    courseId,
+    conflictWithCourseId,
+    dayOfWeek: candidateTimeslot.dayOfWeek,
+    overlap: {
+      startMin: overlapStart,
+      endMin: overlapEnd,
+      startPeriod: overlapStartPeriod,
+      endPeriod: overlapEndPeriod,
+    },
+  }
+}
+
+export const findTimetableConflicts = (
+  candidate: TimetableItem,
+  existingItems: readonly TimetableItem[],
+): TimetableConflict[] => {
+  if (isEwantCourse(candidate.course) || candidate.timeslots.length === 0) {
+    return []
+  }
+
+  const conflicts: TimetableConflict[] = []
+
+  existingItems.forEach((existingItem) => {
+    if (
+      existingItem.course.id === candidate.course.id
+      || existingItem.course.semester !== candidate.course.semester
+      || isEwantCourse(existingItem.course)
+      || existingItem.timeslots.length === 0
+    ) {
+      return
+    }
+
+    candidate.timeslots.forEach((candidateTimeslot) => {
+      existingItem.timeslots.forEach((existingTimeslot) => {
+        if (!hasTimeslotOverlap(candidateTimeslot, existingTimeslot)) return
+
+        conflicts.push(buildTimetableConflict(
+          candidate.course.id,
+          existingItem.course.id,
+          candidateTimeslot,
+          existingTimeslot,
+        ))
+      })
+    })
+  })
+
+  return conflicts
+}
+
+export const getConflictCourseIds = (
+  conflicts: readonly TimetableConflict[],
+): number[] => Array.from(new Set(conflicts.map((conflict) => conflict.conflictWithCourseId)))
+
+export const findConflictCourseIds = (
+  candidate: TimetableItem,
+  existingItems: readonly TimetableItem[],
+): number[] => getConflictCourseIds(findTimetableConflicts(candidate, existingItems))
+
+export const getMissingTimeslotItems = <T extends TimetableItem>(
+  items: readonly T[],
+): T[] => items.filter(
+  (item) => !isEwantCourse(item.course) && item.timeslots.length === 0,
+)
+
+export const countMissingTimeslotCourses = (
+  items: readonly TimetableItem[],
+): number => getMissingTimeslotItems(items).length
+
+export const hasWeekendCourses = (
+  items: readonly TimetableItem[],
+): boolean => items.some(
+  (item) => !isEwantCourse(item.course)
+    && item.timeslots.some((timeslot) => timeslot.dayOfWeek === 6 || timeslot.dayOfWeek === 7),
+)


### PR DESCRIPTION
## 標題

建立訪客課表本機儲存與安全 mutation

---

## 摘要

加入共用課表時段工具、訪客課表 localStorage schema、衝堂檢查與具 CAS 語意的本機操作 hook。

---

## 背景／問題

訪客需要在未登入時規劃課表，同時避免多分頁或過期 snapshot 靜默覆寫較新的本機資料。

---

## 變更內容

- 新增共用課表時段與衝堂運算工具。
- 驗證並正規化 localStorage snapshot。
- 序列化新增、交換、移除與清除操作。
- 提供 reactive guest timetable hook 與跨分頁同步。

---

## 測試方式

- Frontend：`npm run build`
- Frontend：`npm run lint`
- Guest storage smoke test
- `git diff --check`

---

## 備註

- 此為 feature integration PR 2/6。
- Base：`feat/guest-timetable`
- Head：`feat/guest-timetable-storage`
- #70 已先合併完成；目前 PR diff 僅包含 guest storage 的 4 commits／4 個檔案。