### PR TITLE
修正課程篩選選項與瀏覽歷史同步

### DIFF
--- a/backend/controllers/courseController.ts
+++ b/backend/controllers/courseController.ts
@@ -2,6 +2,17 @@ import CourseService from "../services/courseService";
 import CourseViewService from "../services/courseViewService";
 import { RequestHandler } from "express";
 
+const getQueryValues = (value: unknown): string[] => {
+  if (value === undefined || value === null || value === "") return [];
+  return String(value).split(",").map((item) => item.trim());
+};
+
+const getCourseOptionFilters = (query: Record<string, unknown>) => ({
+  category: String(query.category || "") || undefined,
+  academy: String(query.academy || "") || undefined,
+  semesters: getQueryValues(query.semester ?? query.semesters).filter(Boolean),
+});
+
 export const getAllCourses: RequestHandler = async (
   req,
   res
@@ -60,7 +71,7 @@ export const getAllDepartments: RequestHandler = async (
   res
 ): Promise<void> => {
   try {
-    const departments = await CourseService.getAllDepartments();
+    const departments = await CourseService.getAllDepartments(getCourseOptionFilters(req.query));
     res.status(200).json({ departments });
   } catch (err) {
     res.status(500).json({ message: err });
@@ -72,7 +83,7 @@ export const getAllAcademies: RequestHandler = async (
   res
 ): Promise<void> => {
   try {
-    const academies = await CourseService.getAllAcademies();
+    const academies = await CourseService.getAllAcademies(getCourseOptionFilters(req.query));
     res.status(200).json({ academies });
   } catch (err) {
     res.status(500).json({ message: err });

--- a/backend/repositories/courseRepository.ts
+++ b/backend/repositories/courseRepository.ts
@@ -133,6 +133,7 @@ class CourseRepository {
       order.push(["interests_count", "desc"]);
     }
     order.push(["created_at", "desc"]);
+    order.push(["id", "desc"]);
 
     const [courses, total] = await Promise.all([
       CourseModel.findAll({ where: whereCondition, limit, offset, order }),

--- a/backend/repositories/courseRepository.ts
+++ b/backend/repositories/courseRepository.ts
@@ -1,17 +1,63 @@
 import { Op, Transaction } from "sequelize";
 import CourseModel from "../models/Course";
 import CourseScheduleModel from "../models/CourseSchedule";
-import { Course } from "../types/course";
-import { PaginationParams } from "../types/course";
+import { Course, CourseOptionFilters, PaginationParams } from "../types/course";
 import db from "../models";
 
+const EWANT_DEPARTMENT = "校外遠距(EWANT)";
 const PERIOD_ORDER = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G"] as const;
 const PERIOD_INDEX_MAP = PERIOD_ORDER.reduce<Record<string, number>>((acc, period, index) => {
   acc[period] = index;
   return acc;
 }, {});
 
+const getCategoryConditions = (category?: string): any[] => {
+  if (category === "general") {
+    return [{ department: { [Op.like]: "%通識%" } }];
+  }
+  if (category === "university") {
+    return [{
+      [Op.and]: [
+        { department: { [Op.notLike]: "%碩士%" } },
+        { department: { [Op.notLike]: "%通識%" } },
+        { department: { [Op.notLike]: EWANT_DEPARTMENT } },
+      ],
+    }];
+  }
+  if (category === "graduate") {
+    return [{ department: { [Op.like]: "%碩士%" } }];
+  }
+  if (category === "teacher") {
+    return [{ department: { [Op.like]: "%師%" } }];
+  }
+  if (category === "ewant") {
+    return [{ department: EWANT_DEPARTMENT }];
+  }
+  return [];
+};
+
 class CourseRepository {
+  private getCourseOptionWhere = (
+    filters: CourseOptionFilters,
+    excludeEwantWhenUnfiltered = false
+  ): any => {
+    const whereCondition: any = {};
+    const categoryConditions = getCategoryConditions(filters.category);
+
+    if (excludeEwantWhenUnfiltered && (!filters.category || filters.category === "all")) {
+      categoryConditions.push({ department: { [Op.ne]: EWANT_DEPARTMENT } });
+    }
+    if (categoryConditions.length > 0) {
+      whereCondition[Op.and] = categoryConditions;
+    }
+    if (filters.academy) whereCondition.academy = filters.academy;
+    if (filters.semesters && filters.semesters.length > 0) {
+      whereCondition.semester = { [Op.in]: filters.semesters };
+    }
+
+    return whereCondition;
+  };
+
   private getFilteredCourseIdsBySchedule = async (
     weekdays: number[],
     periods: string[]
@@ -68,25 +114,7 @@ class CourseRepository {
     }
 
     // category(tab選項)filter與department有關
-    const categoryConditions: any[] = [];
-    if (search && search.category === "general") {
-      categoryConditions.push({ department: { [Op.like]: "%通識%" } });
-    } else if (search && search.category === "university") {
-      categoryConditions.push({
-        [Op.and]: [
-          { department: { [Op.notLike]: "%碩士%" } },
-          { department: { [Op.notLike]: "%通識%" } },
-          { department: { [Op.notLike]: "校外遠距(EWANT)" } },
-        ]
-      });
-    } else if (search && search.category === "graduate") {
-      categoryConditions.push({ department: { [Op.like]: "%碩士%" } });
-    } else if (search && search.category === "teacher") {
-      categoryConditions.push({ department: { [Op.like]: "%師%" } });
-    }
-    if (search && search.category === "ewant") {
-      categoryConditions.push({ department: "校外遠距(EWANT)" });
-    }
+    const categoryConditions = getCategoryConditions(search?.category);
     if (search && search.department) {
       categoryConditions.push({ department: search.department });
     }
@@ -153,14 +181,10 @@ class CourseRepository {
     return await CourseModel.count();
   }
 
-  async getAllDepartments(): Promise<string[]> {
+  async getAllDepartments(filters: CourseOptionFilters = {}): Promise<string[]> {
     const departments = await CourseModel.findAll({
       attributes: [[db.Sequelize.fn("DISTINCT", db.Sequelize.col("department")), "department"]],
-      where: {
-        department: {
-          [Op.ne]: "校外遠距(EWANT)",
-        },
-      },
+      where: this.getCourseOptionWhere(filters, true),
       raw: true
     });
     const departmentList = departments.map((item: { department: string }) => {
@@ -169,9 +193,10 @@ class CourseRepository {
     return departmentList;
   }
 
-  async getAllAcademies(): Promise<string[]> {
+  async getAllAcademies(filters: CourseOptionFilters = {}): Promise<string[]> {
     const academies = await CourseModel.findAll({
       attributes: [[db.Sequelize.fn("DISTINCT", db.Sequelize.col("academy")), "academy"]],
+      where: this.getCourseOptionWhere(filters, true),
       raw: true
     });
     const academyList = academies

--- a/backend/services/courseService.ts
+++ b/backend/services/courseService.ts
@@ -1,4 +1,4 @@
-import { Course, CourseDetailResponse } from "../types/course";
+import { Course, CourseDetailResponse, CourseOptionFilters } from "../types/course";
 import { PaginationParams } from "../types/course";
 import CourseRepository from "../repositories/courseRepository";
 import InterestRepository from "../repositories/interestRepository";
@@ -24,12 +24,12 @@ class CourseService {
     return { course, hasUserAddInterest, related_posts };
   }
 
-  async getAllDepartments(): Promise<string[]>{
-    return await CourseRepository.getAllDepartments();
+  async getAllDepartments(filters: CourseOptionFilters = {}): Promise<string[]>{
+    return await CourseRepository.getAllDepartments(filters);
   }
 
-  async getAllAcademies(): Promise<string[]>{
-    return await CourseRepository.getAllAcademies();
+  async getAllAcademies(filters: CourseOptionFilters = {}): Promise<string[]>{
+    return await CourseRepository.getAllAcademies(filters);
   }
 
   async getAllSemesters(): Promise<string[]>{

--- a/backend/types/course.ts
+++ b/backend/types/course.ts
@@ -71,6 +71,12 @@ export interface CourseSearchParams {
   sortBy?: string;
 }
 
+export interface CourseOptionFilters {
+  category?: string;
+  academy?: string;
+  semesters?: string[];
+}
+
 export interface PaginationParams {
   page: number;
   limit: number;

--- a/frontend/src/apis/courseAPI.ts
+++ b/frontend/src/apis/courseAPI.ts
@@ -1,4 +1,4 @@
-import { Course, CourseDetailResponse, CourseResponse, SearchParams } from '../types/courseType'
+import { Course, CourseDetailResponse, CourseOptionFilters, CourseResponse, SearchParams } from '../types/courseType'
 import { axiosInstance } from './axiosInstance'
 
 export const getCourses = async (searchParams: SearchParams): Promise<CourseResponse> => {
@@ -21,13 +21,13 @@ export const getCourse = async (course_id: string): Promise<CourseDetailResponse
   return response.data
 }
 
-export const getDepartments = async (): Promise<{ departments: string[] }> => {
-  const response = await axiosInstance.get('/courses/getAllDepartments')
+export const getDepartments = async (filters: CourseOptionFilters = {}): Promise<{ departments: string[] }> => {
+  const response = await axiosInstance.get('/courses/getAllDepartments', { params: filters })
   return response.data
 }
 
-export const getAcademies = async (): Promise<{ academies: string[] }> => {
-  const response = await axiosInstance.get('/courses/getAllAcademies')
+export const getAcademies = async (filters: CourseOptionFilters = {}): Promise<{ academies: string[] }> => {
+  const response = await axiosInstance.get('/courses/getAllAcademies', { params: filters })
   return response.data
 }
 

--- a/frontend/src/components/CourseFilter.tsx
+++ b/frontend/src/components/CourseFilter.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Container, Tabs, Input, Button, Select, MultiSelect, Accordion } from '@mantine/core'
 import { SearchParams, FilterOption } from '../types/courseType'
 import { FaSearch } from 'react-icons/fa'
@@ -10,11 +10,12 @@ import periodTimeMap from '../utils/periodTimeMap'
 
 interface CourseFilterProps {
     searchParams: SearchParams;
-    onSearch: (searchParams: SearchParams) => void;
+    onSearch: (searchParams: SearchParams, options?: { replace?: boolean }) => void;
     onClick: (page: number) => void;
 };
 
 const CourseFilter: React.FC<CourseFilterProps> = ({ searchParams, onSearch, onClick }) => {
+    const onSearchRef = useRef(onSearch)
     const [searchText, setSearchText] = useState(searchParams.search)
     const [activeTab, setActiveTab] = useState(searchParams.category)
     const [academy, setAcademy] = useState(searchParams.academy)
@@ -24,6 +25,10 @@ const CourseFilter: React.FC<CourseFilterProps> = ({ searchParams, onSearch, onC
     const [periods, setPeriods] = useState<string[]>(searchParams.periods)
     const [semesters, setSemesters] = useState<string[]>(searchParams.semesters)
     const [advancedAccordionValue, setAdvancedAccordionValue] = useState<string | null>(null)
+
+    useEffect(() => {
+        onSearchRef.current = onSearch
+    }, [onSearch])
 
     useEffect(() => {
         setSearchText(searchParams.search)
@@ -44,9 +49,105 @@ const CourseFilter: React.FC<CourseFilterProps> = ({ searchParams, onSearch, onC
         { label: '師培', value: 'teacher' },
         { label: 'EWANT', value: 'ewant' },
     ]
-    const { data: departmentList, isLoading: isLoadingDepartments } = useGetDepartments()
-    const { data: academyList, isLoading: isLoadingAcademies } = useGetAcademies()
+    const showOrganizationFilters = activeTab === 'university' || activeTab === 'graduate'
+    const optionSemesterFilter = semesters.length > 0 ? semesters.join(',') : undefined
+    const { data: departmentList, isLoading: isLoadingDepartments } = useGetDepartments(
+        showOrganizationFilters,
+        {
+            semester: optionSemesterFilter,
+            category: activeTab,
+            academy: academy || undefined,
+        },
+    )
+    const { data: academyList, isLoading: isLoadingAcademies } = useGetAcademies(
+        showOrganizationFilters,
+        {
+            semester: optionSemesterFilter,
+            category: activeTab,
+        },
+    )
     const { data: semesterList } = useGetSemesters()
+    const organizationOptionContextMatchesUrl = activeTab === searchParams.category
+        && semesters.join(',') === searchParams.semesters.join(',')
+
+    useEffect(() => {
+        if (!showOrganizationFilters) {
+            if (!academy && !department) return
+
+            setAcademy('')
+            setDepartment('')
+            if (
+                organizationOptionContextMatchesUrl
+                && (searchParams.academy || searchParams.department)
+            ) {
+                onSearchRef.current(
+                    {
+                        ...searchParams,
+                        page: 1,
+                        academy: '',
+                        department: '',
+                    },
+                    { replace: true },
+                )
+            }
+            return
+        }
+
+        if (
+            academy
+            && !isLoadingAcademies
+            && academyList
+            && !academyList.academies.includes(academy)
+        ) {
+            setAcademy('')
+            setDepartment('')
+            if (
+                organizationOptionContextMatchesUrl
+                && (searchParams.academy || searchParams.department)
+            ) {
+                onSearchRef.current(
+                    {
+                        ...searchParams,
+                        page: 1,
+                        academy: '',
+                        department: '',
+                    },
+                    { replace: true },
+                )
+            }
+            return
+        }
+
+        if (
+            department
+            && !isLoadingDepartments
+            && departmentList
+            && !departmentList.departments.includes(department)
+        ) {
+            setDepartment('')
+            if (organizationOptionContextMatchesUrl && searchParams.department) {
+                onSearchRef.current(
+                    {
+                        ...searchParams,
+                        page: 1,
+                        department: '',
+                    },
+                    { replace: true },
+                )
+            }
+        }
+    }, [
+        academy,
+        academyList,
+        department,
+        departmentList,
+        isLoadingAcademies,
+        isLoadingDepartments,
+        organizationOptionContextMatchesUrl,
+        searchParams,
+        showOrganizationFilters,
+    ])
+
     const weekdayOptions = [
         { value: '1', label: '星期一' },
         { value: '2', label: '星期二' },
@@ -143,7 +244,7 @@ const CourseFilter: React.FC<CourseFilterProps> = ({ searchParams, onSearch, onC
                     onChange={(e) => setSearchText(e.target.value)}
                 />
 
-                {(activeTab === 'university' || activeTab === 'graduate') && !isLoadingDepartments && !isLoadingAcademies && (
+                {showOrganizationFilters && (
                     <>
                         <Select
                             placeholder='選擇學院'
@@ -152,8 +253,14 @@ const CourseFilter: React.FC<CourseFilterProps> = ({ searchParams, onSearch, onC
                             size='md'
                             classNames={{ input: style.selectInput }}
                             className={style.select}
-                            onChange={(value) => setAcademy(value!)}
+                            onChange={(value) => {
+                                setAcademy(value ?? '')
+                                setDepartment('')
+                            }}
+                            disabled={isLoadingAcademies}
                             searchable
+                            clearable
+                            nothingFoundMessage='找不到符合的學院'
                         />
                         <Select
                             placeholder='選擇系所'
@@ -162,8 +269,11 @@ const CourseFilter: React.FC<CourseFilterProps> = ({ searchParams, onSearch, onC
                             size='md'
                             classNames={{ input: style.selectInput }}
                             className={style.select}
-                            onChange={(value) => setDepartment(value!)}
+                            onChange={(value) => setDepartment(value ?? '')}
+                            disabled={isLoadingDepartments}
                             searchable
+                            clearable
+                            nothingFoundMessage='找不到符合的系所'
                         />
                     </>
                 )}
@@ -232,7 +342,11 @@ const CourseFilter: React.FC<CourseFilterProps> = ({ searchParams, onSearch, onC
                     </Accordion>
                 )}
 
-                <Button className={style.searchButton} onClick={() => handleClick()}>
+                <Button
+                    className={style.searchButton}
+                    disabled={showOrganizationFilters && (isLoadingAcademies || isLoadingDepartments)}
+                    onClick={() => handleClick()}
+                >
                     搜尋
                 </Button>
             </Container>

--- a/frontend/src/hooks/courses/useGetAcademies.ts
+++ b/frontend/src/hooks/courses/useGetAcademies.ts
@@ -1,11 +1,13 @@
 import { useQuery } from '@tanstack/react-query'
 import { QUERY_KEYS } from '../queryKeys'
 import { getAcademies } from '../../apis/courseAPI'
+import type { CourseOptionFilters } from '../../types/courseType'
 
-export const useGetAcademies = () => {
+export const useGetAcademies = (enabled = true, filters: CourseOptionFilters = {}) => {
     return useQuery({
-        queryKey: [QUERY_KEYS.ACADEMIES],
-        queryFn: () => getAcademies(),
+        queryKey: [QUERY_KEYS.ACADEMIES, filters],
+        queryFn: () => getAcademies(filters),
+        enabled,
         staleTime: 1000 * 60 * 60,
         gcTime: 1000 * 60 * 60,
     })

--- a/frontend/src/hooks/courses/useGetCourses.ts
+++ b/frontend/src/hooks/courses/useGetCourses.ts
@@ -5,7 +5,7 @@ import { QUERY_KEYS } from '../queryKeys'
 
 export const useGetCourses = (searchParams: SearchParams, enabled = true) => {
   return useQuery({
-    queryKey: [QUERY_KEYS.COURSES, ...Object.values(searchParams)],
+    queryKey: [QUERY_KEYS.COURSES, searchParams],
     queryFn: () => getCourses(searchParams),
     placeholderData: (prev) => prev,
     enabled,

--- a/frontend/src/hooks/courses/useGetDepartments.ts
+++ b/frontend/src/hooks/courses/useGetDepartments.ts
@@ -1,11 +1,13 @@
 import { useQuery } from '@tanstack/react-query'
 import { QUERY_KEYS } from '../queryKeys'
 import { getDepartments } from '../../apis/courseAPI'
+import type { CourseOptionFilters } from '../../types/courseType'
 
-export const useGetDepartments = () => {
+export const useGetDepartments = (enabled = true, filters: CourseOptionFilters = {}) => {
     return useQuery({
-        queryKey: [QUERY_KEYS.DEPARTMENTS],
-        queryFn: () => getDepartments(),
+        queryKey: [QUERY_KEYS.DEPARTMENTS, filters],
+        queryFn: () => getDepartments(filters),
+        enabled,
         staleTime: 1000 * 60 * 60,
         gcTime: 1000 * 60 * 60,
     })

--- a/frontend/src/pages/CoursesPage.tsx
+++ b/frontend/src/pages/CoursesPage.tsx
@@ -104,7 +104,7 @@ const CoursesPage: React.FC = () => {
 	}
 
 	// 還要研究這部分
-	const updateURL = (params: SearchParams) => {
+	const updateURL = (params: SearchParams, options: { replace?: boolean } = {}) => {
 		const newQueryParams = new URLSearchParams()
 		if (params.page > 1) newQueryParams.set('page', params.page.toString())
 		if (params.search) newQueryParams.set('search', params.search)
@@ -117,7 +117,7 @@ const CoursesPage: React.FC = () => {
 		if (params.semesters.length > 0) newQueryParams.set('semesters', params.semesters.join(','))
 		if (params.sortBy) newQueryParams.set('sortBy', params.sortBy)
 
-		navigate(`?${newQueryParams.toString()}`)
+		navigate(`?${newQueryParams.toString()}`, { replace: options.replace ?? false })
 	}
 
 	// 排序功能
@@ -157,8 +157,8 @@ const CoursesPage: React.FC = () => {
 		<div>
 			<CourseFilter
 				searchParams={searchParams}
-				onSearch={(params) => {
-					updateURL(params)
+				onSearch={(params, options) => {
+					updateURL(params, options)
 				}}
 				onClick={setPage}
 			/>

--- a/frontend/src/types/courseType.ts
+++ b/frontend/src/types/courseType.ts
@@ -76,6 +76,12 @@ export interface FilterOption {
   value: string;
 }
 
+export interface CourseOptionFilters {
+  semester?: string;
+  category?: string;
+  academy?: string;
+}
+
 export interface SearchParams {
   page: number;
   limit: number;


### PR DESCRIPTION
## 標題

修正課程篩選選項與瀏覽歷史同步

---

## 摘要

讓課程列表的分頁 query identity 穩定，並依目前學期、學院與系所條件取得可用篩選選項；同步 URL 時改用 replace，避免每次修正條件都產生多餘或無效的瀏覽歷史。

此 PR 僅包含 4 個 commits、11 個檔案。

---

## 背景／問題

課程篩選原本有三個互相關聯的問題：

1. 分頁查詢的 query identity 可能因參數物件不穩定而重建。
2. 學院、系所與分類選項未完整依目前篩選 context 收斂，可能保留已無結果的選項。
3. 自動修正 URL 條件時使用 push，導致返回鍵經過多筆並非使用者主動操作的 history entries。

---

## 變更內容

- 穩定 paginated course query 的參數與 query key。
- Course organization API 接受目前學期、學院、系所與分類 context。
- Backend repository 依 context 過濾可用 organization options。
- CourseFilter 將目前條件傳給 academies／departments queries。
- 清理已失效的選項時同步修正前端狀態。
- CoursesPage 更新查詢字串時使用 replace，避免污染瀏覽歷史。

---

## 測試方式

已執行：

- Frontend：`npm run build`
- Frontend：`npm run lint`
- Backend：`npx tsc --noEmit`
- `git diff --check`

建議人工驗證：

1. 切換學期後，學院與系所選項會隨可用課程更新。
2. 選擇學院後，系所選項只顯示符合目前 context 的項目。
3. 當既有 URL 帶入失效條件時，頁面會修正條件但不新增一筆 history。
4. 連續調整篩選後使用瀏覽器返回鍵，確認只返回使用者實際操作過的頁面。

---

## 備註

- 此為 feature integration PR 3/6。
- Base：`feat/guest-timetable`
- Head：`fix/course-filter-history`
- #70、#71 已先合併完成。
- 舊 #72 僅保留先前誤 merge 的歷史紀錄；本 PR 才是目前應合併的 filter PR。