### PR TITLE
建立標準課程時段 contract 與原子課表 mutation

### DIFF
--- a/backend/controllers/courseController.ts
+++ b/backend/controllers/courseController.ts
@@ -1,6 +1,7 @@
 import CourseService from "../services/courseService";
 import CourseViewService from "../services/courseViewService";
 import { RequestHandler } from "express";
+import { PERIOD_ORDER } from "../utils/courseSchedule";
 
 const getQueryValues = (value: unknown): string[] => {
   if (value === undefined || value === null || value === "") return [];
@@ -18,21 +19,27 @@ export const getAllCourses: RequestHandler = async (
   res
 ): Promise<void> => {
   try {
-    const page = parseInt(req.query.page as string) || 1;
-    const limit = parseInt(req.query.limit as string) || 15;
+    const page = Math.max(parseInt(req.query.page as string) || 1, 1);
+    const limit = Math.min(Math.max(parseInt(req.query.limit as string) || 15, 1), 100);
     const offset = (page - 1) * limit;
-    const weekdays = String(req.query.weekdays || "")
-      .split(",")
-      .map((item) => parseInt(item.trim(), 10))
-      .filter((value) => !Number.isNaN(value) && value >= 1 && value <= 7);
-    const periods = String(req.query.periods || "")
-      .split(",")
-      .map((item) => item.trim().toUpperCase())
-      .filter((value) => Boolean(value));
+    const weekdayValues = getQueryValues(req.query.weekdays);
+    if (weekdayValues.some((value) => !/^[1-7]$/.test(value))) {
+      res.status(400).json({ message: "星期篩選格式錯誤，weekdays 僅接受 1 至 7。" });
+      return;
+    }
+    const weekdays = weekdayValues.map(Number);
+
+    const allowedPeriods = new Set(PERIOD_ORDER);
+    const periods = getQueryValues(req.query.periods).map((value) => value.toUpperCase());
+    if (periods.some((period) => !allowedPeriods.has(period))) {
+      res.status(400).json({ message: "節次篩選格式錯誤，periods 僅接受 1 至 9 或 A 至 G。" });
+      return;
+    }
     const semesters = String(req.query.semesters || "")
       .split(",")
       .map((item) => item.trim())
       .filter((value) => Boolean(value));
+    const includeTimeslots = req.query.includeTimeslots === "true";
 
     const search = {
       search: String(req.query.search || ""),
@@ -46,12 +53,10 @@ export const getAllCourses: RequestHandler = async (
       sortBy: String(req.query.sortBy || "")
     };
 
-    const { courses, total } = await CourseService.getAllCourses({
-      page,
-      limit,
-      offset,
-      search,
-    });
+    const courseResult = includeTimeslots
+      ? await CourseService.getAllCourses({ page, limit, offset, search }, true)
+      : await CourseService.getAllCourses({ page, limit, offset, search });
+    const { courses, total } = courseResult;
     res.status(200).json({
       courses,
       pagination: {

--- a/backend/controllers/timetableController.ts
+++ b/backend/controllers/timetableController.ts
@@ -1,6 +1,20 @@
 ﻿import { RequestHandler, Response } from "express";
 import TimetableService, { TimetableServiceError } from "../services/timetableService";
 
+const parsePositiveSafeInteger = (value: unknown): number | null => {
+  if (
+    (typeof value !== "string" && typeof value !== "number")
+    || String(value).trim() === ""
+  ) {
+    return null;
+  }
+
+  const parsedValue = Number(value);
+  return Number.isSafeInteger(parsedValue) && parsedValue > 0
+    ? parsedValue
+    : null;
+};
+
 const handleTimetableError = (res: Response, err: unknown): void => {
   if (err instanceof TimetableServiceError) {
     res.status(err.status).json({
@@ -51,9 +65,9 @@ export const addTimetableCourse: RequestHandler = async (req, res): Promise<void
       return;
     }
 
-    const timetableId = parseInt(req.params.timetableId);
-    const courseId = Number(req.body?.courseId);
-    if (Number.isNaN(timetableId) || Number.isNaN(courseId)) {
+    const timetableId = parsePositiveSafeInteger(req.params.timetableId);
+    const courseId = parsePositiveSafeInteger(req.body?.courseId);
+    if (timetableId === null || courseId === null) {
       res.status(400).json({ message: "參數格式錯誤" });
       return;
     }
@@ -80,8 +94,8 @@ export const batchAddTimetableFromInterests: RequestHandler = async (req, res): 
       return;
     }
 
-    const timetableId = parseInt(req.params.timetableId);
-    if (Number.isNaN(timetableId)) {
+    const timetableId = parsePositiveSafeInteger(req.params.timetableId);
+    if (timetableId === null) {
       res.status(400).json({ message: "參數格式錯誤" });
       return;
     }
@@ -123,9 +137,9 @@ export const removeTimetableCourse: RequestHandler = async (req, res): Promise<v
       return;
     }
 
-    const timetableId = parseInt(req.params.timetableId);
-    const courseId = parseInt(req.params.courseId);
-    if (Number.isNaN(timetableId) || Number.isNaN(courseId)) {
+    const timetableId = parsePositiveSafeInteger(req.params.timetableId);
+    const courseId = parsePositiveSafeInteger(req.params.courseId);
+    if (timetableId === null || courseId === null) {
       res.status(400).json({ message: "參數格式錯誤" });
       return;
     }

--- a/backend/controllers/timetableController.ts
+++ b/backend/controllers/timetableController.ts
@@ -115,14 +115,40 @@ export const swapTimetableCourse: RequestHandler = async (req, res): Promise<voi
       return;
     }
 
-    const timetableId = parseInt(req.params.timetableId);
-    const courseId = Number(req.body?.courseId);
-    if (Number.isNaN(timetableId) || Number.isNaN(courseId)) {
-      res.status(400).json({ message: "參數格式錯誤" });
+    const timetableId = parsePositiveSafeInteger(req.params.timetableId);
+    const courseId = parsePositiveSafeInteger(req.body?.courseId);
+    const rawConflictCourseIds = req.body?.conflictCourseIds;
+    if (rawConflictCourseIds === undefined) {
+      res.status(409).json({
+        code: "CLIENT_UPDATE_REQUIRED",
+        message: "課表交換功能已更新，請重新整理頁面後再試",
+      });
       return;
     }
 
-    const result = await TimetableService.swapCourse(timetableId, user_id, courseId);
+    const parsedConflictCourseIds = Array.isArray(rawConflictCourseIds)
+      ? rawConflictCourseIds.map(parsePositiveSafeInteger)
+      : [];
+    const hasInvalidConflictCourseIds = !Array.isArray(rawConflictCourseIds)
+      || parsedConflictCourseIds.some((value) => value === null);
+    if (
+      timetableId === null
+      || courseId === null
+      || hasInvalidConflictCourseIds
+    ) {
+      res.status(400).json({ message: "參數格式錯誤" });
+      return;
+    }
+    const conflictCourseIds = parsedConflictCourseIds.filter(
+      (value): value is number => value !== null
+    );
+
+    const result = await TimetableService.swapCourse(
+      timetableId,
+      user_id,
+      courseId,
+      conflictCourseIds
+    );
     res.status(200).json(result);
   } catch (err) {
     handleTimetableError(res, err);

--- a/backend/repositories/courseRepository.ts
+++ b/backend/repositories/courseRepository.ts
@@ -107,7 +107,7 @@ class CourseRepository {
     limit,
     offset,
     search,
-  }: PaginationParams): Promise<{ courses: Course[]; total: number }> {
+  }: PaginationParams): Promise<{ courses: CourseModel[]; total: number }> {
     const whereCondition: any = {};
     if (search && search.search) {
       whereCondition[Op.or] = [

--- a/backend/repositories/courseRepository.ts
+++ b/backend/repositories/courseRepository.ts
@@ -3,9 +3,12 @@ import CourseModel from "../models/Course";
 import CourseScheduleModel from "../models/CourseSchedule";
 import { Course, CourseOptionFilters, PaginationParams } from "../types/course";
 import db from "../models";
+import {
+  EWANT_DEPARTMENT,
+  normalizeCourseSchedule,
+  PERIOD_ORDER,
+} from "../utils/courseSchedule";
 
-const EWANT_DEPARTMENT = "校外遠距(EWANT)";
-const PERIOD_ORDER = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G"] as const;
 const PERIOD_INDEX_MAP = PERIOD_ORDER.reduce<Record<string, number>>((acc, period, index) => {
   acc[period] = index;
   return acc;
@@ -78,16 +81,16 @@ class CourseRepository {
 
     const matchedCourseIds = new Set<number>();
     scheduleRows.forEach((row) => {
-      const startIndex = PERIOD_INDEX_MAP[row.start_period as string];
-      if (typeof startIndex !== "number") return;
+      const normalizedSchedule = normalizeCourseSchedule(row);
+      if (!normalizedSchedule) return;
 
       if (selectedPeriods.size === 0) {
         matchedCourseIds.add(Number(row.course_id));
         return;
       }
 
-      const span = Math.max(Number(row.span) || 1, 1);
-      const endIndex = startIndex + span - 1;
+      const startIndex = PERIOD_INDEX_MAP[normalizedSchedule.startPeriod];
+      const endIndex = PERIOD_INDEX_MAP[normalizedSchedule.endPeriod];
       for (let index = startIndex; index <= endIndex; index += 1) {
         const period = PERIOD_ORDER[index];
         if (period && selectedPeriods.has(period)) {

--- a/backend/repositories/courseScheduleRepository.ts
+++ b/backend/repositories/courseScheduleRepository.ts
@@ -1,4 +1,5 @@
 import CourseScheduleModel from "../models/CourseSchedule";
+import { Transaction } from "sequelize";
 
 class CourseScheduleRepository {
   async getByCourseId(course_id: number): Promise<CourseScheduleModel[]> {
@@ -8,10 +9,14 @@ class CourseScheduleRepository {
     });
   }
 
-  async getByCourseIds(courseIds: number[]): Promise<CourseScheduleModel[]> {
+  async getByCourseIds(
+    courseIds: number[],
+    transaction?: Transaction
+  ): Promise<CourseScheduleModel[]> {
     if (courseIds.length === 0) return [];
     return await CourseScheduleModel.findAll({
       where: { course_id: courseIds },
+      transaction,
       order: [["course_id", "ASC"], ["day", "ASC"], ["start_period", "ASC"]],
     });
   }

--- a/backend/repositories/interestRepository.ts
+++ b/backend/repositories/interestRepository.ts
@@ -46,17 +46,28 @@ class InterestRepository {
     })
   }
 
-  async getAllInterestsByUserId(user_id: number): Promise<AllInterestsResponse[]> {
+  async getAllInterestsByUserId(
+    user_id: number,
+    transaction?: Transaction
+  ): Promise<AllInterestsResponse[]> {
     const interests = await InterestModel.findAll({
       where: { user_id },
       attributes: ["id", "course_id", "created_at"],
+      transaction,
       order: [["created_at", "DESC"]],
       include: [
         {
           model: CourseModel,
           as: "course",
           required: true,
-          attributes: ["id", "semester", "course_name", "instructor"],
+          attributes: [
+            "id",
+            "semester",
+            "course_name",
+            "department",
+            "instructor",
+            "course_room",
+          ],
         },
       ],
     });

--- a/backend/repositories/timetableRepository.ts
+++ b/backend/repositories/timetableRepository.ts
@@ -30,12 +30,6 @@ class TimetableRepository {
     }
   }
 
-  async findByIdAndUser(id: number, user_id: number): Promise<TimetableModel | null> {
-    return await TimetableModel.findOne({
-      where: { id, user_id },
-    });
-  }
-
   async findByIdAndUserForUpdate(
     id: number,
     user_id: number,

--- a/backend/repositories/timetableRepository.ts
+++ b/backend/repositories/timetableRepository.ts
@@ -1,5 +1,5 @@
 import TimetableModel from "../models/Timetable";
-import { UniqueConstraintError } from "sequelize";
+import { Transaction, UniqueConstraintError } from "sequelize";
 
 class TimetableRepository {
   async findByUserAndSemester(user_id: number, semester: string): Promise<TimetableModel | null> {
@@ -33,6 +33,18 @@ class TimetableRepository {
   async findByIdAndUser(id: number, user_id: number): Promise<TimetableModel | null> {
     return await TimetableModel.findOne({
       where: { id, user_id },
+    });
+  }
+
+  async findByIdAndUserForUpdate(
+    id: number,
+    user_id: number,
+    transaction: Transaction
+  ): Promise<TimetableModel | null> {
+    return await TimetableModel.findOne({
+      where: { id, user_id },
+      transaction,
+      lock: transaction.LOCK.UPDATE,
     });
   }
 }

--- a/backend/services/courseService.ts
+++ b/backend/services/courseService.ts
@@ -1,12 +1,56 @@
-import { Course, CourseDetailResponse, CourseOptionFilters } from "../types/course";
+import {
+  Course,
+  CourseDetailResponse,
+  CourseListResult,
+  CourseOptionFilters,
+  CourseWithTimeslots,
+} from "../types/course";
 import { PaginationParams } from "../types/course";
 import CourseRepository from "../repositories/courseRepository";
+import CourseScheduleRepository from "../repositories/courseScheduleRepository";
 import InterestRepository from "../repositories/interestRepository";
 import CourseRelatedPostService from "./courseRelatedPostService";
+import {
+  isEwantDepartment,
+  normalizeCourseSchedule,
+  normalizeCourseSchedules,
+} from "../utils/courseSchedule";
 
 class CourseService {
-  async getAllCourses(params: PaginationParams): Promise<{ courses: Course[], total: number }> {
-    return await CourseRepository.getAllCourses(params);
+  async getAllCourses(params: PaginationParams): Promise<CourseListResult>;
+  async getAllCourses(params: PaginationParams, includeTimeslots: false): Promise<CourseListResult>;
+  async getAllCourses(params: PaginationParams, includeTimeslots: true): Promise<CourseListResult<CourseWithTimeslots>>;
+  async getAllCourses(
+    params: PaginationParams,
+    includeTimeslots = false
+  ): Promise<CourseListResult<Course | CourseWithTimeslots>> {
+    const result = await CourseRepository.getAllCourses(params);
+    if (!includeTimeslots) return result;
+
+    const courseIds = result.courses.map((course) => course.id);
+    const schedules = await CourseScheduleRepository.getByCourseIds(courseIds);
+    const timeslotsByCourseId = schedules.reduce<Map<number, CourseWithTimeslots["timeslots"]>>(
+      (map, schedule) => {
+        const normalized = normalizeCourseSchedule(schedule);
+        if (!normalized) return map;
+
+        const current = map.get(schedule.course_id) ?? [];
+        current.push(normalized);
+        map.set(schedule.course_id, current);
+        return map;
+      },
+      new Map()
+    );
+
+    return {
+      ...result,
+      courses: result.courses.map((course) => ({
+        ...(course.toJSON() as Course),
+        timeslots: isEwantDepartment(course.department)
+          ? []
+          : timeslotsByCourseId.get(course.id) ?? [],
+      })),
+    };
   }
 
   async getCourse(user_id: number|undefined, course_id: number): Promise<CourseDetailResponse | null>{
@@ -19,9 +63,15 @@ class CourseService {
       if(interest !== null) hasUserAddInterest = true;
     };
 
-    const related_posts = await CourseRelatedPostService.getByCourseId(course_id);
+    const [related_posts, schedules] = await Promise.all([
+      CourseRelatedPostService.getByCourseId(course_id),
+      CourseScheduleRepository.getByCourseId(course_id),
+    ]);
+    const timeslots = isEwantDepartment(course.department)
+      ? []
+      : normalizeCourseSchedules(schedules);
 
-    return { course, hasUserAddInterest, related_posts };
+    return { course, timeslots, hasUserAddInterest, related_posts };
   }
 
   async getAllDepartments(filters: CourseOptionFilters = {}): Promise<string[]>{

--- a/backend/services/timetableService.ts
+++ b/backend/services/timetableService.ts
@@ -13,6 +13,12 @@ import {
   TimetableItemResponse,
   TimetableResponse,
 } from "../types/timetable";
+import {
+  buildTimetableConflict,
+  hasTimeslotOverlap,
+  isEwantDepartment,
+  normalizeCourseSchedule,
+} from "../utils/courseSchedule";
 
 type CourseMeta = {
   id: number;
@@ -26,83 +32,6 @@ type CourseMeta = {
 type CourseWithTimeslots = {
   course: CourseMeta;
   timeslots: CourseTimeslot[];
-};
-
-const PERIOD_ORDER = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G"];
-const PERIOD_INDEX_MAP = PERIOD_ORDER.reduce<Record<string, number>>((map, period, index) => {
-  map[period] = index;
-  return map;
-}, {});
-const PERIOD_MIN_MAP: Record<string, { start: number; end: number }> = {
-  "1": { start: 430, end: 480 },
-  "2": { start: 480, end: 530 },
-  "3": { start: 540, end: 590 },
-  "4": { start: 600, end: 650 },
-  "5": { start: 660, end: 710 },
-  "6": { start: 720, end: 770 },
-  "7": { start: 780, end: 830 },
-  "8": { start: 840, end: 890 },
-  "9": { start: 900, end: 950 },
-  A: { start: 960, end: 1010 },
-  B: { start: 1020, end: 1070 },
-  C: { start: 1110, end: 1160 },
-  D: { start: 1160, end: 1210 },
-  E: { start: 1210, end: 1260 },
-  F: { start: 1260, end: 1310 },
-  G: { start: 1310, end: 1360 },
-};
-
-const getPeriodByMinute = (minute: number, mode: "start" | "end"): string => {
-  if (mode === "start") {
-    const found = PERIOD_ORDER.find((period) => PERIOD_MIN_MAP[period].start <= minute && minute < PERIOD_MIN_MAP[period].end);
-    return found ?? PERIOD_ORDER[0];
-  }
-
-  const found = [...PERIOD_ORDER].reverse().find((period) => PERIOD_MIN_MAP[period].start < minute && minute <= PERIOD_MIN_MAP[period].end);
-  return found ?? PERIOD_ORDER[PERIOD_ORDER.length - 1];
-};
-
-const normalizeSchedule = (schedule: CourseScheduleModel): CourseTimeslot | null => {
-  const startIndex = PERIOD_INDEX_MAP[schedule.start_period];
-  if (typeof startIndex !== "number") return null;
-
-  const endIndex = startIndex + Math.max(schedule.span, 1) - 1;
-  if (endIndex >= PERIOD_ORDER.length) return null;
-
-  const startPeriod = PERIOD_ORDER[startIndex];
-  const endPeriod = PERIOD_ORDER[endIndex];
-  const startMin = PERIOD_MIN_MAP[startPeriod]?.start;
-  const endMin = PERIOD_MIN_MAP[endPeriod]?.end;
-  if (typeof startMin !== "number" || typeof endMin !== "number") return null;
-
-  return {
-    dayOfWeek: schedule.day,
-    startPeriod,
-    endPeriod,
-    startMin,
-    endMin,
-  };
-};
-
-const hasOverlap = (a: CourseTimeslot, b: CourseTimeslot): boolean => {
-  return a.dayOfWeek === b.dayOfWeek && a.startMin < b.endMin && b.startMin < a.endMin;
-};
-
-const buildConflict = (courseId: number, conflictWithCourseId: number, a: CourseTimeslot, b: CourseTimeslot): TimetableConflict => {
-  const overlapStart = Math.max(a.startMin, b.startMin);
-  const overlapEnd = Math.min(a.endMin, b.endMin);
-
-  return {
-    courseId,
-    conflictWithCourseId,
-    dayOfWeek: a.dayOfWeek,
-    overlap: {
-      startMin: overlapStart,
-      endMin: overlapEnd,
-      startPeriod: getPeriodByMinute(overlapStart, "start"),
-      endPeriod: getPeriodByMinute(overlapEnd, "end"),
-    },
-  };
 };
 
 export class TimetableServiceError extends Error {
@@ -136,10 +65,10 @@ class TimetableService {
     });
 
     schedules.forEach((schedule) => {
-      const normalized = normalizeSchedule(schedule);
-      if (!normalized) return;
       const target = map.get(schedule.course_id);
-      if (!target) return;
+      if (!target || isEwantDepartment(target.course.department)) return;
+      const normalized = normalizeCourseSchedule(schedule);
+      if (!normalized) return;
       target.timeslots.push(normalized);
     });
 
@@ -152,8 +81,8 @@ class TimetableService {
     existingCourses.forEach((existing) => {
       candidate.timeslots.forEach((candidateSlot) => {
         existing.timeslots.forEach((existingSlot) => {
-          if (!hasOverlap(candidateSlot, existingSlot)) return;
-          conflicts.push(buildConflict(candidate.course.id, existing.course.id, candidateSlot, existingSlot));
+          if (!hasTimeslotOverlap(candidateSlot, existingSlot)) return;
+          conflicts.push(buildTimetableConflict(candidate.course.id, existing.course.id, candidateSlot, existingSlot));
         });
       });
     });
@@ -167,7 +96,7 @@ class TimetableService {
     const schedules = await CourseScheduleRepository.getByCourseIds(courseIds);
 
     const scheduleMap = schedules.reduce<Map<number, CourseTimeslot[]>>((map, schedule) => {
-      const normalized = normalizeSchedule(schedule);
+      const normalized = normalizeCourseSchedule(schedule);
       if (!normalized) return map;
 
       const current = map.get(schedule.course_id) ?? [];
@@ -189,7 +118,7 @@ class TimetableService {
           instructor: course.instructor,
           room: course.course_room,
         },
-        timeslots: scheduleMap.get(course.id) ?? [],
+        timeslots: isEwantDepartment(course.department) ? [] : scheduleMap.get(course.id) ?? [],
       };
     });
 
@@ -456,14 +385,18 @@ class TimetableService {
     const items = await TimetableItemRepository.getAllByUserId(userId);
     const courseIds = Array.from(new Set(items.map((item) => item.course_id)));
     const schedules = await CourseScheduleRepository.getByCourseIds(courseIds);
-    const hasTimeslotsSet = new Set(schedules.map((schedule) => schedule.course_id));
+    const hasTimeslotsSet = new Set(
+      schedules
+        .filter((schedule) => normalizeCourseSchedule(schedule) !== null)
+        .map((schedule) => schedule.course_id)
+    );
 
     return items.map((item) => {
       const raw = item.toJSON() as unknown as TimetableItemWithSemesterJson;
       return {
         timetableId: raw.timetable.id,
         semester: raw.timetable.semester,
-        hasTimeslots: hasTimeslotsSet.has(raw.course.id),
+        hasTimeslots: !isEwantDepartment(raw.course.department) && hasTimeslotsSet.has(raw.course.id),
         course: {
           id: raw.course.id,
           name: raw.course.course_name,

--- a/backend/services/timetableService.ts
+++ b/backend/services/timetableService.ts
@@ -46,14 +46,6 @@ export class TimetableServiceError extends Error {
 }
 
 class TimetableService {
-  private async getOrThrowOwnedTimetable(timetableId: number, userId: number) {
-    const timetable = await TimetableRepository.findByIdAndUser(timetableId, userId);
-    if (!timetable) {
-      throw new TimetableServiceError(404, "找不到課表");
-    }
-    return timetable;
-  }
-
   private async getOrThrowLockedTimetable(
     timetableId: number,
     userId: number,
@@ -263,8 +255,12 @@ class TimetableService {
     }
   }
 
-  async swapCourse(timetableId: number, userId: number, courseId: number) {
-    const timetable = await this.getOrThrowOwnedTimetable(timetableId, userId);
+  async swapCourse(
+    timetableId: number,
+    userId: number,
+    courseId: number,
+    expectedConflictCourseIds: number[]
+  ) {
     const course = await CourseRepository.getCourse(courseId);
     if (!course) {
       throw new TimetableServiceError(404, "找不到課程");
@@ -279,58 +275,79 @@ class TimetableService {
       room: course.course_room,
     };
 
-    if (course.semester !== timetable.semester) {
-      throw new TimetableServiceError(409, "只能加入相同學期的課程");
-    }
-
     try {
-      return await db.sequelize.transaction(async (transaction) => {
-        const existingItem = await TimetableItemRepository.findByTimetableAndCourse(timetable.id, course.id, transaction);
-        if (existingItem) {
+      return await db.sequelize.transaction(
+        { isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED },
+        async (transaction) => {
+          const timetable = await this.getOrThrowLockedTimetable(
+            timetableId,
+            userId,
+            transaction
+          );
+          if (course.semester !== timetable.semester) {
+            throw new TimetableServiceError(409, "只能加入相同學期的課程");
+          }
+
+          const timetableItems = await TimetableItemRepository.getAllByTimetableId(timetable.id, transaction);
+          if (timetableItems.some((item) => item.course_id === course.id)) {
+            return {
+              added: false,
+              alreadyExists: true,
+              removedCourseIds: [] as number[],
+            };
+          }
+
+          const existingCourses: CourseMeta[] = timetableItems.map((item) => {
+            const raw = item.toJSON() as unknown as TimetableItemModelJson;
+            return {
+              id: raw.course.id,
+              name: raw.course.course_name,
+              semester: raw.course.semester,
+              department: raw.course.department,
+              instructor: raw.course.instructor,
+              room: raw.course.course_room,
+            };
+          });
+
+          const allCourseIds = [...new Set([...existingCourses.map((item) => item.id), candidateCourse.id])];
+          const schedules = await CourseScheduleRepository.getByCourseIds(
+            allCourseIds,
+            transaction
+          );
+          const allMap = this.toCourseWithTimeslotsMap([candidateCourse, ...existingCourses], schedules);
+          const candidate = allMap.get(candidateCourse.id) ?? { course: candidateCourse, timeslots: [] };
+          const existingWithTimeslots = existingCourses.map((meta) => allMap.get(meta.id) ?? { course: meta, timeslots: [] });
+
+          const conflicts = this.findConflicts(candidate, existingWithTimeslots);
+          const conflictCourseIds = Array.from(new Set(conflicts.map((item) => item.conflictWithCourseId)));
+          const expectedConflictCourseIdSet = new Set(expectedConflictCourseIds);
+          const conflictsChanged = conflictCourseIds.length !== expectedConflictCourseIdSet.size
+            || conflictCourseIds.some((conflictCourseId) => !expectedConflictCourseIdSet.has(conflictCourseId));
+
+          if (conflictsChanged) {
+            throw new TimetableServiceError(
+              409,
+              "課表已在其他分頁變更，請重新確認衝堂課程",
+              { code: "CONFLICTS_CHANGED", conflicts }
+            );
+          }
+
+          for (const conflictCourseId of conflictCourseIds) {
+            await TimetableItemRepository.removeCourse(timetable.id, conflictCourseId, transaction);
+          }
+
+          await TimetableItemRepository.addCourse(timetable.id, course.id, transaction);
+
           return {
-            added: false,
-            alreadyExists: true,
-            removedCourseIds: [] as number[],
+            added: true,
+            alreadyExists: false,
+            removedCourseIds: conflictCourseIds,
           };
         }
-
-        const timetableItems = await TimetableItemRepository.getAllByTimetableId(timetable.id, transaction);
-        const existingCourses: CourseMeta[] = timetableItems.map((item) => {
-          const raw = item.toJSON() as unknown as TimetableItemModelJson;
-          return {
-            id: raw.course.id,
-            name: raw.course.course_name,
-            semester: raw.course.semester,
-            department: raw.course.department,
-            instructor: raw.course.instructor,
-            room: raw.course.course_room,
-          };
-        });
-
-        const allCourseIds = [...new Set([...existingCourses.map((item) => item.id), candidateCourse.id])];
-        const schedules = await CourseScheduleRepository.getByCourseIds(allCourseIds);
-        const allMap = this.toCourseWithTimeslotsMap([candidateCourse, ...existingCourses], schedules);
-        const candidate = allMap.get(candidateCourse.id) ?? { course: candidateCourse, timeslots: [] };
-        const existingWithTimeslots = existingCourses.map((meta) => allMap.get(meta.id) ?? { course: meta, timeslots: [] });
-
-        const conflicts = this.findConflicts(candidate, existingWithTimeslots);
-        const conflictCourseIds = Array.from(new Set(conflicts.map((item) => item.conflictWithCourseId)));
-
-        for (const conflictCourseId of conflictCourseIds) {
-          await TimetableItemRepository.removeCourse(timetable.id, conflictCourseId, transaction);
-        }
-
-        await TimetableItemRepository.addCourse(timetable.id, course.id, transaction);
-
-        return {
-          added: true,
-          alreadyExists: false,
-          removedCourseIds: conflictCourseIds,
-        };
-      });
+      );
     } catch (error) {
       if (error instanceof UniqueConstraintError) {
-        const existingItem = await TimetableItemRepository.findByTimetableAndCourse(timetable.id, course.id);
+        const existingItem = await TimetableItemRepository.findByTimetableAndCourse(timetableId, course.id);
         if (existingItem) {
           return {
             added: false,

--- a/backend/services/timetableService.ts
+++ b/backend/services/timetableService.ts
@@ -5,7 +5,7 @@ import CourseScheduleRepository from "../repositories/courseScheduleRepository";
 import InterestRepository from "../repositories/interestRepository";
 import TimetableItemRepository from "../repositories/timetableItemRepository";
 import TimetableRepository from "../repositories/timetableRepository";
-import { UniqueConstraintError } from "sequelize";
+import { Transaction, UniqueConstraintError } from "sequelize";
 import {
   AddedCourseItemResponse,
   CourseTimeslot,
@@ -48,6 +48,23 @@ export class TimetableServiceError extends Error {
 class TimetableService {
   private async getOrThrowOwnedTimetable(timetableId: number, userId: number) {
     const timetable = await TimetableRepository.findByIdAndUser(timetableId, userId);
+    if (!timetable) {
+      throw new TimetableServiceError(404, "找不到課表");
+    }
+    return timetable;
+  }
+
+  private async getOrThrowLockedTimetable(
+    timetableId: number,
+    userId: number,
+    transaction: Transaction
+  ) {
+    // 以課表主列作為同一份課表的互斥鎖，讓衝堂檢查與寫入不可交錯。
+    const timetable = await TimetableRepository.findByIdAndUserForUpdate(
+      timetableId,
+      userId,
+      transaction
+    );
     if (!timetable) {
       throw new TimetableServiceError(404, "找不到課表");
     }
@@ -142,41 +159,11 @@ class TimetableService {
   }
 
   async addCourse(timetableId: number, userId: number, courseId: number) {
-    const timetable = await this.getOrThrowOwnedTimetable(timetableId, userId);
     const course = await CourseRepository.getCourse(courseId);
     if (!course) {
       throw new TimetableServiceError(404, "找不到課程");
     }
 
-    if (course.semester !== timetable.semester) {
-      throw new TimetableServiceError(409, "只能加入相同學期的課程");
-    }
-
-    const existingItem = await TimetableItemRepository.findByTimetableAndCourse(timetable.id, course.id);
-    if (existingItem) {
-      return {
-        added: false,
-        alreadyExists: true,
-        conflicts: [],
-      };
-    }
-
-    const timetableItems = await TimetableItemRepository.getAllByTimetableId(timetable.id);
-    const existingCourseIds = timetableItems.map((item) => item.course_id);
-    const allCourseIds = [...new Set([...existingCourseIds, course.id])];
-    const schedules = await CourseScheduleRepository.getByCourseIds(allCourseIds);
-
-    const existingCourses: CourseMeta[] = timetableItems.map((item) => {
-      const raw = item.toJSON() as unknown as TimetableItemModelJson;
-      return {
-        id: raw.course.id,
-        name: raw.course.course_name,
-        semester: raw.course.semester,
-        department: raw.course.department,
-        instructor: raw.course.instructor,
-        room: raw.course.course_room,
-      };
-    });
     const candidateCourse: CourseMeta = {
       id: course.id,
       name: course.course_name,
@@ -186,25 +173,84 @@ class TimetableService {
       room: course.course_room,
     };
 
-    const allMap = this.toCourseWithTimeslotsMap([candidateCourse, ...existingCourses], schedules);
-    const candidate = allMap.get(candidateCourse.id) ?? { course: candidateCourse, timeslots: [] };
-    const existingWithTimeslots = existingCourses.map((meta) => allMap.get(meta.id) ?? { course: meta, timeslots: [] });
-
-    // 缺時段資料（timeslots = []）不參與衝堂判斷，因為無法比較時段
-    const conflicts = this.findConflicts(candidate, existingWithTimeslots);
-    if (conflicts.length > 0) {
-      return {
-        added: false,
-        alreadyExists: false,
-        conflicts,
-      };
-    }
-
     try {
-      await TimetableItemRepository.addCourse(timetable.id, course.id);
+      return await db.sequelize.transaction(
+        { isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED },
+        async (transaction) => {
+          const timetable = await this.getOrThrowLockedTimetable(
+            timetableId,
+            userId,
+            transaction
+          );
+          if (course.semester !== timetable.semester) {
+            throw new TimetableServiceError(409, "只能加入相同學期的課程");
+          }
+
+          const timetableItems = await TimetableItemRepository.getAllByTimetableId(
+            timetable.id,
+            transaction
+          );
+          if (timetableItems.some((item) => item.course_id === course.id)) {
+            return {
+              added: false,
+              alreadyExists: true,
+              conflicts: [],
+            };
+          }
+
+          const existingCourseIds = timetableItems.map((item) => item.course_id);
+          const allCourseIds = [...new Set([...existingCourseIds, course.id])];
+          const schedules = await CourseScheduleRepository.getByCourseIds(
+            allCourseIds,
+            transaction
+          );
+
+          const existingCourses: CourseMeta[] = timetableItems.map((item) => {
+            const raw = item.toJSON() as unknown as TimetableItemModelJson;
+            return {
+              id: raw.course.id,
+              name: raw.course.course_name,
+              semester: raw.course.semester,
+              department: raw.course.department,
+              instructor: raw.course.instructor,
+              room: raw.course.course_room,
+            };
+          });
+          const allMap = this.toCourseWithTimeslotsMap(
+            [candidateCourse, ...existingCourses],
+            schedules
+          );
+          const candidate = allMap.get(candidateCourse.id) ?? {
+            course: candidateCourse,
+            timeslots: [],
+          };
+          const existingWithTimeslots = existingCourses.map(
+            (meta) => allMap.get(meta.id) ?? { course: meta, timeslots: [] }
+          );
+
+          // 缺時段資料（timeslots = []）不參與衝堂判斷，因為無法比較時段
+          const conflicts = this.findConflicts(candidate, existingWithTimeslots);
+          if (conflicts.length > 0) {
+            return {
+              added: false,
+              alreadyExists: false,
+              conflicts,
+            };
+          }
+
+          await TimetableItemRepository.addCourse(timetable.id, course.id, transaction);
+
+          return {
+            added: true,
+            alreadyExists: false,
+            item: { courseId: course.id },
+            conflicts: [],
+          };
+        }
+      );
     } catch (error) {
       if (error instanceof UniqueConstraintError) {
-        const duplicated = await TimetableItemRepository.findByTimetableAndCourse(timetable.id, course.id);
+        const duplicated = await TimetableItemRepository.findByTimetableAndCourse(timetableId, course.id);
         if (duplicated) {
           return {
             added: false,
@@ -215,13 +261,6 @@ class TimetableService {
       }
       throw error;
     }
-
-    return {
-      added: true,
-      alreadyExists: false,
-      item: { courseId: course.id },
-      conflicts: [],
-    };
   }
 
   async swapCourse(timetableId: number, userId: number, courseId: number) {
@@ -229,10 +268,6 @@ class TimetableService {
     const course = await CourseRepository.getCourse(courseId);
     if (!course) {
       throw new TimetableServiceError(404, "找不到課程");
-    }
-
-    if (course.semester !== timetable.semester) {
-      throw new TimetableServiceError(409, "只能加入相同學期的課程");
     }
 
     const candidateCourse: CourseMeta = {
@@ -243,6 +278,10 @@ class TimetableService {
       instructor: course.instructor,
       room: course.course_room,
     };
+
+    if (course.semester !== timetable.semester) {
+      throw new TimetableServiceError(409, "只能加入相同學期的課程");
+    }
 
     try {
       return await db.sequelize.transaction(async (transaction) => {
@@ -377,8 +416,13 @@ class TimetableService {
   }
 
   async removeCourse(timetableId: number, userId: number, courseId: number): Promise<void> {
-    await this.getOrThrowOwnedTimetable(timetableId, userId);
-    await TimetableItemRepository.removeCourse(timetableId, courseId);
+    await db.sequelize.transaction(
+      { isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED },
+      async (transaction) => {
+        await this.getOrThrowLockedTimetable(timetableId, userId, transaction);
+        await TimetableItemRepository.removeCourse(timetableId, courseId, transaction);
+      }
+    );
   }
 
   async getAllAddedCourses(userId: number): Promise<AddedCourseItemResponse[]> {

--- a/backend/services/timetableService.ts
+++ b/backend/services/timetableService.ts
@@ -344,75 +344,111 @@ class TimetableService {
   }
 
   async batchAddFromInterests(timetableId: number, userId: number) {
-    const timetable = await this.getOrThrowOwnedTimetable(timetableId, userId);
-    const allInterests = await InterestRepository.getAllInterestsByUserId(userId);
-    const requested = allInterests.length;
-    const eligibleInterests = allInterests.filter((interest) => interest.course.semester === timetable.semester);
+    return await db.sequelize.transaction(
+      { isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED },
+      async (transaction) => {
+        const timetable = await this.getOrThrowLockedTimetable(
+          timetableId,
+          userId,
+          transaction
+        );
+        const allInterests = await InterestRepository.getAllInterestsByUserId(
+          userId,
+          transaction
+        );
+        const requested = allInterests.length;
+        const eligibleInterests = allInterests.filter(
+          (interest) => interest.course.semester === timetable.semester
+        );
 
-    const existingItems = await TimetableItemRepository.getAllByTimetableId(timetable.id);
-    const existingCourseIds = new Set(existingItems.map((item) => item.course_id));
+        const existingItems = await TimetableItemRepository.getAllByTimetableId(
+          timetable.id,
+          transaction
+        );
+        const existingCourseIds = new Set(existingItems.map((item) => item.course_id));
 
-    const candidateCourses: CourseMeta[] = eligibleInterests.map((interest) => ({
-      id: interest.course.id,
-      name: interest.course.course_name,
-      semester: interest.course.semester,
-      department: interest.course.department,
-      instructor: interest.course.instructor,
-    }));
-    const existingCourses: CourseMeta[] = existingItems.map((item) => {
-      const raw = item.toJSON() as unknown as TimetableItemModelJson;
-      return {
-        id: raw.course.id,
-        name: raw.course.course_name,
-        semester: raw.course.semester,
-        department: raw.course.department,
-        instructor: raw.course.instructor,
-        room: raw.course.course_room,
-      };
-    });
+        const candidateCourses: CourseMeta[] = eligibleInterests.map((interest) => ({
+          id: interest.course.id,
+          name: interest.course.course_name,
+          semester: interest.course.semester,
+          department: interest.course.department,
+          instructor: interest.course.instructor,
+          room: interest.course.course_room,
+        }));
+        const existingCourses: CourseMeta[] = existingItems.map((item) => {
+          const raw = item.toJSON() as unknown as TimetableItemModelJson;
+          return {
+            id: raw.course.id,
+            name: raw.course.course_name,
+            semester: raw.course.semester,
+            department: raw.course.department,
+            instructor: raw.course.instructor,
+            room: raw.course.course_room,
+          };
+        });
 
-    const allCourseIds = [...new Set([...existingCourseIds, ...candidateCourses.map((course) => course.id)])];
-    const schedules = await CourseScheduleRepository.getByCourseIds(allCourseIds);
-    const courseMap = this.toCourseWithTimeslotsMap([...existingCourses, ...candidateCourses], schedules);
+        const allCourseIds = [...new Set([
+          ...existingCourseIds,
+          ...candidateCourses.map((course) => course.id),
+        ])];
+        const schedules = await CourseScheduleRepository.getByCourseIds(
+          allCourseIds,
+          transaction
+        );
+        const courseMap = this.toCourseWithTimeslotsMap(
+          [...existingCourses, ...candidateCourses],
+          schedules
+        );
 
-    const selectedCourseIds = new Set(existingCourses.map((course) => course.id));
-    const selectedCourses = [...existingCourses].map((course) => courseMap.get(course.id) ?? { course, timeslots: [] });
-    const conflicts: TimetableConflict[] = [];
-    let added = 0;
-    let skippedAlreadyExists = 0;
-    let conflicted = 0;
+        const selectedCourseIds = new Set(existingCourses.map((course) => course.id));
+        const selectedCourses = existingCourses.map(
+          (course) => courseMap.get(course.id) ?? { course, timeslots: [] }
+        );
+        const conflicts: TimetableConflict[] = [];
+        let added = 0;
+        let skippedAlreadyExists = 0;
+        let conflicted = 0;
 
-    for (const candidateMeta of candidateCourses) {
-      if (selectedCourseIds.has(candidateMeta.id)) {
-        skippedAlreadyExists += 1;
-        continue;
+        for (const candidateMeta of candidateCourses) {
+          if (selectedCourseIds.has(candidateMeta.id)) {
+            skippedAlreadyExists += 1;
+            continue;
+          }
+
+          const candidate = courseMap.get(candidateMeta.id) ?? {
+            course: candidateMeta,
+            timeslots: [],
+          };
+          const detected = this.findConflicts(candidate, selectedCourses);
+
+          if (detected.length > 0) {
+            conflicted += 1;
+            conflicts.push(...detected);
+            continue;
+          }
+
+          await TimetableItemRepository.addCourse(
+            timetable.id,
+            candidateMeta.id,
+            transaction
+          );
+          added += 1;
+          selectedCourseIds.add(candidateMeta.id);
+          selectedCourses.push(candidate);
+        }
+
+        return {
+          summary: {
+            requested,
+            eligibleSameSemester: eligibleInterests.length,
+            added,
+            skippedAlreadyExists,
+            conflicted,
+          },
+          conflicts,
+        };
       }
-
-      const candidate = courseMap.get(candidateMeta.id) ?? { course: candidateMeta, timeslots: [] };
-      const detected = this.findConflicts(candidate, selectedCourses);
-
-      if (detected.length > 0) {
-        conflicted += 1;
-        conflicts.push(...detected);
-        continue;
-      }
-
-      await TimetableItemRepository.addCourse(timetable.id, candidateMeta.id);
-      added += 1;
-      selectedCourseIds.add(candidateMeta.id);
-      selectedCourses.push(candidate);
-    }
-
-    return {
-      summary: {
-        requested,
-        eligibleSameSemester: eligibleInterests.length,
-        added,
-        skippedAlreadyExists,
-        conflicted,
-      },
-      conflicts,
-    };
+    );
   }
 
   async removeCourse(timetableId: number, userId: number, courseId: number): Promise<void> {

--- a/backend/types/course.ts
+++ b/backend/types/course.ts
@@ -1,3 +1,5 @@
+import type { CourseTimeslot } from "./timetable";
+
 export interface Course {
   id: number;
   course_name: string;
@@ -17,6 +19,15 @@ export interface Course {
   view_count?: number;
   review_count?: number;
   dcard_related_post_count?: number;
+}
+
+export interface CourseWithTimeslots extends Course {
+  timeslots: CourseTimeslot[];
+}
+
+export interface CourseListResult<TCourse extends Course = Course> {
+  courses: TCourse[];
+  total: number;
 }
 
 export interface CourseRelatedPost {
@@ -55,6 +66,7 @@ export interface RelatedPostComment {
 
 export interface CourseDetailResponse {
   course: Course;
+  timeslots: CourseTimeslot[];
   hasUserAddInterest: boolean;
   related_posts: CourseRelatedPost[];
 }

--- a/backend/utils/courseSchedule.ts
+++ b/backend/utils/courseSchedule.ts
@@ -1,0 +1,97 @@
+import type CourseScheduleModel from "../models/CourseSchedule";
+import type { CourseTimeslot, TimetableConflict } from "../types/timetable";
+
+export const EWANT_DEPARTMENT = "校外遠距(EWANT)";
+
+export const PERIOD_ORDER = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G"];
+const PERIOD_INDEX_MAP = PERIOD_ORDER.reduce<Record<string, number>>((map, period, index) => {
+  map[period] = index;
+  return map;
+}, {});
+export const PERIOD_MIN_MAP: Record<string, { start: number; end: number }> = {
+  "1": { start: 430, end: 480 },
+  "2": { start: 480, end: 530 },
+  "3": { start: 540, end: 590 },
+  "4": { start: 600, end: 650 },
+  "5": { start: 660, end: 710 },
+  "6": { start: 720, end: 770 },
+  "7": { start: 780, end: 830 },
+  "8": { start: 840, end: 890 },
+  "9": { start: 900, end: 950 },
+  A: { start: 960, end: 1010 },
+  B: { start: 1020, end: 1070 },
+  C: { start: 1110, end: 1160 },
+  D: { start: 1160, end: 1210 },
+  E: { start: 1210, end: 1260 },
+  F: { start: 1260, end: 1310 },
+  G: { start: 1310, end: 1360 },
+};
+
+const getPeriodByMinute = (minute: number, mode: "start" | "end"): string => {
+  if (mode === "start") {
+    const found = PERIOD_ORDER.find((period) => PERIOD_MIN_MAP[period].start <= minute && minute < PERIOD_MIN_MAP[period].end);
+    return found ?? PERIOD_ORDER[0];
+  }
+
+  const found = [...PERIOD_ORDER].reverse().find((period) => PERIOD_MIN_MAP[period].start < minute && minute <= PERIOD_MIN_MAP[period].end);
+  return found ?? PERIOD_ORDER[PERIOD_ORDER.length - 1];
+};
+
+export const normalizeCourseSchedule = (schedule: CourseScheduleModel): CourseTimeslot | null => {
+  if (!Number.isInteger(schedule.day) || schedule.day < 1 || schedule.day > 7) return null;
+  if (!Number.isInteger(schedule.span) || schedule.span < 1) return null;
+
+  const startIndex = PERIOD_INDEX_MAP[schedule.start_period];
+  if (typeof startIndex !== "number") return null;
+
+  const endIndex = startIndex + schedule.span - 1;
+  if (endIndex >= PERIOD_ORDER.length) return null;
+
+  const startPeriod = PERIOD_ORDER[startIndex];
+  const endPeriod = PERIOD_ORDER[endIndex];
+  const startMin = PERIOD_MIN_MAP[startPeriod]?.start;
+  const endMin = PERIOD_MIN_MAP[endPeriod]?.end;
+  if (typeof startMin !== "number" || typeof endMin !== "number") return null;
+
+  return {
+    dayOfWeek: schedule.day,
+    startPeriod,
+    endPeriod,
+    startMin,
+    endMin,
+  };
+};
+
+export const normalizeCourseSchedules = (schedules: CourseScheduleModel[]): CourseTimeslot[] => {
+  return schedules
+    .map(normalizeCourseSchedule)
+    .filter((timeslot): timeslot is CourseTimeslot => timeslot !== null);
+};
+
+export const isEwantDepartment = (department: string): boolean => department === EWANT_DEPARTMENT;
+
+export const hasTimeslotOverlap = (a: CourseTimeslot, b: CourseTimeslot): boolean => {
+  return a.dayOfWeek === b.dayOfWeek && a.startMin < b.endMin && b.startMin < a.endMin;
+};
+
+export const buildTimetableConflict = (
+  courseId: number,
+  conflictWithCourseId: number,
+  a: CourseTimeslot,
+  b: CourseTimeslot
+): TimetableConflict => {
+  const overlapStart = Math.max(a.startMin, b.startMin);
+  const overlapEnd = Math.min(a.endMin, b.endMin);
+
+  return {
+    courseId,
+    conflictWithCourseId,
+    dayOfWeek: a.dayOfWeek,
+    overlap: {
+      startMin: overlapStart,
+      endMin: overlapEnd,
+      startPeriod: getPeriodByMinute(overlapStart, "start"),
+      endPeriod: getPeriodByMinute(overlapEnd, "end"),
+    },
+  };
+};


### PR DESCRIPTION
## 標題

建立標準課程時段 contract 與原子課表 mutation

---

## 摘要

統一 backend 對課程時段的解析與輸出，讓 course API 能提供標準 timeslots；同時以 transaction、row lock 與衝堂集合確認保護課表新增、移除、批次匯入及交換。

此 PR 僅包含 5 個 commits、10 個 backend 檔案。

---

## 背景／問題

課表 domain 原本有幾個需要一起處理的問題：

1. Course 與 Timetable 各自組合課程時段，容易產生不同的正規化結果。
2. 新增、移除與批次匯入若同時發生，可能根據過期的 timetable items 做判斷。
3. 使用者看到衝堂提示後，另一個分頁可能先修改課表；若仍直接交換，會刪除使用者沒有重新確認的課程。
4. Course API 缺少穩定的 timeslot contract，前端 planner 必須重新解析 display string。

---

## 變更內容

### 共用 schedule domain

- 新增 `backend/utils/courseSchedule.ts`。
- 統一課程 metadata、timeslot map 與衝堂判斷。
- EWANT 與一般課程使用相同的標準輸出格式。
- Course schedule repository 支援沿用既有 transaction。

### Course API timeslots

- Course list／detail 可依需求載入標準 timeslots。
- Controller、service、repository 與 type contract 同步更新。
- 避免前端從 `course_time` display string 再次推導時段。

### 課表 mutation transaction

- 新增與移除課程時先鎖定所屬 timetable。
- 在同一 transaction 內重新讀取 items、檢查重複與衝堂。
- Batch interest import 在鎖內重新確認 eligible courses。
- Unique constraint race 仍轉換成可預期的 already-exists 結果。

### 原子衝堂交換

交換 API 要求 client 帶回使用者確認過的 `conflictCourseIds`：

1. Backend 鎖定 timetable。
2. 重新計算目前實際衝堂集合。
3. 比較實際集合與 client 確認集合。
4. 若集合已改變，回傳 `409 CONFLICTS_CHANGED`，不修改資料。
5. 集合一致時，才在同一 transaction 內移除衝堂課並加入目標課程。

這可避免提示視窗開啟後，其他分頁的課表變更導致錯誤刪課。

---

## 測試方式

已執行：

- Backend TypeScript：
  ```bash
  cd backend
  npx tsc --noEmit
  ```
- Course time parser tests：
  ```bash
  cd backend
  npm run test:course-time
  ```
- Diff whitespace：
  ```bash
  git diff --check
  ```

建議人工驗證：

1. 取得 course detail 時確認 timeslots 與既有 `course_time` 相符。
2. 同時從兩個分頁新增相同課程，確認不會產生重複 item。
3. 衝堂提示開啟後從另一分頁修改課表，再確認交換應得到 `CONFLICTS_CHANGED`。
4. 使用原本確認的衝堂集合交換，確認刪除與新增在同一 transaction 完成。
5. 批次匯入 interests 時確認同學期、已存在與衝堂摘要正確。

---

## 備註

- 此為 feature integration PR 4/6。
- Base：`feat/guest-timetable`
- Head：`feat/timetable-domain-api`
- #70、#71、#77 已先合併完成。
- 舊 #73 僅保留先前誤 merge 的歷史紀錄；本 PR 才是目前應合併的 domain API PR。
- 此 PR 不包含 planner UI；前端介面會在下一支 PR 處理。