### PR TITLE
修正課程篩選選項與瀏覽歷史同步

### DIFF
--- a/backend/controllers/courseController.ts
+++ b/backend/controllers/courseController.ts
@@ -1,6 +1,7 @@
 import CourseService from "../services/courseService";
 import CourseViewService from "../services/courseViewService";
 import { RequestHandler } from "express";
+import { PERIOD_ORDER } from "../utils/courseSchedule";
 
 const getQueryValues = (value: unknown): string[] => {
   if (value === undefined || value === null || value === "") return [];
@@ -18,21 +19,27 @@ export const getAllCourses: RequestHandler = async (
   res
 ): Promise<void> => {
   try {
-    const page = parseInt(req.query.page as string) || 1;
-    const limit = parseInt(req.query.limit as string) || 15;
+    const page = Math.max(parseInt(req.query.page as string) || 1, 1);
+    const limit = Math.min(Math.max(parseInt(req.query.limit as string) || 15, 1), 100);
     const offset = (page - 1) * limit;
-    const weekdays = String(req.query.weekdays || "")
-      .split(",")
-      .map((item) => parseInt(item.trim(), 10))
-      .filter((value) => !Number.isNaN(value) && value >= 1 && value <= 7);
-    const periods = String(req.query.periods || "")
-      .split(",")
-      .map((item) => item.trim().toUpperCase())
-      .filter((value) => Boolean(value));
+    const weekdayValues = getQueryValues(req.query.weekdays);
+    if (weekdayValues.some((value) => !/^[1-7]$/.test(value))) {
+      res.status(400).json({ message: "星期篩選格式錯誤，weekdays 僅接受 1 至 7。" });
+      return;
+    }
+    const weekdays = weekdayValues.map(Number);
+
+    const allowedPeriods = new Set(PERIOD_ORDER);
+    const periods = getQueryValues(req.query.periods).map((value) => value.toUpperCase());
+    if (periods.some((period) => !allowedPeriods.has(period))) {
+      res.status(400).json({ message: "節次篩選格式錯誤，periods 僅接受 1 至 9 或 A 至 G。" });
+      return;
+    }
     const semesters = String(req.query.semesters || "")
       .split(",")
       .map((item) => item.trim())
       .filter((value) => Boolean(value));
+    const includeTimeslots = req.query.includeTimeslots === "true";
 
     const search = {
       search: String(req.query.search || ""),
@@ -46,12 +53,10 @@ export const getAllCourses: RequestHandler = async (
       sortBy: String(req.query.sortBy || "")
     };
 
-    const { courses, total } = await CourseService.getAllCourses({
-      page,
-      limit,
-      offset,
-      search,
-    });
+    const courseResult = includeTimeslots
+      ? await CourseService.getAllCourses({ page, limit, offset, search }, true)
+      : await CourseService.getAllCourses({ page, limit, offset, search });
+    const { courses, total } = courseResult;
     res.status(200).json({
       courses,
       pagination: {

--- a/backend/controllers/courseController.ts
+++ b/backend/controllers/courseController.ts
@@ -2,6 +2,17 @@ import CourseService from "../services/courseService";
 import CourseViewService from "../services/courseViewService";
 import { RequestHandler } from "express";
 
+const getQueryValues = (value: unknown): string[] => {
+  if (value === undefined || value === null || value === "") return [];
+  return String(value).split(",").map((item) => item.trim());
+};
+
+const getCourseOptionFilters = (query: Record<string, unknown>) => ({
+  category: String(query.category || "") || undefined,
+  academy: String(query.academy || "") || undefined,
+  semesters: getQueryValues(query.semester ?? query.semesters).filter(Boolean),
+});
+
 export const getAllCourses: RequestHandler = async (
   req,
   res
@@ -60,7 +71,7 @@ export const getAllDepartments: RequestHandler = async (
   res
 ): Promise<void> => {
   try {
-    const departments = await CourseService.getAllDepartments();
+    const departments = await CourseService.getAllDepartments(getCourseOptionFilters(req.query));
     res.status(200).json({ departments });
   } catch (err) {
     res.status(500).json({ message: err });
@@ -72,7 +83,7 @@ export const getAllAcademies: RequestHandler = async (
   res
 ): Promise<void> => {
   try {
-    const academies = await CourseService.getAllAcademies();
+    const academies = await CourseService.getAllAcademies(getCourseOptionFilters(req.query));
     res.status(200).json({ academies });
   } catch (err) {
     res.status(500).json({ message: err });

--- a/backend/controllers/timetableController.ts
+++ b/backend/controllers/timetableController.ts
@@ -1,6 +1,20 @@
 ﻿import { RequestHandler, Response } from "express";
 import TimetableService, { TimetableServiceError } from "../services/timetableService";
 
+const parsePositiveSafeInteger = (value: unknown): number | null => {
+  if (
+    (typeof value !== "string" && typeof value !== "number")
+    || String(value).trim() === ""
+  ) {
+    return null;
+  }
+
+  const parsedValue = Number(value);
+  return Number.isSafeInteger(parsedValue) && parsedValue > 0
+    ? parsedValue
+    : null;
+};
+
 const handleTimetableError = (res: Response, err: unknown): void => {
   if (err instanceof TimetableServiceError) {
     res.status(err.status).json({
@@ -51,9 +65,9 @@ export const addTimetableCourse: RequestHandler = async (req, res): Promise<void
       return;
     }
 
-    const timetableId = parseInt(req.params.timetableId);
-    const courseId = Number(req.body?.courseId);
-    if (Number.isNaN(timetableId) || Number.isNaN(courseId)) {
+    const timetableId = parsePositiveSafeInteger(req.params.timetableId);
+    const courseId = parsePositiveSafeInteger(req.body?.courseId);
+    if (timetableId === null || courseId === null) {
       res.status(400).json({ message: "參數格式錯誤" });
       return;
     }
@@ -80,8 +94,8 @@ export const batchAddTimetableFromInterests: RequestHandler = async (req, res): 
       return;
     }
 
-    const timetableId = parseInt(req.params.timetableId);
-    if (Number.isNaN(timetableId)) {
+    const timetableId = parsePositiveSafeInteger(req.params.timetableId);
+    if (timetableId === null) {
       res.status(400).json({ message: "參數格式錯誤" });
       return;
     }
@@ -123,9 +137,9 @@ export const removeTimetableCourse: RequestHandler = async (req, res): Promise<v
       return;
     }
 
-    const timetableId = parseInt(req.params.timetableId);
-    const courseId = parseInt(req.params.courseId);
-    if (Number.isNaN(timetableId) || Number.isNaN(courseId)) {
+    const timetableId = parsePositiveSafeInteger(req.params.timetableId);
+    const courseId = parsePositiveSafeInteger(req.params.courseId);
+    if (timetableId === null || courseId === null) {
       res.status(400).json({ message: "參數格式錯誤" });
       return;
     }

--- a/backend/controllers/timetableController.ts
+++ b/backend/controllers/timetableController.ts
@@ -115,14 +115,40 @@ export const swapTimetableCourse: RequestHandler = async (req, res): Promise<voi
       return;
     }
 
-    const timetableId = parseInt(req.params.timetableId);
-    const courseId = Number(req.body?.courseId);
-    if (Number.isNaN(timetableId) || Number.isNaN(courseId)) {
-      res.status(400).json({ message: "參數格式錯誤" });
+    const timetableId = parsePositiveSafeInteger(req.params.timetableId);
+    const courseId = parsePositiveSafeInteger(req.body?.courseId);
+    const rawConflictCourseIds = req.body?.conflictCourseIds;
+    if (rawConflictCourseIds === undefined) {
+      res.status(409).json({
+        code: "CLIENT_UPDATE_REQUIRED",
+        message: "課表交換功能已更新，請重新整理頁面後再試",
+      });
       return;
     }
 
-    const result = await TimetableService.swapCourse(timetableId, user_id, courseId);
+    const parsedConflictCourseIds = Array.isArray(rawConflictCourseIds)
+      ? rawConflictCourseIds.map(parsePositiveSafeInteger)
+      : [];
+    const hasInvalidConflictCourseIds = !Array.isArray(rawConflictCourseIds)
+      || parsedConflictCourseIds.some((value) => value === null);
+    if (
+      timetableId === null
+      || courseId === null
+      || hasInvalidConflictCourseIds
+    ) {
+      res.status(400).json({ message: "參數格式錯誤" });
+      return;
+    }
+    const conflictCourseIds = parsedConflictCourseIds.filter(
+      (value): value is number => value !== null
+    );
+
+    const result = await TimetableService.swapCourse(
+      timetableId,
+      user_id,
+      courseId,
+      conflictCourseIds
+    );
     res.status(200).json(result);
   } catch (err) {
     handleTimetableError(res, err);

--- a/backend/repositories/courseRepository.ts
+++ b/backend/repositories/courseRepository.ts
@@ -133,6 +133,7 @@ class CourseRepository {
       order.push(["interests_count", "desc"]);
     }
     order.push(["created_at", "desc"]);
+    order.push(["id", "desc"]);
 
     const [courses, total] = await Promise.all([
       CourseModel.findAll({ where: whereCondition, limit, offset, order }),

--- a/backend/repositories/courseRepository.ts
+++ b/backend/repositories/courseRepository.ts
@@ -107,7 +107,7 @@ class CourseRepository {
     limit,
     offset,
     search,
-  }: PaginationParams): Promise<{ courses: Course[]; total: number }> {
+  }: PaginationParams): Promise<{ courses: CourseModel[]; total: number }> {
     const whereCondition: any = {};
     if (search && search.search) {
       whereCondition[Op.or] = [

--- a/backend/repositories/courseRepository.ts
+++ b/backend/repositories/courseRepository.ts
@@ -3,9 +3,12 @@ import CourseModel from "../models/Course";
 import CourseScheduleModel from "../models/CourseSchedule";
 import { Course, CourseOptionFilters, PaginationParams } from "../types/course";
 import db from "../models";
+import {
+  EWANT_DEPARTMENT,
+  normalizeCourseSchedule,
+  PERIOD_ORDER,
+} from "../utils/courseSchedule";
 
-const EWANT_DEPARTMENT = "校外遠距(EWANT)";
-const PERIOD_ORDER = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G"] as const;
 const PERIOD_INDEX_MAP = PERIOD_ORDER.reduce<Record<string, number>>((acc, period, index) => {
   acc[period] = index;
   return acc;
@@ -78,16 +81,16 @@ class CourseRepository {
 
     const matchedCourseIds = new Set<number>();
     scheduleRows.forEach((row) => {
-      const startIndex = PERIOD_INDEX_MAP[row.start_period as string];
-      if (typeof startIndex !== "number") return;
+      const normalizedSchedule = normalizeCourseSchedule(row);
+      if (!normalizedSchedule) return;
 
       if (selectedPeriods.size === 0) {
         matchedCourseIds.add(Number(row.course_id));
         return;
       }
 
-      const span = Math.max(Number(row.span) || 1, 1);
-      const endIndex = startIndex + span - 1;
+      const startIndex = PERIOD_INDEX_MAP[normalizedSchedule.startPeriod];
+      const endIndex = PERIOD_INDEX_MAP[normalizedSchedule.endPeriod];
       for (let index = startIndex; index <= endIndex; index += 1) {
         const period = PERIOD_ORDER[index];
         if (period && selectedPeriods.has(period)) {

--- a/backend/repositories/courseRepository.ts
+++ b/backend/repositories/courseRepository.ts
@@ -1,17 +1,63 @@
 import { Op, Transaction } from "sequelize";
 import CourseModel from "../models/Course";
 import CourseScheduleModel from "../models/CourseSchedule";
-import { Course } from "../types/course";
-import { PaginationParams } from "../types/course";
+import { Course, CourseOptionFilters, PaginationParams } from "../types/course";
 import db from "../models";
 
+const EWANT_DEPARTMENT = "校外遠距(EWANT)";
 const PERIOD_ORDER = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G"] as const;
 const PERIOD_INDEX_MAP = PERIOD_ORDER.reduce<Record<string, number>>((acc, period, index) => {
   acc[period] = index;
   return acc;
 }, {});
 
+const getCategoryConditions = (category?: string): any[] => {
+  if (category === "general") {
+    return [{ department: { [Op.like]: "%通識%" } }];
+  }
+  if (category === "university") {
+    return [{
+      [Op.and]: [
+        { department: { [Op.notLike]: "%碩士%" } },
+        { department: { [Op.notLike]: "%通識%" } },
+        { department: { [Op.notLike]: EWANT_DEPARTMENT } },
+      ],
+    }];
+  }
+  if (category === "graduate") {
+    return [{ department: { [Op.like]: "%碩士%" } }];
+  }
+  if (category === "teacher") {
+    return [{ department: { [Op.like]: "%師%" } }];
+  }
+  if (category === "ewant") {
+    return [{ department: EWANT_DEPARTMENT }];
+  }
+  return [];
+};
+
 class CourseRepository {
+  private getCourseOptionWhere = (
+    filters: CourseOptionFilters,
+    excludeEwantWhenUnfiltered = false
+  ): any => {
+    const whereCondition: any = {};
+    const categoryConditions = getCategoryConditions(filters.category);
+
+    if (excludeEwantWhenUnfiltered && (!filters.category || filters.category === "all")) {
+      categoryConditions.push({ department: { [Op.ne]: EWANT_DEPARTMENT } });
+    }
+    if (categoryConditions.length > 0) {
+      whereCondition[Op.and] = categoryConditions;
+    }
+    if (filters.academy) whereCondition.academy = filters.academy;
+    if (filters.semesters && filters.semesters.length > 0) {
+      whereCondition.semester = { [Op.in]: filters.semesters };
+    }
+
+    return whereCondition;
+  };
+
   private getFilteredCourseIdsBySchedule = async (
     weekdays: number[],
     periods: string[]
@@ -68,25 +114,7 @@ class CourseRepository {
     }
 
     // category(tab選項)filter與department有關
-    const categoryConditions: any[] = [];
-    if (search && search.category === "general") {
-      categoryConditions.push({ department: { [Op.like]: "%通識%" } });
-    } else if (search && search.category === "university") {
-      categoryConditions.push({
-        [Op.and]: [
-          { department: { [Op.notLike]: "%碩士%" } },
-          { department: { [Op.notLike]: "%通識%" } },
-          { department: { [Op.notLike]: "校外遠距(EWANT)" } },
-        ]
-      });
-    } else if (search && search.category === "graduate") {
-      categoryConditions.push({ department: { [Op.like]: "%碩士%" } });
-    } else if (search && search.category === "teacher") {
-      categoryConditions.push({ department: { [Op.like]: "%師%" } });
-    }
-    if (search && search.category === "ewant") {
-      categoryConditions.push({ department: "校外遠距(EWANT)" });
-    }
+    const categoryConditions = getCategoryConditions(search?.category);
     if (search && search.department) {
       categoryConditions.push({ department: search.department });
     }
@@ -153,14 +181,10 @@ class CourseRepository {
     return await CourseModel.count();
   }
 
-  async getAllDepartments(): Promise<string[]> {
+  async getAllDepartments(filters: CourseOptionFilters = {}): Promise<string[]> {
     const departments = await CourseModel.findAll({
       attributes: [[db.Sequelize.fn("DISTINCT", db.Sequelize.col("department")), "department"]],
-      where: {
-        department: {
-          [Op.ne]: "校外遠距(EWANT)",
-        },
-      },
+      where: this.getCourseOptionWhere(filters, true),
       raw: true
     });
     const departmentList = departments.map((item: { department: string }) => {
@@ -169,9 +193,10 @@ class CourseRepository {
     return departmentList;
   }
 
-  async getAllAcademies(): Promise<string[]> {
+  async getAllAcademies(filters: CourseOptionFilters = {}): Promise<string[]> {
     const academies = await CourseModel.findAll({
       attributes: [[db.Sequelize.fn("DISTINCT", db.Sequelize.col("academy")), "academy"]],
+      where: this.getCourseOptionWhere(filters, true),
       raw: true
     });
     const academyList = academies

--- a/backend/repositories/courseScheduleRepository.ts
+++ b/backend/repositories/courseScheduleRepository.ts
@@ -1,4 +1,5 @@
 import CourseScheduleModel from "../models/CourseSchedule";
+import { Transaction } from "sequelize";
 
 class CourseScheduleRepository {
   async getByCourseId(course_id: number): Promise<CourseScheduleModel[]> {
@@ -8,10 +9,14 @@ class CourseScheduleRepository {
     });
   }
 
-  async getByCourseIds(courseIds: number[]): Promise<CourseScheduleModel[]> {
+  async getByCourseIds(
+    courseIds: number[],
+    transaction?: Transaction
+  ): Promise<CourseScheduleModel[]> {
     if (courseIds.length === 0) return [];
     return await CourseScheduleModel.findAll({
       where: { course_id: courseIds },
+      transaction,
       order: [["course_id", "ASC"], ["day", "ASC"], ["start_period", "ASC"]],
     });
   }

--- a/backend/repositories/interestRepository.ts
+++ b/backend/repositories/interestRepository.ts
@@ -46,17 +46,28 @@ class InterestRepository {
     })
   }
 
-  async getAllInterestsByUserId(user_id: number): Promise<AllInterestsResponse[]> {
+  async getAllInterestsByUserId(
+    user_id: number,
+    transaction?: Transaction
+  ): Promise<AllInterestsResponse[]> {
     const interests = await InterestModel.findAll({
       where: { user_id },
       attributes: ["id", "course_id", "created_at"],
+      transaction,
       order: [["created_at", "DESC"]],
       include: [
         {
           model: CourseModel,
           as: "course",
           required: true,
-          attributes: ["id", "semester", "course_name", "instructor"],
+          attributes: [
+            "id",
+            "semester",
+            "course_name",
+            "department",
+            "instructor",
+            "course_room",
+          ],
         },
       ],
     });

--- a/backend/repositories/timetableRepository.ts
+++ b/backend/repositories/timetableRepository.ts
@@ -30,12 +30,6 @@ class TimetableRepository {
     }
   }
 
-  async findByIdAndUser(id: number, user_id: number): Promise<TimetableModel | null> {
-    return await TimetableModel.findOne({
-      where: { id, user_id },
-    });
-  }
-
   async findByIdAndUserForUpdate(
     id: number,
     user_id: number,

--- a/backend/repositories/timetableRepository.ts
+++ b/backend/repositories/timetableRepository.ts
@@ -1,5 +1,5 @@
 import TimetableModel from "../models/Timetable";
-import { UniqueConstraintError } from "sequelize";
+import { Transaction, UniqueConstraintError } from "sequelize";
 
 class TimetableRepository {
   async findByUserAndSemester(user_id: number, semester: string): Promise<TimetableModel | null> {
@@ -33,6 +33,18 @@ class TimetableRepository {
   async findByIdAndUser(id: number, user_id: number): Promise<TimetableModel | null> {
     return await TimetableModel.findOne({
       where: { id, user_id },
+    });
+  }
+
+  async findByIdAndUserForUpdate(
+    id: number,
+    user_id: number,
+    transaction: Transaction
+  ): Promise<TimetableModel | null> {
+    return await TimetableModel.findOne({
+      where: { id, user_id },
+      transaction,
+      lock: transaction.LOCK.UPDATE,
     });
   }
 }

--- a/backend/services/courseService.ts
+++ b/backend/services/courseService.ts
@@ -1,4 +1,4 @@
-import { Course, CourseDetailResponse } from "../types/course";
+import { Course, CourseDetailResponse, CourseOptionFilters } from "../types/course";
 import { PaginationParams } from "../types/course";
 import CourseRepository from "../repositories/courseRepository";
 import InterestRepository from "../repositories/interestRepository";
@@ -24,12 +24,12 @@ class CourseService {
     return { course, hasUserAddInterest, related_posts };
   }
 
-  async getAllDepartments(): Promise<string[]>{
-    return await CourseRepository.getAllDepartments();
+  async getAllDepartments(filters: CourseOptionFilters = {}): Promise<string[]>{
+    return await CourseRepository.getAllDepartments(filters);
   }
 
-  async getAllAcademies(): Promise<string[]>{
-    return await CourseRepository.getAllAcademies();
+  async getAllAcademies(filters: CourseOptionFilters = {}): Promise<string[]>{
+    return await CourseRepository.getAllAcademies(filters);
   }
 
   async getAllSemesters(): Promise<string[]>{

--- a/backend/services/courseService.ts
+++ b/backend/services/courseService.ts
@@ -1,12 +1,56 @@
-import { Course, CourseDetailResponse, CourseOptionFilters } from "../types/course";
+import {
+  Course,
+  CourseDetailResponse,
+  CourseListResult,
+  CourseOptionFilters,
+  CourseWithTimeslots,
+} from "../types/course";
 import { PaginationParams } from "../types/course";
 import CourseRepository from "../repositories/courseRepository";
+import CourseScheduleRepository from "../repositories/courseScheduleRepository";
 import InterestRepository from "../repositories/interestRepository";
 import CourseRelatedPostService from "./courseRelatedPostService";
+import {
+  isEwantDepartment,
+  normalizeCourseSchedule,
+  normalizeCourseSchedules,
+} from "../utils/courseSchedule";
 
 class CourseService {
-  async getAllCourses(params: PaginationParams): Promise<{ courses: Course[], total: number }> {
-    return await CourseRepository.getAllCourses(params);
+  async getAllCourses(params: PaginationParams): Promise<CourseListResult>;
+  async getAllCourses(params: PaginationParams, includeTimeslots: false): Promise<CourseListResult>;
+  async getAllCourses(params: PaginationParams, includeTimeslots: true): Promise<CourseListResult<CourseWithTimeslots>>;
+  async getAllCourses(
+    params: PaginationParams,
+    includeTimeslots = false
+  ): Promise<CourseListResult<Course | CourseWithTimeslots>> {
+    const result = await CourseRepository.getAllCourses(params);
+    if (!includeTimeslots) return result;
+
+    const courseIds = result.courses.map((course) => course.id);
+    const schedules = await CourseScheduleRepository.getByCourseIds(courseIds);
+    const timeslotsByCourseId = schedules.reduce<Map<number, CourseWithTimeslots["timeslots"]>>(
+      (map, schedule) => {
+        const normalized = normalizeCourseSchedule(schedule);
+        if (!normalized) return map;
+
+        const current = map.get(schedule.course_id) ?? [];
+        current.push(normalized);
+        map.set(schedule.course_id, current);
+        return map;
+      },
+      new Map()
+    );
+
+    return {
+      ...result,
+      courses: result.courses.map((course) => ({
+        ...(course.toJSON() as Course),
+        timeslots: isEwantDepartment(course.department)
+          ? []
+          : timeslotsByCourseId.get(course.id) ?? [],
+      })),
+    };
   }
 
   async getCourse(user_id: number|undefined, course_id: number): Promise<CourseDetailResponse | null>{
@@ -19,9 +63,15 @@ class CourseService {
       if(interest !== null) hasUserAddInterest = true;
     };
 
-    const related_posts = await CourseRelatedPostService.getByCourseId(course_id);
+    const [related_posts, schedules] = await Promise.all([
+      CourseRelatedPostService.getByCourseId(course_id),
+      CourseScheduleRepository.getByCourseId(course_id),
+    ]);
+    const timeslots = isEwantDepartment(course.department)
+      ? []
+      : normalizeCourseSchedules(schedules);
 
-    return { course, hasUserAddInterest, related_posts };
+    return { course, timeslots, hasUserAddInterest, related_posts };
   }
 
   async getAllDepartments(filters: CourseOptionFilters = {}): Promise<string[]>{

--- a/backend/services/timetableService.ts
+++ b/backend/services/timetableService.ts
@@ -13,6 +13,12 @@ import {
   TimetableItemResponse,
   TimetableResponse,
 } from "../types/timetable";
+import {
+  buildTimetableConflict,
+  hasTimeslotOverlap,
+  isEwantDepartment,
+  normalizeCourseSchedule,
+} from "../utils/courseSchedule";
 
 type CourseMeta = {
   id: number;
@@ -26,83 +32,6 @@ type CourseMeta = {
 type CourseWithTimeslots = {
   course: CourseMeta;
   timeslots: CourseTimeslot[];
-};
-
-const PERIOD_ORDER = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G"];
-const PERIOD_INDEX_MAP = PERIOD_ORDER.reduce<Record<string, number>>((map, period, index) => {
-  map[period] = index;
-  return map;
-}, {});
-const PERIOD_MIN_MAP: Record<string, { start: number; end: number }> = {
-  "1": { start: 430, end: 480 },
-  "2": { start: 480, end: 530 },
-  "3": { start: 540, end: 590 },
-  "4": { start: 600, end: 650 },
-  "5": { start: 660, end: 710 },
-  "6": { start: 720, end: 770 },
-  "7": { start: 780, end: 830 },
-  "8": { start: 840, end: 890 },
-  "9": { start: 900, end: 950 },
-  A: { start: 960, end: 1010 },
-  B: { start: 1020, end: 1070 },
-  C: { start: 1110, end: 1160 },
-  D: { start: 1160, end: 1210 },
-  E: { start: 1210, end: 1260 },
-  F: { start: 1260, end: 1310 },
-  G: { start: 1310, end: 1360 },
-};
-
-const getPeriodByMinute = (minute: number, mode: "start" | "end"): string => {
-  if (mode === "start") {
-    const found = PERIOD_ORDER.find((period) => PERIOD_MIN_MAP[period].start <= minute && minute < PERIOD_MIN_MAP[period].end);
-    return found ?? PERIOD_ORDER[0];
-  }
-
-  const found = [...PERIOD_ORDER].reverse().find((period) => PERIOD_MIN_MAP[period].start < minute && minute <= PERIOD_MIN_MAP[period].end);
-  return found ?? PERIOD_ORDER[PERIOD_ORDER.length - 1];
-};
-
-const normalizeSchedule = (schedule: CourseScheduleModel): CourseTimeslot | null => {
-  const startIndex = PERIOD_INDEX_MAP[schedule.start_period];
-  if (typeof startIndex !== "number") return null;
-
-  const endIndex = startIndex + Math.max(schedule.span, 1) - 1;
-  if (endIndex >= PERIOD_ORDER.length) return null;
-
-  const startPeriod = PERIOD_ORDER[startIndex];
-  const endPeriod = PERIOD_ORDER[endIndex];
-  const startMin = PERIOD_MIN_MAP[startPeriod]?.start;
-  const endMin = PERIOD_MIN_MAP[endPeriod]?.end;
-  if (typeof startMin !== "number" || typeof endMin !== "number") return null;
-
-  return {
-    dayOfWeek: schedule.day,
-    startPeriod,
-    endPeriod,
-    startMin,
-    endMin,
-  };
-};
-
-const hasOverlap = (a: CourseTimeslot, b: CourseTimeslot): boolean => {
-  return a.dayOfWeek === b.dayOfWeek && a.startMin < b.endMin && b.startMin < a.endMin;
-};
-
-const buildConflict = (courseId: number, conflictWithCourseId: number, a: CourseTimeslot, b: CourseTimeslot): TimetableConflict => {
-  const overlapStart = Math.max(a.startMin, b.startMin);
-  const overlapEnd = Math.min(a.endMin, b.endMin);
-
-  return {
-    courseId,
-    conflictWithCourseId,
-    dayOfWeek: a.dayOfWeek,
-    overlap: {
-      startMin: overlapStart,
-      endMin: overlapEnd,
-      startPeriod: getPeriodByMinute(overlapStart, "start"),
-      endPeriod: getPeriodByMinute(overlapEnd, "end"),
-    },
-  };
 };
 
 export class TimetableServiceError extends Error {
@@ -136,10 +65,10 @@ class TimetableService {
     });
 
     schedules.forEach((schedule) => {
-      const normalized = normalizeSchedule(schedule);
-      if (!normalized) return;
       const target = map.get(schedule.course_id);
-      if (!target) return;
+      if (!target || isEwantDepartment(target.course.department)) return;
+      const normalized = normalizeCourseSchedule(schedule);
+      if (!normalized) return;
       target.timeslots.push(normalized);
     });
 
@@ -152,8 +81,8 @@ class TimetableService {
     existingCourses.forEach((existing) => {
       candidate.timeslots.forEach((candidateSlot) => {
         existing.timeslots.forEach((existingSlot) => {
-          if (!hasOverlap(candidateSlot, existingSlot)) return;
-          conflicts.push(buildConflict(candidate.course.id, existing.course.id, candidateSlot, existingSlot));
+          if (!hasTimeslotOverlap(candidateSlot, existingSlot)) return;
+          conflicts.push(buildTimetableConflict(candidate.course.id, existing.course.id, candidateSlot, existingSlot));
         });
       });
     });
@@ -167,7 +96,7 @@ class TimetableService {
     const schedules = await CourseScheduleRepository.getByCourseIds(courseIds);
 
     const scheduleMap = schedules.reduce<Map<number, CourseTimeslot[]>>((map, schedule) => {
-      const normalized = normalizeSchedule(schedule);
+      const normalized = normalizeCourseSchedule(schedule);
       if (!normalized) return map;
 
       const current = map.get(schedule.course_id) ?? [];
@@ -189,7 +118,7 @@ class TimetableService {
           instructor: course.instructor,
           room: course.course_room,
         },
-        timeslots: scheduleMap.get(course.id) ?? [],
+        timeslots: isEwantDepartment(course.department) ? [] : scheduleMap.get(course.id) ?? [],
       };
     });
 
@@ -456,14 +385,18 @@ class TimetableService {
     const items = await TimetableItemRepository.getAllByUserId(userId);
     const courseIds = Array.from(new Set(items.map((item) => item.course_id)));
     const schedules = await CourseScheduleRepository.getByCourseIds(courseIds);
-    const hasTimeslotsSet = new Set(schedules.map((schedule) => schedule.course_id));
+    const hasTimeslotsSet = new Set(
+      schedules
+        .filter((schedule) => normalizeCourseSchedule(schedule) !== null)
+        .map((schedule) => schedule.course_id)
+    );
 
     return items.map((item) => {
       const raw = item.toJSON() as unknown as TimetableItemWithSemesterJson;
       return {
         timetableId: raw.timetable.id,
         semester: raw.timetable.semester,
-        hasTimeslots: hasTimeslotsSet.has(raw.course.id),
+        hasTimeslots: !isEwantDepartment(raw.course.department) && hasTimeslotsSet.has(raw.course.id),
         course: {
           id: raw.course.id,
           name: raw.course.course_name,

--- a/backend/services/timetableService.ts
+++ b/backend/services/timetableService.ts
@@ -46,14 +46,6 @@ export class TimetableServiceError extends Error {
 }
 
 class TimetableService {
-  private async getOrThrowOwnedTimetable(timetableId: number, userId: number) {
-    const timetable = await TimetableRepository.findByIdAndUser(timetableId, userId);
-    if (!timetable) {
-      throw new TimetableServiceError(404, "找不到課表");
-    }
-    return timetable;
-  }
-
   private async getOrThrowLockedTimetable(
     timetableId: number,
     userId: number,
@@ -263,8 +255,12 @@ class TimetableService {
     }
   }
 
-  async swapCourse(timetableId: number, userId: number, courseId: number) {
-    const timetable = await this.getOrThrowOwnedTimetable(timetableId, userId);
+  async swapCourse(
+    timetableId: number,
+    userId: number,
+    courseId: number,
+    expectedConflictCourseIds: number[]
+  ) {
     const course = await CourseRepository.getCourse(courseId);
     if (!course) {
       throw new TimetableServiceError(404, "找不到課程");
@@ -279,58 +275,79 @@ class TimetableService {
       room: course.course_room,
     };
 
-    if (course.semester !== timetable.semester) {
-      throw new TimetableServiceError(409, "只能加入相同學期的課程");
-    }
-
     try {
-      return await db.sequelize.transaction(async (transaction) => {
-        const existingItem = await TimetableItemRepository.findByTimetableAndCourse(timetable.id, course.id, transaction);
-        if (existingItem) {
+      return await db.sequelize.transaction(
+        { isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED },
+        async (transaction) => {
+          const timetable = await this.getOrThrowLockedTimetable(
+            timetableId,
+            userId,
+            transaction
+          );
+          if (course.semester !== timetable.semester) {
+            throw new TimetableServiceError(409, "只能加入相同學期的課程");
+          }
+
+          const timetableItems = await TimetableItemRepository.getAllByTimetableId(timetable.id, transaction);
+          if (timetableItems.some((item) => item.course_id === course.id)) {
+            return {
+              added: false,
+              alreadyExists: true,
+              removedCourseIds: [] as number[],
+            };
+          }
+
+          const existingCourses: CourseMeta[] = timetableItems.map((item) => {
+            const raw = item.toJSON() as unknown as TimetableItemModelJson;
+            return {
+              id: raw.course.id,
+              name: raw.course.course_name,
+              semester: raw.course.semester,
+              department: raw.course.department,
+              instructor: raw.course.instructor,
+              room: raw.course.course_room,
+            };
+          });
+
+          const allCourseIds = [...new Set([...existingCourses.map((item) => item.id), candidateCourse.id])];
+          const schedules = await CourseScheduleRepository.getByCourseIds(
+            allCourseIds,
+            transaction
+          );
+          const allMap = this.toCourseWithTimeslotsMap([candidateCourse, ...existingCourses], schedules);
+          const candidate = allMap.get(candidateCourse.id) ?? { course: candidateCourse, timeslots: [] };
+          const existingWithTimeslots = existingCourses.map((meta) => allMap.get(meta.id) ?? { course: meta, timeslots: [] });
+
+          const conflicts = this.findConflicts(candidate, existingWithTimeslots);
+          const conflictCourseIds = Array.from(new Set(conflicts.map((item) => item.conflictWithCourseId)));
+          const expectedConflictCourseIdSet = new Set(expectedConflictCourseIds);
+          const conflictsChanged = conflictCourseIds.length !== expectedConflictCourseIdSet.size
+            || conflictCourseIds.some((conflictCourseId) => !expectedConflictCourseIdSet.has(conflictCourseId));
+
+          if (conflictsChanged) {
+            throw new TimetableServiceError(
+              409,
+              "課表已在其他分頁變更，請重新確認衝堂課程",
+              { code: "CONFLICTS_CHANGED", conflicts }
+            );
+          }
+
+          for (const conflictCourseId of conflictCourseIds) {
+            await TimetableItemRepository.removeCourse(timetable.id, conflictCourseId, transaction);
+          }
+
+          await TimetableItemRepository.addCourse(timetable.id, course.id, transaction);
+
           return {
-            added: false,
-            alreadyExists: true,
-            removedCourseIds: [] as number[],
+            added: true,
+            alreadyExists: false,
+            removedCourseIds: conflictCourseIds,
           };
         }
-
-        const timetableItems = await TimetableItemRepository.getAllByTimetableId(timetable.id, transaction);
-        const existingCourses: CourseMeta[] = timetableItems.map((item) => {
-          const raw = item.toJSON() as unknown as TimetableItemModelJson;
-          return {
-            id: raw.course.id,
-            name: raw.course.course_name,
-            semester: raw.course.semester,
-            department: raw.course.department,
-            instructor: raw.course.instructor,
-            room: raw.course.course_room,
-          };
-        });
-
-        const allCourseIds = [...new Set([...existingCourses.map((item) => item.id), candidateCourse.id])];
-        const schedules = await CourseScheduleRepository.getByCourseIds(allCourseIds);
-        const allMap = this.toCourseWithTimeslotsMap([candidateCourse, ...existingCourses], schedules);
-        const candidate = allMap.get(candidateCourse.id) ?? { course: candidateCourse, timeslots: [] };
-        const existingWithTimeslots = existingCourses.map((meta) => allMap.get(meta.id) ?? { course: meta, timeslots: [] });
-
-        const conflicts = this.findConflicts(candidate, existingWithTimeslots);
-        const conflictCourseIds = Array.from(new Set(conflicts.map((item) => item.conflictWithCourseId)));
-
-        for (const conflictCourseId of conflictCourseIds) {
-          await TimetableItemRepository.removeCourse(timetable.id, conflictCourseId, transaction);
-        }
-
-        await TimetableItemRepository.addCourse(timetable.id, course.id, transaction);
-
-        return {
-          added: true,
-          alreadyExists: false,
-          removedCourseIds: conflictCourseIds,
-        };
-      });
+      );
     } catch (error) {
       if (error instanceof UniqueConstraintError) {
-        const existingItem = await TimetableItemRepository.findByTimetableAndCourse(timetable.id, course.id);
+        const existingItem = await TimetableItemRepository.findByTimetableAndCourse(timetableId, course.id);
         if (existingItem) {
           return {
             added: false,

--- a/backend/services/timetableService.ts
+++ b/backend/services/timetableService.ts
@@ -5,7 +5,7 @@ import CourseScheduleRepository from "../repositories/courseScheduleRepository";
 import InterestRepository from "../repositories/interestRepository";
 import TimetableItemRepository from "../repositories/timetableItemRepository";
 import TimetableRepository from "../repositories/timetableRepository";
-import { UniqueConstraintError } from "sequelize";
+import { Transaction, UniqueConstraintError } from "sequelize";
 import {
   AddedCourseItemResponse,
   CourseTimeslot,
@@ -48,6 +48,23 @@ export class TimetableServiceError extends Error {
 class TimetableService {
   private async getOrThrowOwnedTimetable(timetableId: number, userId: number) {
     const timetable = await TimetableRepository.findByIdAndUser(timetableId, userId);
+    if (!timetable) {
+      throw new TimetableServiceError(404, "找不到課表");
+    }
+    return timetable;
+  }
+
+  private async getOrThrowLockedTimetable(
+    timetableId: number,
+    userId: number,
+    transaction: Transaction
+  ) {
+    // 以課表主列作為同一份課表的互斥鎖，讓衝堂檢查與寫入不可交錯。
+    const timetable = await TimetableRepository.findByIdAndUserForUpdate(
+      timetableId,
+      userId,
+      transaction
+    );
     if (!timetable) {
       throw new TimetableServiceError(404, "找不到課表");
     }
@@ -142,41 +159,11 @@ class TimetableService {
   }
 
   async addCourse(timetableId: number, userId: number, courseId: number) {
-    const timetable = await this.getOrThrowOwnedTimetable(timetableId, userId);
     const course = await CourseRepository.getCourse(courseId);
     if (!course) {
       throw new TimetableServiceError(404, "找不到課程");
     }
 
-    if (course.semester !== timetable.semester) {
-      throw new TimetableServiceError(409, "只能加入相同學期的課程");
-    }
-
-    const existingItem = await TimetableItemRepository.findByTimetableAndCourse(timetable.id, course.id);
-    if (existingItem) {
-      return {
-        added: false,
-        alreadyExists: true,
-        conflicts: [],
-      };
-    }
-
-    const timetableItems = await TimetableItemRepository.getAllByTimetableId(timetable.id);
-    const existingCourseIds = timetableItems.map((item) => item.course_id);
-    const allCourseIds = [...new Set([...existingCourseIds, course.id])];
-    const schedules = await CourseScheduleRepository.getByCourseIds(allCourseIds);
-
-    const existingCourses: CourseMeta[] = timetableItems.map((item) => {
-      const raw = item.toJSON() as unknown as TimetableItemModelJson;
-      return {
-        id: raw.course.id,
-        name: raw.course.course_name,
-        semester: raw.course.semester,
-        department: raw.course.department,
-        instructor: raw.course.instructor,
-        room: raw.course.course_room,
-      };
-    });
     const candidateCourse: CourseMeta = {
       id: course.id,
       name: course.course_name,
@@ -186,25 +173,84 @@ class TimetableService {
       room: course.course_room,
     };
 
-    const allMap = this.toCourseWithTimeslotsMap([candidateCourse, ...existingCourses], schedules);
-    const candidate = allMap.get(candidateCourse.id) ?? { course: candidateCourse, timeslots: [] };
-    const existingWithTimeslots = existingCourses.map((meta) => allMap.get(meta.id) ?? { course: meta, timeslots: [] });
-
-    // 缺時段資料（timeslots = []）不參與衝堂判斷，因為無法比較時段
-    const conflicts = this.findConflicts(candidate, existingWithTimeslots);
-    if (conflicts.length > 0) {
-      return {
-        added: false,
-        alreadyExists: false,
-        conflicts,
-      };
-    }
-
     try {
-      await TimetableItemRepository.addCourse(timetable.id, course.id);
+      return await db.sequelize.transaction(
+        { isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED },
+        async (transaction) => {
+          const timetable = await this.getOrThrowLockedTimetable(
+            timetableId,
+            userId,
+            transaction
+          );
+          if (course.semester !== timetable.semester) {
+            throw new TimetableServiceError(409, "只能加入相同學期的課程");
+          }
+
+          const timetableItems = await TimetableItemRepository.getAllByTimetableId(
+            timetable.id,
+            transaction
+          );
+          if (timetableItems.some((item) => item.course_id === course.id)) {
+            return {
+              added: false,
+              alreadyExists: true,
+              conflicts: [],
+            };
+          }
+
+          const existingCourseIds = timetableItems.map((item) => item.course_id);
+          const allCourseIds = [...new Set([...existingCourseIds, course.id])];
+          const schedules = await CourseScheduleRepository.getByCourseIds(
+            allCourseIds,
+            transaction
+          );
+
+          const existingCourses: CourseMeta[] = timetableItems.map((item) => {
+            const raw = item.toJSON() as unknown as TimetableItemModelJson;
+            return {
+              id: raw.course.id,
+              name: raw.course.course_name,
+              semester: raw.course.semester,
+              department: raw.course.department,
+              instructor: raw.course.instructor,
+              room: raw.course.course_room,
+            };
+          });
+          const allMap = this.toCourseWithTimeslotsMap(
+            [candidateCourse, ...existingCourses],
+            schedules
+          );
+          const candidate = allMap.get(candidateCourse.id) ?? {
+            course: candidateCourse,
+            timeslots: [],
+          };
+          const existingWithTimeslots = existingCourses.map(
+            (meta) => allMap.get(meta.id) ?? { course: meta, timeslots: [] }
+          );
+
+          // 缺時段資料（timeslots = []）不參與衝堂判斷，因為無法比較時段
+          const conflicts = this.findConflicts(candidate, existingWithTimeslots);
+          if (conflicts.length > 0) {
+            return {
+              added: false,
+              alreadyExists: false,
+              conflicts,
+            };
+          }
+
+          await TimetableItemRepository.addCourse(timetable.id, course.id, transaction);
+
+          return {
+            added: true,
+            alreadyExists: false,
+            item: { courseId: course.id },
+            conflicts: [],
+          };
+        }
+      );
     } catch (error) {
       if (error instanceof UniqueConstraintError) {
-        const duplicated = await TimetableItemRepository.findByTimetableAndCourse(timetable.id, course.id);
+        const duplicated = await TimetableItemRepository.findByTimetableAndCourse(timetableId, course.id);
         if (duplicated) {
           return {
             added: false,
@@ -215,13 +261,6 @@ class TimetableService {
       }
       throw error;
     }
-
-    return {
-      added: true,
-      alreadyExists: false,
-      item: { courseId: course.id },
-      conflicts: [],
-    };
   }
 
   async swapCourse(timetableId: number, userId: number, courseId: number) {
@@ -229,10 +268,6 @@ class TimetableService {
     const course = await CourseRepository.getCourse(courseId);
     if (!course) {
       throw new TimetableServiceError(404, "找不到課程");
-    }
-
-    if (course.semester !== timetable.semester) {
-      throw new TimetableServiceError(409, "只能加入相同學期的課程");
     }
 
     const candidateCourse: CourseMeta = {
@@ -243,6 +278,10 @@ class TimetableService {
       instructor: course.instructor,
       room: course.course_room,
     };
+
+    if (course.semester !== timetable.semester) {
+      throw new TimetableServiceError(409, "只能加入相同學期的課程");
+    }
 
     try {
       return await db.sequelize.transaction(async (transaction) => {
@@ -377,8 +416,13 @@ class TimetableService {
   }
 
   async removeCourse(timetableId: number, userId: number, courseId: number): Promise<void> {
-    await this.getOrThrowOwnedTimetable(timetableId, userId);
-    await TimetableItemRepository.removeCourse(timetableId, courseId);
+    await db.sequelize.transaction(
+      { isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED },
+      async (transaction) => {
+        await this.getOrThrowLockedTimetable(timetableId, userId, transaction);
+        await TimetableItemRepository.removeCourse(timetableId, courseId, transaction);
+      }
+    );
   }
 
   async getAllAddedCourses(userId: number): Promise<AddedCourseItemResponse[]> {

--- a/backend/services/timetableService.ts
+++ b/backend/services/timetableService.ts
@@ -344,75 +344,111 @@ class TimetableService {
   }
 
   async batchAddFromInterests(timetableId: number, userId: number) {
-    const timetable = await this.getOrThrowOwnedTimetable(timetableId, userId);
-    const allInterests = await InterestRepository.getAllInterestsByUserId(userId);
-    const requested = allInterests.length;
-    const eligibleInterests = allInterests.filter((interest) => interest.course.semester === timetable.semester);
+    return await db.sequelize.transaction(
+      { isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED },
+      async (transaction) => {
+        const timetable = await this.getOrThrowLockedTimetable(
+          timetableId,
+          userId,
+          transaction
+        );
+        const allInterests = await InterestRepository.getAllInterestsByUserId(
+          userId,
+          transaction
+        );
+        const requested = allInterests.length;
+        const eligibleInterests = allInterests.filter(
+          (interest) => interest.course.semester === timetable.semester
+        );
 
-    const existingItems = await TimetableItemRepository.getAllByTimetableId(timetable.id);
-    const existingCourseIds = new Set(existingItems.map((item) => item.course_id));
+        const existingItems = await TimetableItemRepository.getAllByTimetableId(
+          timetable.id,
+          transaction
+        );
+        const existingCourseIds = new Set(existingItems.map((item) => item.course_id));
 
-    const candidateCourses: CourseMeta[] = eligibleInterests.map((interest) => ({
-      id: interest.course.id,
-      name: interest.course.course_name,
-      semester: interest.course.semester,
-      department: interest.course.department,
-      instructor: interest.course.instructor,
-    }));
-    const existingCourses: CourseMeta[] = existingItems.map((item) => {
-      const raw = item.toJSON() as unknown as TimetableItemModelJson;
-      return {
-        id: raw.course.id,
-        name: raw.course.course_name,
-        semester: raw.course.semester,
-        department: raw.course.department,
-        instructor: raw.course.instructor,
-        room: raw.course.course_room,
-      };
-    });
+        const candidateCourses: CourseMeta[] = eligibleInterests.map((interest) => ({
+          id: interest.course.id,
+          name: interest.course.course_name,
+          semester: interest.course.semester,
+          department: interest.course.department,
+          instructor: interest.course.instructor,
+          room: interest.course.course_room,
+        }));
+        const existingCourses: CourseMeta[] = existingItems.map((item) => {
+          const raw = item.toJSON() as unknown as TimetableItemModelJson;
+          return {
+            id: raw.course.id,
+            name: raw.course.course_name,
+            semester: raw.course.semester,
+            department: raw.course.department,
+            instructor: raw.course.instructor,
+            room: raw.course.course_room,
+          };
+        });
 
-    const allCourseIds = [...new Set([...existingCourseIds, ...candidateCourses.map((course) => course.id)])];
-    const schedules = await CourseScheduleRepository.getByCourseIds(allCourseIds);
-    const courseMap = this.toCourseWithTimeslotsMap([...existingCourses, ...candidateCourses], schedules);
+        const allCourseIds = [...new Set([
+          ...existingCourseIds,
+          ...candidateCourses.map((course) => course.id),
+        ])];
+        const schedules = await CourseScheduleRepository.getByCourseIds(
+          allCourseIds,
+          transaction
+        );
+        const courseMap = this.toCourseWithTimeslotsMap(
+          [...existingCourses, ...candidateCourses],
+          schedules
+        );
 
-    const selectedCourseIds = new Set(existingCourses.map((course) => course.id));
-    const selectedCourses = [...existingCourses].map((course) => courseMap.get(course.id) ?? { course, timeslots: [] });
-    const conflicts: TimetableConflict[] = [];
-    let added = 0;
-    let skippedAlreadyExists = 0;
-    let conflicted = 0;
+        const selectedCourseIds = new Set(existingCourses.map((course) => course.id));
+        const selectedCourses = existingCourses.map(
+          (course) => courseMap.get(course.id) ?? { course, timeslots: [] }
+        );
+        const conflicts: TimetableConflict[] = [];
+        let added = 0;
+        let skippedAlreadyExists = 0;
+        let conflicted = 0;
 
-    for (const candidateMeta of candidateCourses) {
-      if (selectedCourseIds.has(candidateMeta.id)) {
-        skippedAlreadyExists += 1;
-        continue;
+        for (const candidateMeta of candidateCourses) {
+          if (selectedCourseIds.has(candidateMeta.id)) {
+            skippedAlreadyExists += 1;
+            continue;
+          }
+
+          const candidate = courseMap.get(candidateMeta.id) ?? {
+            course: candidateMeta,
+            timeslots: [],
+          };
+          const detected = this.findConflicts(candidate, selectedCourses);
+
+          if (detected.length > 0) {
+            conflicted += 1;
+            conflicts.push(...detected);
+            continue;
+          }
+
+          await TimetableItemRepository.addCourse(
+            timetable.id,
+            candidateMeta.id,
+            transaction
+          );
+          added += 1;
+          selectedCourseIds.add(candidateMeta.id);
+          selectedCourses.push(candidate);
+        }
+
+        return {
+          summary: {
+            requested,
+            eligibleSameSemester: eligibleInterests.length,
+            added,
+            skippedAlreadyExists,
+            conflicted,
+          },
+          conflicts,
+        };
       }
-
-      const candidate = courseMap.get(candidateMeta.id) ?? { course: candidateMeta, timeslots: [] };
-      const detected = this.findConflicts(candidate, selectedCourses);
-
-      if (detected.length > 0) {
-        conflicted += 1;
-        conflicts.push(...detected);
-        continue;
-      }
-
-      await TimetableItemRepository.addCourse(timetable.id, candidateMeta.id);
-      added += 1;
-      selectedCourseIds.add(candidateMeta.id);
-      selectedCourses.push(candidate);
-    }
-
-    return {
-      summary: {
-        requested,
-        eligibleSameSemester: eligibleInterests.length,
-        added,
-        skippedAlreadyExists,
-        conflicted,
-      },
-      conflicts,
-    };
+    );
   }
 
   async removeCourse(timetableId: number, userId: number, courseId: number): Promise<void> {

--- a/backend/types/course.ts
+++ b/backend/types/course.ts
@@ -1,3 +1,5 @@
+import type { CourseTimeslot } from "./timetable";
+
 export interface Course {
   id: number;
   course_name: string;
@@ -17,6 +19,15 @@ export interface Course {
   view_count?: number;
   review_count?: number;
   dcard_related_post_count?: number;
+}
+
+export interface CourseWithTimeslots extends Course {
+  timeslots: CourseTimeslot[];
+}
+
+export interface CourseListResult<TCourse extends Course = Course> {
+  courses: TCourse[];
+  total: number;
 }
 
 export interface CourseRelatedPost {
@@ -55,6 +66,7 @@ export interface RelatedPostComment {
 
 export interface CourseDetailResponse {
   course: Course;
+  timeslots: CourseTimeslot[];
   hasUserAddInterest: boolean;
   related_posts: CourseRelatedPost[];
 }

--- a/backend/types/course.ts
+++ b/backend/types/course.ts
@@ -71,6 +71,12 @@ export interface CourseSearchParams {
   sortBy?: string;
 }
 
+export interface CourseOptionFilters {
+  category?: string;
+  academy?: string;
+  semesters?: string[];
+}
+
 export interface PaginationParams {
   page: number;
   limit: number;

--- a/backend/utils/courseSchedule.ts
+++ b/backend/utils/courseSchedule.ts
@@ -1,0 +1,97 @@
+import type CourseScheduleModel from "../models/CourseSchedule";
+import type { CourseTimeslot, TimetableConflict } from "../types/timetable";
+
+export const EWANT_DEPARTMENT = "校外遠距(EWANT)";
+
+export const PERIOD_ORDER = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G"];
+const PERIOD_INDEX_MAP = PERIOD_ORDER.reduce<Record<string, number>>((map, period, index) => {
+  map[period] = index;
+  return map;
+}, {});
+export const PERIOD_MIN_MAP: Record<string, { start: number; end: number }> = {
+  "1": { start: 430, end: 480 },
+  "2": { start: 480, end: 530 },
+  "3": { start: 540, end: 590 },
+  "4": { start: 600, end: 650 },
+  "5": { start: 660, end: 710 },
+  "6": { start: 720, end: 770 },
+  "7": { start: 780, end: 830 },
+  "8": { start: 840, end: 890 },
+  "9": { start: 900, end: 950 },
+  A: { start: 960, end: 1010 },
+  B: { start: 1020, end: 1070 },
+  C: { start: 1110, end: 1160 },
+  D: { start: 1160, end: 1210 },
+  E: { start: 1210, end: 1260 },
+  F: { start: 1260, end: 1310 },
+  G: { start: 1310, end: 1360 },
+};
+
+const getPeriodByMinute = (minute: number, mode: "start" | "end"): string => {
+  if (mode === "start") {
+    const found = PERIOD_ORDER.find((period) => PERIOD_MIN_MAP[period].start <= minute && minute < PERIOD_MIN_MAP[period].end);
+    return found ?? PERIOD_ORDER[0];
+  }
+
+  const found = [...PERIOD_ORDER].reverse().find((period) => PERIOD_MIN_MAP[period].start < minute && minute <= PERIOD_MIN_MAP[period].end);
+  return found ?? PERIOD_ORDER[PERIOD_ORDER.length - 1];
+};
+
+export const normalizeCourseSchedule = (schedule: CourseScheduleModel): CourseTimeslot | null => {
+  if (!Number.isInteger(schedule.day) || schedule.day < 1 || schedule.day > 7) return null;
+  if (!Number.isInteger(schedule.span) || schedule.span < 1) return null;
+
+  const startIndex = PERIOD_INDEX_MAP[schedule.start_period];
+  if (typeof startIndex !== "number") return null;
+
+  const endIndex = startIndex + schedule.span - 1;
+  if (endIndex >= PERIOD_ORDER.length) return null;
+
+  const startPeriod = PERIOD_ORDER[startIndex];
+  const endPeriod = PERIOD_ORDER[endIndex];
+  const startMin = PERIOD_MIN_MAP[startPeriod]?.start;
+  const endMin = PERIOD_MIN_MAP[endPeriod]?.end;
+  if (typeof startMin !== "number" || typeof endMin !== "number") return null;
+
+  return {
+    dayOfWeek: schedule.day,
+    startPeriod,
+    endPeriod,
+    startMin,
+    endMin,
+  };
+};
+
+export const normalizeCourseSchedules = (schedules: CourseScheduleModel[]): CourseTimeslot[] => {
+  return schedules
+    .map(normalizeCourseSchedule)
+    .filter((timeslot): timeslot is CourseTimeslot => timeslot !== null);
+};
+
+export const isEwantDepartment = (department: string): boolean => department === EWANT_DEPARTMENT;
+
+export const hasTimeslotOverlap = (a: CourseTimeslot, b: CourseTimeslot): boolean => {
+  return a.dayOfWeek === b.dayOfWeek && a.startMin < b.endMin && b.startMin < a.endMin;
+};
+
+export const buildTimetableConflict = (
+  courseId: number,
+  conflictWithCourseId: number,
+  a: CourseTimeslot,
+  b: CourseTimeslot
+): TimetableConflict => {
+  const overlapStart = Math.max(a.startMin, b.startMin);
+  const overlapEnd = Math.min(a.endMin, b.endMin);
+
+  return {
+    courseId,
+    conflictWithCourseId,
+    dayOfWeek: a.dayOfWeek,
+    overlap: {
+      startMin: overlapStart,
+      endMin: overlapEnd,
+      startPeriod: getPeriodByMinute(overlapStart, "start"),
+      endPeriod: getPeriodByMinute(overlapEnd, "end"),
+    },
+  };
+};

--- a/frontend/src/apis/courseAPI.ts
+++ b/frontend/src/apis/courseAPI.ts
@@ -1,4 +1,4 @@
-import { Course, CourseDetailResponse, CourseResponse, SearchParams } from '../types/courseType'
+import { Course, CourseDetailResponse, CourseOptionFilters, CourseResponse, SearchParams } from '../types/courseType'
 import { axiosInstance } from './axiosInstance'
 
 export const getCourses = async (searchParams: SearchParams): Promise<CourseResponse> => {
@@ -21,13 +21,13 @@ export const getCourse = async (course_id: string): Promise<CourseDetailResponse
   return response.data
 }
 
-export const getDepartments = async (): Promise<{ departments: string[] }> => {
-  const response = await axiosInstance.get('/courses/getAllDepartments')
+export const getDepartments = async (filters: CourseOptionFilters = {}): Promise<{ departments: string[] }> => {
+  const response = await axiosInstance.get('/courses/getAllDepartments', { params: filters })
   return response.data
 }
 
-export const getAcademies = async (): Promise<{ academies: string[] }> => {
-  const response = await axiosInstance.get('/courses/getAllAcademies')
+export const getAcademies = async (filters: CourseOptionFilters = {}): Promise<{ academies: string[] }> => {
+  const response = await axiosInstance.get('/courses/getAllAcademies', { params: filters })
   return response.data
 }
 

--- a/frontend/src/components/CourseFilter.tsx
+++ b/frontend/src/components/CourseFilter.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Container, Tabs, Input, Button, Select, MultiSelect, Accordion } from '@mantine/core'
 import { SearchParams, FilterOption } from '../types/courseType'
 import { FaSearch } from 'react-icons/fa'
@@ -10,11 +10,12 @@ import periodTimeMap from '../utils/periodTimeMap'
 
 interface CourseFilterProps {
     searchParams: SearchParams;
-    onSearch: (searchParams: SearchParams) => void;
+    onSearch: (searchParams: SearchParams, options?: { replace?: boolean }) => void;
     onClick: (page: number) => void;
 };
 
 const CourseFilter: React.FC<CourseFilterProps> = ({ searchParams, onSearch, onClick }) => {
+    const onSearchRef = useRef(onSearch)
     const [searchText, setSearchText] = useState(searchParams.search)
     const [activeTab, setActiveTab] = useState(searchParams.category)
     const [academy, setAcademy] = useState(searchParams.academy)
@@ -24,6 +25,10 @@ const CourseFilter: React.FC<CourseFilterProps> = ({ searchParams, onSearch, onC
     const [periods, setPeriods] = useState<string[]>(searchParams.periods)
     const [semesters, setSemesters] = useState<string[]>(searchParams.semesters)
     const [advancedAccordionValue, setAdvancedAccordionValue] = useState<string | null>(null)
+
+    useEffect(() => {
+        onSearchRef.current = onSearch
+    }, [onSearch])
 
     useEffect(() => {
         setSearchText(searchParams.search)
@@ -44,9 +49,105 @@ const CourseFilter: React.FC<CourseFilterProps> = ({ searchParams, onSearch, onC
         { label: '師培', value: 'teacher' },
         { label: 'EWANT', value: 'ewant' },
     ]
-    const { data: departmentList, isLoading: isLoadingDepartments } = useGetDepartments()
-    const { data: academyList, isLoading: isLoadingAcademies } = useGetAcademies()
+    const showOrganizationFilters = activeTab === 'university' || activeTab === 'graduate'
+    const optionSemesterFilter = semesters.length > 0 ? semesters.join(',') : undefined
+    const { data: departmentList, isLoading: isLoadingDepartments } = useGetDepartments(
+        showOrganizationFilters,
+        {
+            semester: optionSemesterFilter,
+            category: activeTab,
+            academy: academy || undefined,
+        },
+    )
+    const { data: academyList, isLoading: isLoadingAcademies } = useGetAcademies(
+        showOrganizationFilters,
+        {
+            semester: optionSemesterFilter,
+            category: activeTab,
+        },
+    )
     const { data: semesterList } = useGetSemesters()
+    const organizationOptionContextMatchesUrl = activeTab === searchParams.category
+        && semesters.join(',') === searchParams.semesters.join(',')
+
+    useEffect(() => {
+        if (!showOrganizationFilters) {
+            if (!academy && !department) return
+
+            setAcademy('')
+            setDepartment('')
+            if (
+                organizationOptionContextMatchesUrl
+                && (searchParams.academy || searchParams.department)
+            ) {
+                onSearchRef.current(
+                    {
+                        ...searchParams,
+                        page: 1,
+                        academy: '',
+                        department: '',
+                    },
+                    { replace: true },
+                )
+            }
+            return
+        }
+
+        if (
+            academy
+            && !isLoadingAcademies
+            && academyList
+            && !academyList.academies.includes(academy)
+        ) {
+            setAcademy('')
+            setDepartment('')
+            if (
+                organizationOptionContextMatchesUrl
+                && (searchParams.academy || searchParams.department)
+            ) {
+                onSearchRef.current(
+                    {
+                        ...searchParams,
+                        page: 1,
+                        academy: '',
+                        department: '',
+                    },
+                    { replace: true },
+                )
+            }
+            return
+        }
+
+        if (
+            department
+            && !isLoadingDepartments
+            && departmentList
+            && !departmentList.departments.includes(department)
+        ) {
+            setDepartment('')
+            if (organizationOptionContextMatchesUrl && searchParams.department) {
+                onSearchRef.current(
+                    {
+                        ...searchParams,
+                        page: 1,
+                        department: '',
+                    },
+                    { replace: true },
+                )
+            }
+        }
+    }, [
+        academy,
+        academyList,
+        department,
+        departmentList,
+        isLoadingAcademies,
+        isLoadingDepartments,
+        organizationOptionContextMatchesUrl,
+        searchParams,
+        showOrganizationFilters,
+    ])
+
     const weekdayOptions = [
         { value: '1', label: '星期一' },
         { value: '2', label: '星期二' },
@@ -143,7 +244,7 @@ const CourseFilter: React.FC<CourseFilterProps> = ({ searchParams, onSearch, onC
                     onChange={(e) => setSearchText(e.target.value)}
                 />
 
-                {(activeTab === 'university' || activeTab === 'graduate') && !isLoadingDepartments && !isLoadingAcademies && (
+                {showOrganizationFilters && (
                     <>
                         <Select
                             placeholder='選擇學院'
@@ -152,8 +253,14 @@ const CourseFilter: React.FC<CourseFilterProps> = ({ searchParams, onSearch, onC
                             size='md'
                             classNames={{ input: style.selectInput }}
                             className={style.select}
-                            onChange={(value) => setAcademy(value!)}
+                            onChange={(value) => {
+                                setAcademy(value ?? '')
+                                setDepartment('')
+                            }}
+                            disabled={isLoadingAcademies}
                             searchable
+                            clearable
+                            nothingFoundMessage='找不到符合的學院'
                         />
                         <Select
                             placeholder='選擇系所'
@@ -162,8 +269,11 @@ const CourseFilter: React.FC<CourseFilterProps> = ({ searchParams, onSearch, onC
                             size='md'
                             classNames={{ input: style.selectInput }}
                             className={style.select}
-                            onChange={(value) => setDepartment(value!)}
+                            onChange={(value) => setDepartment(value ?? '')}
+                            disabled={isLoadingDepartments}
                             searchable
+                            clearable
+                            nothingFoundMessage='找不到符合的系所'
                         />
                     </>
                 )}
@@ -232,7 +342,11 @@ const CourseFilter: React.FC<CourseFilterProps> = ({ searchParams, onSearch, onC
                     </Accordion>
                 )}
 
-                <Button className={style.searchButton} onClick={() => handleClick()}>
+                <Button
+                    className={style.searchButton}
+                    disabled={showOrganizationFilters && (isLoadingAcademies || isLoadingDepartments)}
+                    onClick={() => handleClick()}
+                >
                     搜尋
                 </Button>
             </Container>

--- a/frontend/src/hooks/courses/useGetAcademies.ts
+++ b/frontend/src/hooks/courses/useGetAcademies.ts
@@ -1,11 +1,13 @@
 import { useQuery } from '@tanstack/react-query'
 import { QUERY_KEYS } from '../queryKeys'
 import { getAcademies } from '../../apis/courseAPI'
+import type { CourseOptionFilters } from '../../types/courseType'
 
-export const useGetAcademies = () => {
+export const useGetAcademies = (enabled = true, filters: CourseOptionFilters = {}) => {
     return useQuery({
-        queryKey: [QUERY_KEYS.ACADEMIES],
-        queryFn: () => getAcademies(),
+        queryKey: [QUERY_KEYS.ACADEMIES, filters],
+        queryFn: () => getAcademies(filters),
+        enabled,
         staleTime: 1000 * 60 * 60,
         gcTime: 1000 * 60 * 60,
     })

--- a/frontend/src/hooks/courses/useGetCourses.ts
+++ b/frontend/src/hooks/courses/useGetCourses.ts
@@ -5,7 +5,7 @@ import { QUERY_KEYS } from '../queryKeys'
 
 export const useGetCourses = (searchParams: SearchParams, enabled = true) => {
   return useQuery({
-    queryKey: [QUERY_KEYS.COURSES, ...Object.values(searchParams)],
+    queryKey: [QUERY_KEYS.COURSES, searchParams],
     queryFn: () => getCourses(searchParams),
     placeholderData: (prev) => prev,
     enabled,

--- a/frontend/src/hooks/courses/useGetDepartments.ts
+++ b/frontend/src/hooks/courses/useGetDepartments.ts
@@ -1,11 +1,13 @@
 import { useQuery } from '@tanstack/react-query'
 import { QUERY_KEYS } from '../queryKeys'
 import { getDepartments } from '../../apis/courseAPI'
+import type { CourseOptionFilters } from '../../types/courseType'
 
-export const useGetDepartments = () => {
+export const useGetDepartments = (enabled = true, filters: CourseOptionFilters = {}) => {
     return useQuery({
-        queryKey: [QUERY_KEYS.DEPARTMENTS],
-        queryFn: () => getDepartments(),
+        queryKey: [QUERY_KEYS.DEPARTMENTS, filters],
+        queryFn: () => getDepartments(filters),
+        enabled,
         staleTime: 1000 * 60 * 60,
         gcTime: 1000 * 60 * 60,
     })

--- a/frontend/src/pages/CoursesPage.tsx
+++ b/frontend/src/pages/CoursesPage.tsx
@@ -104,7 +104,7 @@ const CoursesPage: React.FC = () => {
 	}
 
 	// 還要研究這部分
-	const updateURL = (params: SearchParams) => {
+	const updateURL = (params: SearchParams, options: { replace?: boolean } = {}) => {
 		const newQueryParams = new URLSearchParams()
 		if (params.page > 1) newQueryParams.set('page', params.page.toString())
 		if (params.search) newQueryParams.set('search', params.search)
@@ -117,7 +117,7 @@ const CoursesPage: React.FC = () => {
 		if (params.semesters.length > 0) newQueryParams.set('semesters', params.semesters.join(','))
 		if (params.sortBy) newQueryParams.set('sortBy', params.sortBy)
 
-		navigate(`?${newQueryParams.toString()}`)
+		navigate(`?${newQueryParams.toString()}`, { replace: options.replace ?? false })
 	}
 
 	// 排序功能
@@ -157,8 +157,8 @@ const CoursesPage: React.FC = () => {
 		<div>
 			<CourseFilter
 				searchParams={searchParams}
-				onSearch={(params) => {
-					updateURL(params)
+				onSearch={(params, options) => {
+					updateURL(params, options)
 				}}
 				onClick={setPage}
 			/>

--- a/frontend/src/types/courseType.ts
+++ b/frontend/src/types/courseType.ts
@@ -76,6 +76,12 @@ export interface FilterOption {
   value: string;
 }
 
+export interface CourseOptionFilters {
+  semester?: string;
+  category?: string;
+  academy?: string;
+}
+
 export interface SearchParams {
   page: number;
   limit: number;


### PR DESCRIPTION
## 標題

修正課程篩選選項與瀏覽歷史同步

---

## 摘要

穩定課程分頁 query identity，讓學院／系所／分類選項依目前條件取得，並避免篩選同步產生多餘 history entries。

---

## 背景／問題

篩選條件更新可能推入無效或重複的瀏覽歷史，且選項未完整依目前學期與組織條件收斂。

---

## 變更內容

- 穩定 paginated course query key。
- 後端支援依 context 取得組織篩選選項。
- 前端 CourseFilter 傳遞目前篩選 context。
- URL 同步改用 replace 修正 history 行為。

---

## 測試方式

- Frontend：npm run build
- Frontend：npm run lint
- Backend：npx tsc --noEmit
- git diff --check

---

## 備註

此為 stacked PR 3/6，base 為 feat/guest-timetable-storage。