### PR TITLE
加入訪客課表登入後安全匯入流程

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import RouteHeadTitle from './seo/RouteHeadTitle'
 
 import Header from './components/Header'
 import Footer from './components/Footer'
+import GuestTimetableImportModal from './components/GuestTimetableImportModal'
 import {
   applyAuthStatusResponse,
   clearOAuthAuthSessionTransitionOwner,
@@ -149,7 +150,7 @@ function App() {
       {hasCurrentAuthError && (
         <Alert color='red' title='無法確認登入狀態' radius={0}>
           <Group justify='space-between' align='center' gap='sm'>
-            <Text size='sm'>已登入狀態不會因連線異常切換成訪客。</Text>
+            <Text size='sm'>已登入狀態不會因連線異常切換成訪客；訪客仍可查看本機課表。</Text>
             <Button
               variant='light'
               color='red'
@@ -162,6 +163,7 @@ function App() {
           </Group>
         </Alert>
       )}
+      <GuestTimetableImportModal />
       <main style={{ flex: 1 }}>
         <Outlet />
       </main>

--- a/frontend/src/components/GuestTimetableImportModal.tsx
+++ b/frontend/src/components/GuestTimetableImportModal.tsx
@@ -1,0 +1,892 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import {
+  ActionIcon,
+  Button,
+  Card,
+  Group,
+  Loader,
+  Modal,
+  ScrollArea,
+  Stack,
+  Text,
+  Tooltip,
+} from '@mantine/core'
+import { notifications } from '@mantine/notifications'
+import { Link, useLocation } from 'react-router-dom'
+import { FaCalendarPlus, FaExternalLinkAlt } from 'react-icons/fa'
+
+import {
+  addTimetableCourse,
+  getTimetableBySemester,
+  swapTimetableCourse,
+} from '../apis/timetableAPI'
+import type { ApiError } from '../apis/axiosInstance'
+import { useGuestTimetable } from '../hooks/timetables/useGuestTimetable'
+import { QUERY_KEYS } from '../hooks/queryKeys'
+import { useAuthStore } from '../stores/authStore'
+import styles from '../styles/components/Timetable.module.css'
+import {
+  isGuestTimetableImportPromptHandled,
+  markGuestTimetableImportPromptHandled,
+  subscribeGuestTimetableImportPromptRequest,
+} from '../utils/guestTimetableImportSession'
+import { findConflictCourseIds } from '../utils/timetable'
+import {
+  captureAuthStatusRequestSnapshot,
+  forceGuestAuthSessionRecord,
+  getUserCacheScope,
+  isAuthenticatedUserCacheScopeCurrent,
+} from '../utils/userCacheScope'
+import type {
+  GuestTimetableItem,
+  GuestTimetableStorage,
+  TimetableConflict,
+  TimetableResponse,
+} from '../types/timetableType'
+import SwapConflictModal from './TimetableSection/SwapConflictModal'
+
+type ImportPhase = 'idle' | 'confirm-clear' | 'importing' | 'result'
+
+type ImportSummary = {
+  added: number
+  alreadyExists: number
+  conflicted: number
+  failed: number
+}
+
+type ImportConflictDetail = {
+  timetableId: number
+  semester: string
+  courseId: number
+  courseName: string
+  item: GuestTimetableItem
+  conflictingCourses: Array<{
+    id: number
+    name: string
+  }>
+}
+
+type ImportContext = {
+  userCacheScope: string
+  authSessionEpoch: string
+  authSessionSnapshot: ReturnType<typeof captureAuthStatusRequestSnapshot>
+  controller: AbortController
+}
+
+const EMPTY_IMPORT_SUMMARY: ImportSummary = {
+  added: 0,
+  alreadyExists: 0,
+  conflicted: 0,
+  failed: 0,
+}
+
+const getApiError = (error: unknown): ApiError | null =>
+  error instanceof Error ? error as ApiError : null
+
+const isUnauthorizedError = (error: unknown): boolean =>
+  getApiError(error)?.status === 401
+
+const hasApiErrorCode = (error: unknown, code: string): boolean => {
+  const apiError = getApiError(error)
+  if (!apiError) return false
+
+  const errorData = apiError.data as { code?: unknown } | undefined
+  return apiError.status === 409 && errorData?.code === code
+}
+
+const getConflictCourseIds = (error: unknown): number[] => {
+  const apiError = getApiError(error)
+  if (!apiError || apiError.status !== 409) return []
+
+  const errorData = apiError.data as { conflicts?: TimetableConflict[] } | undefined
+  if (!Array.isArray(errorData?.conflicts)) return []
+
+  return Array.from(new Set(
+    errorData.conflicts
+      .map((conflict) => conflict.conflictWithCourseId)
+      .filter((courseId) => Number.isSafeInteger(courseId) && courseId > 0),
+  ))
+}
+
+const rebuildConflictDetail = (
+  conflictDetail: ImportConflictDetail,
+  timetableResponse: TimetableResponse,
+  conflictCourseIds = findConflictCourseIds(
+    conflictDetail.item,
+    timetableResponse.items,
+  ),
+): ImportConflictDetail => {
+  const courseNameMap = new Map(
+    timetableResponse.items.map((item) => [item.course.id, item.course.name]),
+  )
+
+  return {
+    ...conflictDetail,
+    timetableId: timetableResponse.timetable.id,
+    conflictingCourses: conflictCourseIds.map((courseId) => ({
+      id: courseId,
+      name: courseNameMap.get(courseId) ?? `課程 #${courseId}`,
+    })),
+  }
+}
+
+const AuthenticatedGuestTimetableImportModal: React.FC = () => {
+  const queryClient = useQueryClient()
+  const location = useLocation()
+  const logout = useAuthStore((state) => state.logout)
+  const userCacheScope = useAuthStore((state) => getUserCacheScope(state.user))
+  const {
+    storage,
+    summary: guestSummary,
+    error: guestStorageError,
+    removeCourse,
+    clearAll,
+  } = useGuestTimetable()
+  const [phase, setPhase] = useState<ImportPhase>('idle')
+  const [isHandled, setIsHandled] = useState(isGuestTimetableImportPromptHandled)
+  const [importSummary, setImportSummary] = useState<ImportSummary>(EMPTY_IMPORT_SUMMARY)
+  const [importConflictDetails, setImportConflictDetails] = useState<ImportConflictDetail[]>([])
+  const [pendingSwap, setPendingSwap] = useState<ImportConflictDetail | null>(null)
+  const [isSwapSubmitting, setIsSwapSubmitting] = useState(false)
+  const [isClearSubmitting, setIsClearSubmitting] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [clearAllSnapshot, setClearAllSnapshot] = useState<GuestTimetableStorage | null>(null)
+  const importInProgressRef = useRef(false)
+  const clearInProgressRef = useRef(false)
+  const activeImportRef = useRef<ImportContext | null>(null)
+
+  useEffect(() => {
+    const unsubscribe = subscribeGuestTimetableImportPromptRequest(() => {
+      if (importInProgressRef.current || clearInProgressRef.current) return
+      setActionError(null)
+      setClearAllSnapshot(null)
+      setPhase('idle')
+      setIsHandled(false)
+    })
+
+    return () => {
+      unsubscribe()
+      activeImportRef.current?.controller.abort()
+      activeImportRef.current = null
+      importInProgressRef.current = false
+      clearInProgressRef.current = false
+    }
+  }, [])
+
+  const isImportContextCurrent = (importContext: ImportContext): boolean => {
+    const authState = useAuthStore.getState()
+    return activeImportRef.current === importContext
+      && !importContext.controller.signal.aborted
+      && isAuthenticatedUserCacheScopeCurrent(
+        authState,
+        importContext.userCacheScope,
+        importContext.authSessionEpoch,
+      )
+  }
+
+  const semesterEntries = useMemo(
+    () => Object.entries(storage.semesters).filter(([, items]) => items.length > 0),
+    [storage],
+  )
+  const shouldShowInitialPrompt = (
+    guestSummary.totalCourses > 0 || guestStorageError !== null
+  ) && !isHandled && location.pathname === '/timetable'
+  const visiblePhase: ImportPhase = phase === 'idle' && shouldShowInitialPrompt ? 'idle' : phase
+  const opened = shouldShowInitialPrompt || phase !== 'idle'
+
+  const markHandled = (): void => {
+    markGuestTimetableImportPromptHandled()
+    setIsHandled(true)
+  }
+
+  const handleDismiss = (): void => {
+    if (
+      importInProgressRef.current
+      || clearInProgressRef.current
+      || phase === 'importing'
+      || isSwapSubmitting
+      || isClearSubmitting
+    ) return
+    markHandled()
+    setActionError(null)
+    setClearAllSnapshot(null)
+    setPendingSwap(null)
+    setPhase('idle')
+  }
+
+  const handleClearAll = async (): Promise<void> => {
+    if (!clearAllSnapshot || clearInProgressRef.current) return
+
+    try {
+      clearInProgressRef.current = true
+      setIsClearSubmitting(true)
+      const clearResult = await clearAll(clearAllSnapshot)
+      if (clearResult === 'changed') {
+        setClearAllSnapshot(null)
+        setPhase('idle')
+        notifications.show({
+          title: '本機課表已變更',
+          message: '其他分頁已更新本機課表，請重新確認後再清除。',
+          color: 'orange',
+        })
+        return
+      }
+      markHandled()
+      setActionError(null)
+      setClearAllSnapshot(null)
+      setPhase('idle')
+      notifications.show({
+        title: clearResult === 'cleared' ? '已清除本機課表' : '本機課表已清空',
+        message: clearResult === 'cleared'
+          ? '所有訪客學期的本機課表皆已清除。'
+          : '本機課表已在其他分頁清空。',
+        color: clearResult === 'cleared' ? 'green' : 'blue',
+      })
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : '無法清除本機課表，請稍後再試。')
+    } finally {
+      clearInProgressRef.current = false
+      setIsClearSubmitting(false)
+    }
+  }
+
+  const handleImport = async (): Promise<void> => {
+    if (importInProgressRef.current || clearInProgressRef.current) return
+    importInProgressRef.current = true
+    const authSessionSnapshot = captureAuthStatusRequestSnapshot()
+    const importContext: ImportContext = {
+      userCacheScope,
+      authSessionEpoch: authSessionSnapshot?.epoch ?? '',
+      authSessionSnapshot,
+      controller: new AbortController(),
+    }
+    activeImportRef.current?.controller.abort()
+    activeImportRef.current = importContext
+    const requestContext = {
+      signal: importContext.controller.signal,
+      expectedSessionScope: importContext.userCacheScope,
+    }
+
+    const importEntries = semesterEntries.map(([semester, items]) => [semester, [...items]] as const)
+    const totalCourses = importEntries.reduce((total, [, items]) => total + items.length, 0)
+    const nextSummary: ImportSummary = { ...EMPTY_IMPORT_SUMMARY }
+    const nextConflictDetails: ImportConflictDetail[] = []
+    const cleanupErrors: string[] = []
+    let authExpired = false
+    let sessionChanged = false
+
+    markHandled()
+    setActionError(null)
+    setImportSummary(EMPTY_IMPORT_SUMMARY)
+    setImportConflictDetails([])
+    setPhase('importing')
+
+    for (const [semester, items] of importEntries) {
+      if (!isImportContextCurrent(importContext)) {
+        sessionChanged = true
+        break
+      }
+
+      let timetableId: number
+      let accountCourseNameMap = new Map<number, string>()
+
+      try {
+        const timetableResponse = await getTimetableBySemester(semester, requestContext)
+        timetableId = timetableResponse.timetable.id
+        accountCourseNameMap = new Map(
+          timetableResponse.items.map((item) => [item.course.id, item.course.name]),
+        )
+      } catch (error) {
+        if (importContext.controller.signal.aborted) return
+        if (isUnauthorizedError(error)) {
+          authExpired = true
+          break
+        }
+        if (hasApiErrorCode(error, 'SESSION_CHANGED')) {
+          sessionChanged = true
+          break
+        }
+
+        nextSummary.failed += items.length
+        continue
+      }
+
+      for (const item of items) {
+        if (!isImportContextCurrent(importContext)) {
+          sessionChanged = true
+          break
+        }
+
+        try {
+          const result = await addTimetableCourse(
+            timetableId,
+            item.course.id,
+            requestContext,
+          )
+
+          if (result.added) {
+            nextSummary.added += 1
+            accountCourseNameMap.set(item.course.id, item.course.name)
+          } else if (result.alreadyExists) {
+            nextSummary.alreadyExists += 1
+            accountCourseNameMap.set(item.course.id, item.course.name)
+          } else {
+            nextSummary.failed += 1
+            continue
+          }
+
+          if (!isImportContextCurrent(importContext)) {
+            sessionChanged = true
+            break
+          }
+
+          try {
+            const removed = await removeCourse(
+              semester,
+              item.course.id,
+              () => isImportContextCurrent(importContext),
+            )
+            if (!removed && !isImportContextCurrent(importContext)) {
+              sessionChanged = true
+              break
+            }
+          } catch (error) {
+            cleanupErrors.push(
+              error instanceof Error
+                ? error.message
+                : `「${item.course.name}」已保存到帳號，但無法清除本機資料。`,
+            )
+          }
+        } catch (error) {
+          if (importContext.controller.signal.aborted) return
+          if (isUnauthorizedError(error)) {
+            authExpired = true
+            break
+          }
+          if (hasApiErrorCode(error, 'SESSION_CHANGED')) {
+            sessionChanged = true
+            break
+          }
+
+          const conflictCourseIds = getConflictCourseIds(error)
+          if (conflictCourseIds.length > 0) {
+            nextSummary.conflicted += 1
+            nextConflictDetails.push({
+              timetableId,
+              semester,
+              courseId: item.course.id,
+              courseName: item.course.name,
+              item,
+              conflictingCourses: conflictCourseIds.map((courseId) => ({
+                id: courseId,
+                name: accountCourseNameMap.get(courseId) ?? `課程 #${courseId}`,
+              })),
+            })
+          } else {
+            nextSummary.failed += 1
+          }
+        }
+      }
+
+      if (authExpired || sessionChanged) break
+    }
+
+    if (authExpired || sessionChanged) {
+      const categorizedCourses = nextSummary.added
+        + nextSummary.alreadyExists
+        + nextSummary.conflicted
+        + nextSummary.failed
+      nextSummary.failed += Math.max(totalCourses - categorizedCourses, 0)
+    }
+
+    if (!sessionChanged) {
+      try {
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TIMETABLE] }),
+          queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TIMETABLE_ALL_ITEMS] }),
+        ])
+      } catch {
+        cleanupErrors.push('帳號課表已處理，但畫面更新失敗，請重新整理後確認。')
+      }
+    }
+
+    if (activeImportRef.current !== importContext) return
+    activeImportRef.current = null
+    importInProgressRef.current = false
+    if (authExpired) {
+      const changedToGuest = await forceGuestAuthSessionRecord(importContext.authSessionSnapshot)
+      if (changedToGuest) logout()
+      return
+    }
+
+    setImportSummary(nextSummary)
+    setImportConflictDetails(nextConflictDetails)
+    setActionError([
+      ...cleanupErrors,
+      ...(sessionChanged ? ['登入帳號已變更，匯入已停止；尚未處理的本機課程會繼續保留。'] : []),
+    ].join(' ') || null)
+    setPhase('result')
+  }
+
+  const pendingSwapCourseNameMap = useMemo(
+    () => new Map(
+      pendingSwap?.conflictingCourses.map((course) => [course.id, course.name]) ?? [],
+    ),
+    [pendingSwap],
+  )
+
+  const handleConflictCourseAction = async (
+    conflictDetail: ImportConflictDetail,
+  ): Promise<void> => {
+    if (isSwapSubmitting) return
+
+    setIsSwapSubmitting(true)
+    setActionError(null)
+    const requestUserCacheScope = userCacheScope
+    const requestAuthSessionSnapshot = captureAuthStatusRequestSnapshot()
+    const requestAuthSessionEpoch = requestAuthSessionSnapshot?.epoch ?? ''
+    const requestContext = { expectedSessionScope: requestUserCacheScope }
+
+    try {
+      const timetableResponse = await getTimetableBySemester(
+        conflictDetail.semester,
+        requestContext,
+      )
+
+      try {
+        const result = await addTimetableCourse(
+          timetableResponse.timetable.id,
+          conflictDetail.courseId,
+          requestContext,
+        )
+
+        const isRequestSessionCurrent = () => isAuthenticatedUserCacheScopeCurrent(
+          useAuthStore.getState(),
+          requestUserCacheScope,
+          requestAuthSessionEpoch,
+        )
+        if (!isRequestSessionCurrent()) {
+          setActionError('登入帳號已變更；帳號課表可能已更新，本機待處理資料會繼續保留。')
+          return
+        }
+
+        try {
+          const removed = await removeCourse(
+            conflictDetail.semester,
+            conflictDetail.courseId,
+            isRequestSessionCurrent,
+          )
+          if (!removed && !isRequestSessionCurrent()) {
+            setActionError('登入帳號已變更；帳號課表可能已更新，本機待處理資料會繼續保留。')
+            return
+          }
+        } catch (error) {
+          setActionError(
+            error instanceof Error
+              ? `課程已加入帳號課表，但本機資料清除失敗：${error.message}`
+              : '課程已加入帳號課表，但本機資料清除失敗，請再試一次。',
+          )
+          return
+        }
+
+        setImportConflictDetails((currentDetails) => currentDetails.filter(
+          (detail) => !(
+            detail.semester === conflictDetail.semester
+            && detail.courseId === conflictDetail.courseId
+          ),
+        ))
+        setImportSummary((currentSummary) => ({
+          ...currentSummary,
+          added: currentSummary.added + (result.alreadyExists ? 0 : 1),
+          alreadyExists: currentSummary.alreadyExists + (result.alreadyExists ? 1 : 0),
+          conflicted: Math.max(currentSummary.conflicted - 1, 0),
+        }))
+        void Promise.all([
+          queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TIMETABLE] }),
+          queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TIMETABLE_ALL_ITEMS] }),
+        ])
+        notifications.show({
+          title: result.alreadyExists ? '課程已在課表中' : '已加入課表',
+          message: `「${conflictDetail.courseName}」已完成處理，本機待處理資料已清除。`,
+          color: result.alreadyExists ? 'blue' : 'green',
+        })
+      } catch (error) {
+        const latestConflictCourseIds = getConflictCourseIds(error)
+        if (latestConflictCourseIds.length > 0) {
+          const latestTimetableResponse = await getTimetableBySemester(
+            conflictDetail.semester,
+            requestContext,
+          )
+          const refreshedDetail = rebuildConflictDetail(
+            conflictDetail,
+            latestTimetableResponse,
+            latestConflictCourseIds,
+          )
+          setImportConflictDetails((currentDetails) => currentDetails.map((detail) => (
+            detail.semester === conflictDetail.semester
+              && detail.courseId === conflictDetail.courseId
+              ? refreshedDetail
+              : detail
+          )))
+          setPendingSwap(refreshedDetail)
+          return
+        }
+        throw error
+      }
+    } catch (error) {
+      if (isUnauthorizedError(error)) {
+        const changedToGuest = await forceGuestAuthSessionRecord(requestAuthSessionSnapshot)
+        if (changedToGuest) logout()
+        return
+      }
+      if (hasApiErrorCode(error, 'SESSION_CHANGED')) {
+        setActionError('登入帳號已變更，請重新開啟本機課表匯入流程。')
+        return
+      }
+
+      setActionError(error instanceof Error ? error.message : '無法處理這門課，請稍後再試。')
+    } finally {
+      setIsSwapSubmitting(false)
+    }
+  }
+
+  const handleConfirmSwap = async (): Promise<void> => {
+    if (!pendingSwap || isSwapSubmitting) return
+
+    setIsSwapSubmitting(true)
+    setActionError(null)
+    const requestUserCacheScope = userCacheScope
+    const requestAuthSessionSnapshot = captureAuthStatusRequestSnapshot()
+    const requestAuthSessionEpoch = requestAuthSessionSnapshot?.epoch ?? ''
+    try {
+      const result = await swapTimetableCourse(
+        pendingSwap.timetableId,
+        pendingSwap.courseId,
+        pendingSwap.conflictingCourses.map((course) => course.id),
+        { expectedSessionScope: requestUserCacheScope },
+      )
+
+      let timetableRefreshFailed = false
+      let refreshedTimetable: TimetableResponse | null = null
+      try {
+        refreshedTimetable = await getTimetableBySemester(
+          pendingSwap.semester,
+          { expectedSessionScope: requestUserCacheScope },
+        )
+      } catch (error) {
+        if (isUnauthorizedError(error) || hasApiErrorCode(error, 'SESSION_CHANGED')) {
+          throw error
+        }
+        timetableRefreshFailed = true
+      }
+
+      try {
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TIMETABLE] }),
+          queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TIMETABLE_ALL_ITEMS] }),
+        ])
+      } catch {
+        timetableRefreshFailed = true
+      }
+
+      const isRequestSessionCurrent = () => isAuthenticatedUserCacheScopeCurrent(
+        useAuthStore.getState(),
+        requestUserCacheScope,
+        requestAuthSessionEpoch,
+      )
+      if (!isRequestSessionCurrent()) {
+        setPendingSwap(null)
+        setActionError('登入帳號已變更；帳號課表可能已完成交換，本機待處理資料會繼續保留。')
+        return
+      }
+
+      try {
+        const removed = await removeCourse(
+          pendingSwap.semester,
+          pendingSwap.courseId,
+          isRequestSessionCurrent,
+        )
+        if (!removed && !isRequestSessionCurrent()) {
+          setPendingSwap(null)
+          setActionError('登入帳號已變更；帳號課表可能已完成交換，本機待處理資料會繼續保留。')
+          return
+        }
+      } catch (error) {
+        setActionError(
+          error instanceof Error
+            ? `帳號課表已完成交換，但本機資料清除失敗：${error.message}`
+            : '帳號課表已完成交換，但本機資料清除失敗，請再試一次。',
+        )
+        notifications.show({
+          title: '課表已交換',
+          message: '帳號課表已更新，但本機資料尚未清除。',
+          color: 'orange',
+        })
+        setPendingSwap(null)
+        return
+      }
+
+      setImportConflictDetails((currentDetails) => currentDetails
+        .filter((detail) => !(
+          detail.semester === pendingSwap.semester
+          && detail.courseId === pendingSwap.courseId
+        ))
+        .map((detail) => (
+          refreshedTimetable && detail.semester === pendingSwap.semester
+            ? rebuildConflictDetail(detail, refreshedTimetable)
+            : detail
+        )))
+      setImportSummary((currentSummary) => ({
+        ...currentSummary,
+        added: currentSummary.added + (result.alreadyExists ? 0 : 1),
+        alreadyExists: currentSummary.alreadyExists + (result.alreadyExists ? 1 : 0),
+        conflicted: Math.max(currentSummary.conflicted - 1, 0),
+      }))
+      if (timetableRefreshFailed) {
+        setActionError('課程已完成交換，但課表畫面更新失敗，請重新整理後確認。')
+      }
+      notifications.show({
+        title: result.alreadyExists ? '課程已在課表中' : '已完成交換',
+        message: result.alreadyExists
+          ? `「${pendingSwap.courseName}」已在帳號課表中，本機待處理資料已清除。`
+          : `已移除 ${result.removedCourseIds.length} 門衝堂課，並加入「${pendingSwap.courseName}」。`,
+        color: result.alreadyExists ? 'blue' : 'green',
+      })
+      setPendingSwap(null)
+    } catch (error) {
+      if (isUnauthorizedError(error)) {
+        const changedToGuest = await forceGuestAuthSessionRecord(requestAuthSessionSnapshot)
+        if (changedToGuest) logout()
+        return
+      }
+      if (hasApiErrorCode(error, 'SESSION_CHANGED')) {
+        setPendingSwap(null)
+        setActionError('登入帳號已變更，請重新開啟本機課表匯入流程。')
+        return
+      }
+      if (hasApiErrorCode(error, 'CONFLICTS_CHANGED') && pendingSwap) {
+        try {
+          const timetableResponse = await getTimetableBySemester(
+            pendingSwap.semester,
+            { expectedSessionScope: requestUserCacheScope },
+          )
+          const refreshedDetail = rebuildConflictDetail(
+            pendingSwap,
+            timetableResponse,
+            getConflictCourseIds(error),
+          )
+          setImportConflictDetails((currentDetails) => currentDetails.map((detail) => (
+            detail.semester === pendingSwap.semester
+              && detail.courseId === pendingSwap.courseId
+              ? refreshedDetail
+              : detail
+          )))
+          setPendingSwap(refreshedDetail.conflictingCourses.length > 0 ? refreshedDetail : null)
+          setActionError('帳號課表已變更，衝堂明細已更新，請重新確認。')
+          return
+        } catch (refreshError) {
+          setPendingSwap(null)
+          setActionError(
+            refreshError instanceof Error
+              ? refreshError.message
+              : '課表已變更，但無法更新衝堂明細，請稍後再試。',
+          )
+          return
+        }
+      }
+
+      setActionError(error instanceof Error ? error.message : '交換課程失敗，請稍後再試。')
+    } finally {
+      setIsSwapSubmitting(false)
+    }
+  }
+
+  const modalTitle = visiblePhase === 'confirm-clear'
+    ? '確認清除本機課表'
+    : visiblePhase === 'result'
+      ? '本機課表匯入結果'
+      : '保存本機課表'
+
+  return (
+    <>
+      <Modal
+        opened={opened}
+        onClose={handleDismiss}
+        title={modalTitle}
+        centered
+        zIndex={1400}
+        scrollAreaComponent={ScrollArea.Autosize}
+        closeOnClickOutside={phase !== 'importing' && !isSwapSubmitting && !isClearSubmitting}
+        closeOnEscape={phase !== 'importing' && !isSwapSubmitting && !isClearSubmitting}
+        withCloseButton={phase !== 'importing' && !isSwapSubmitting && !isClearSubmitting}
+      >
+      {visiblePhase === 'idle' && (
+        <Stack gap='md'>
+          {guestStorageError ? (
+            <Text c='red'>{guestStorageError.message}</Text>
+          ) : (
+            <>
+              <Text>
+                偵測到本機課表，共 {guestSummary.totalCourses} 門課、涵蓋 {guestSummary.semesterCount} 個學期。
+              </Text>
+              <Text size='sm' c='dimmed'>
+                你可以保存到帳號以跨裝置同步，系統不會覆蓋或自動移除帳號內既有課程。
+              </Text>
+            </>
+          )}
+          <Group justify='flex-end'>
+            <Button variant='subtle' onClick={handleDismiss}>稍後處理</Button>
+            <Button
+              variant='light'
+              color='red'
+              disabled={guestStorageError !== null}
+              onClick={() => {
+                setActionError(null)
+                setClearAllSnapshot(storage)
+                setPhase('confirm-clear')
+              }}
+            >
+              清除本機課表
+            </Button>
+            <Button
+              disabled={guestStorageError !== null}
+              onClick={() => void handleImport()}
+            >
+              保存到帳號
+            </Button>
+          </Group>
+        </Stack>
+      )}
+
+      {visiblePhase === 'confirm-clear' && (
+        <Stack gap='md'>
+          <Text>確定要清除所有訪客學期的本機課表嗎？此動作不會影響帳號課表，但無法復原。</Text>
+          {actionError && <Text size='sm' c='red'>{actionError}</Text>}
+          <Group justify='flex-end'>
+            <Button
+              variant='light'
+              onClick={() => {
+                setActionError(null)
+                setClearAllSnapshot(null)
+                setPhase('idle')
+              }}
+              disabled={isClearSubmitting}
+            >
+              取消
+            </Button>
+            <Button
+              color='red'
+              loading={isClearSubmitting}
+              onClick={() => void handleClearAll()}
+            >
+              確認清除
+            </Button>
+          </Group>
+        </Stack>
+      )}
+
+      {visiblePhase === 'importing' && (
+        <Group justify='center' py='lg'>
+          <Loader size='sm' />
+          <Text>正在保存本機課表，請稍候...</Text>
+        </Group>
+      )}
+
+      {visiblePhase === 'result' && (
+        <Stack gap='sm'>
+          <Text>成功加入：{importSummary.added}</Text>
+          <Text>已存在：{importSummary.alreadyExists}</Text>
+          <Text>發生衝堂：{importSummary.conflicted}</Text>
+          <Text>匯入失敗：{importSummary.failed}</Text>
+          {importConflictDetails.length > 0 && (
+            <Stack gap='xs' mt='xs'>
+              <div>
+                <Text fw={700}>衝堂明細</Text>
+                <Text size='xs' c='dimmed'>這些課程仍保留在本機，可直接選擇是否替換帳號內的衝堂課程。</Text>
+              </div>
+              {importConflictDetails.map((conflictDetail) => (
+                <Card
+                  key={`${conflictDetail.semester}-${conflictDetail.courseId}`}
+                  withBorder
+                  padding='sm'
+                >
+                  <Stack gap={6}>
+                    <Text size='sm' fw={700}>
+                      {conflictDetail.semester}｜{conflictDetail.courseName}
+                    </Text>
+                    <Text size='xs' c='dimmed'>
+                      {conflictDetail.conflictingCourses.length > 0
+                        ? `與 ${conflictDetail.conflictingCourses.map((course) => course.name).join('、')} 衝堂`
+                        : '目前已無衝堂，可直接加入帳號課表'}
+                    </Text>
+                    <Group gap='xs' wrap='nowrap'>
+                      <Button
+                        size='xs'
+                        variant='light'
+                        leftSection={<FaCalendarPlus size={12} />}
+                        disabled={isSwapSubmitting}
+                        onClick={() => void handleConflictCourseAction(conflictDetail)}
+                        style={{ flex: 1 }}
+                      >
+                        加入課表
+                      </Button>
+                      <Tooltip label='另開新分頁查看課程評價' withArrow zIndex={1600}>
+                        <ActionIcon
+                          component={Link}
+                          to={`/course/${conflictDetail.courseId}`}
+                          target='_blank'
+                          rel='noopener noreferrer'
+                          size={30}
+                          variant='subtle'
+                          className={styles.courseExternalLinkButton}
+                          aria-label={`另開新分頁查看「${conflictDetail.courseName}」課程評價`}
+                        >
+                          <FaExternalLinkAlt size={13} />
+                        </ActionIcon>
+                      </Tooltip>
+                    </Group>
+                  </Stack>
+                </Card>
+              ))}
+            </Stack>
+          )}
+          {actionError && <Text size='sm' c='red'>{actionError}</Text>}
+          <Group justify='flex-end' mt='sm'>
+            <Button onClick={handleDismiss}>完成</Button>
+          </Group>
+        </Stack>
+      )}
+      </Modal>
+
+      <SwapConflictModal
+        opened={pendingSwap !== null}
+        targetCourse={pendingSwap ? {
+          id: pendingSwap.courseId,
+          name: pendingSwap.courseName,
+        } : null}
+        conflictCourseIds={pendingSwap?.conflictingCourses.map((course) => course.id) ?? []}
+        addedCourseNameMap={pendingSwapCourseNameMap}
+        isSubmitting={isSwapSubmitting}
+        zIndex={1500}
+        showCourseLinks={false}
+        onClose={() => {
+          if (!isSwapSubmitting) setPendingSwap(null)
+        }}
+        onConfirm={() => void handleConfirmSwap()}
+      />
+    </>
+  )
+}
+
+const GuestTimetableImportModal: React.FC = () => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
+  const isAuthResolved = useAuthStore((state) => state.isAuthResolved)
+  const userCacheScope = useAuthStore((state) => getUserCacheScope(state.user))
+
+  if (!isAuthResolved || !isAuthenticated) return null
+
+  return <AuthenticatedGuestTimetableImportModal key={userCacheScope} />
+}
+
+export default GuestTimetableImportModal

--- a/frontend/src/components/GuestTimetableImportModal.tsx
+++ b/frontend/src/components/GuestTimetableImportModal.tsx
@@ -143,7 +143,7 @@ const AuthenticatedGuestTimetableImportModal: React.FC = () => {
     summary: guestSummary,
     error: guestStorageError,
     isCourseSnapshotCurrent,
-    removeCourse,
+    removeCourseSnapshot,
     clearAll,
   } = useGuestTimetable()
   const [phase, setPhase] = useState<ImportPhase>('idle')
@@ -351,14 +351,18 @@ const AuthenticatedGuestTimetableImportModal: React.FC = () => {
           }
 
           try {
-            const removed = await removeCourse(
-              semester,
-              item.course.id,
+            const removed = await removeCourseSnapshot(
+              item,
               () => isImportContextCurrent(importContext),
             )
             if (!removed && !isImportContextCurrent(importContext)) {
               sessionChanged = true
               break
+            }
+            if (!removed) {
+              cleanupErrors.push(
+                `「${item.course.name}」的本機快照已由其他分頁變更，因此未移除其他資料。`,
+              )
             }
           } catch (error) {
             cleanupErrors.push(
@@ -446,6 +450,31 @@ const AuthenticatedGuestTimetableImportModal: React.FC = () => {
     [pendingSwap],
   )
 
+  const discardStaleConflictDetail = (conflictDetail: ImportConflictDetail): void => {
+    setImportConflictDetails((currentDetails) => currentDetails.filter(
+      (detail) => !(
+        detail.semester === conflictDetail.semester
+        && detail.courseId === conflictDetail.courseId
+      ),
+    ))
+    setImportSummary((currentSummary) => ({
+      ...currentSummary,
+      conflicted: Math.max(currentSummary.conflicted - 1, 0),
+      skipped: currentSummary.skipped + 1,
+    }))
+    setPendingSwap((currentPendingSwap) => (
+      currentPendingSwap?.semester === conflictDetail.semester
+        && currentPendingSwap.courseId === conflictDetail.courseId
+        ? null
+        : currentPendingSwap
+    ))
+    notifications.show({
+      title: '本機課程已變更',
+      message: `「${conflictDetail.courseName}」已由其他分頁移除或重新加入，本次不會處理。`,
+      color: 'blue',
+    })
+  }
+
   const handleConflictCourseAction = async (
     conflictDetail: ImportConflictDetail,
   ): Promise<void> => {
@@ -464,6 +493,11 @@ const AuthenticatedGuestTimetableImportModal: React.FC = () => {
         requestContext,
       )
 
+      if (!await isCourseSnapshotCurrent(conflictDetail.item)) {
+        discardStaleConflictDetail(conflictDetail)
+        return
+      }
+
       try {
         const result = await addTimetableCourse(
           timetableResponse.timetable.id,
@@ -481,15 +515,19 @@ const AuthenticatedGuestTimetableImportModal: React.FC = () => {
           return
         }
 
+        let localSnapshotChanged = false
         try {
-          const removed = await removeCourse(
-            conflictDetail.semester,
-            conflictDetail.courseId,
+          const removed = await removeCourseSnapshot(
+            conflictDetail.item,
             isRequestSessionCurrent,
           )
           if (!removed && !isRequestSessionCurrent()) {
             setActionError('登入帳號已變更；帳號課表可能已更新，本機待處理資料會繼續保留。')
             return
+          }
+          if (!removed) {
+            localSnapshotChanged = true
+            setActionError('帳號課表已更新；本機快照已由其他分頁變更，因此未移除其他資料。')
           }
         } catch (error) {
           setActionError(
@@ -518,7 +556,9 @@ const AuthenticatedGuestTimetableImportModal: React.FC = () => {
         ])
         notifications.show({
           title: result.alreadyExists ? '課程已在課表中' : '已加入課表',
-          message: `「${conflictDetail.courseName}」已完成處理，本機待處理資料已清除。`,
+          message: localSnapshotChanged
+            ? `「${conflictDetail.courseName}」已完成帳號處理，其他分頁的本機資料未受影響。`
+            : `「${conflictDetail.courseName}」已完成處理，本機待處理資料已清除。`,
           color: result.alreadyExists ? 'blue' : 'green',
         })
       } catch (error) {
@@ -570,6 +610,11 @@ const AuthenticatedGuestTimetableImportModal: React.FC = () => {
     const requestAuthSessionSnapshot = captureAuthStatusRequestSnapshot()
     const requestAuthSessionEpoch = requestAuthSessionSnapshot?.epoch ?? ''
     try {
+      if (!await isCourseSnapshotCurrent(pendingSwap.item)) {
+        discardStaleConflictDetail(pendingSwap)
+        return
+      }
+
       const result = await swapTimetableCourse(
         pendingSwap.timetableId,
         pendingSwap.courseId,
@@ -579,6 +624,7 @@ const AuthenticatedGuestTimetableImportModal: React.FC = () => {
 
       let timetableRefreshFailed = false
       let refreshedTimetable: TimetableResponse | null = null
+      let localSnapshotChanged = false
       try {
         refreshedTimetable = await getTimetableBySemester(
           pendingSwap.semester,
@@ -612,15 +658,17 @@ const AuthenticatedGuestTimetableImportModal: React.FC = () => {
       }
 
       try {
-        const removed = await removeCourse(
-          pendingSwap.semester,
-          pendingSwap.courseId,
+        const removed = await removeCourseSnapshot(
+          pendingSwap.item,
           isRequestSessionCurrent,
         )
         if (!removed && !isRequestSessionCurrent()) {
           setPendingSwap(null)
           setActionError('登入帳號已變更；帳號課表可能已完成交換，本機待處理資料會繼續保留。')
           return
+        }
+        if (!removed) {
+          localSnapshotChanged = true
         }
       } catch (error) {
         setActionError(
@@ -653,14 +701,21 @@ const AuthenticatedGuestTimetableImportModal: React.FC = () => {
         alreadyExists: currentSummary.alreadyExists + (result.alreadyExists ? 1 : 0),
         conflicted: Math.max(currentSummary.conflicted - 1, 0),
       }))
-      if (timetableRefreshFailed) {
-        setActionError('課程已完成交換，但課表畫面更新失敗，請重新整理後確認。')
-      }
+      setActionError([
+        ...(localSnapshotChanged
+          ? ['帳號課表已完成交換；本機快照已由其他分頁變更，因此未移除其他資料。']
+          : []),
+        ...(timetableRefreshFailed
+          ? ['課表畫面更新失敗，請重新整理後確認。']
+          : []),
+      ].join(' ') || null)
       notifications.show({
         title: result.alreadyExists ? '課程已在課表中' : '已完成交換',
-        message: result.alreadyExists
-          ? `「${pendingSwap.courseName}」已在帳號課表中，本機待處理資料已清除。`
-          : `已移除 ${result.removedCourseIds.length} 門衝堂課，並加入「${pendingSwap.courseName}」。`,
+        message: localSnapshotChanged
+          ? `「${pendingSwap.courseName}」已完成帳號處理，其他分頁的本機資料未受影響。`
+          : result.alreadyExists
+            ? `「${pendingSwap.courseName}」已在帳號課表中，本機待處理資料已清除。`
+            : `已移除 ${result.removedCourseIds.length} 門衝堂課，並加入「${pendingSwap.courseName}」。`,
         color: result.alreadyExists ? 'blue' : 'green',
       })
       setPendingSwap(null)
@@ -809,7 +864,7 @@ const AuthenticatedGuestTimetableImportModal: React.FC = () => {
           <Text>已存在：{importSummary.alreadyExists}</Text>
           <Text>發生衝堂：{importSummary.conflicted}</Text>
           <Text>匯入失敗：{importSummary.failed}</Text>
-          <Text>已由其他分頁移除：{importSummary.skipped}</Text>
+          <Text>本機快照已變更：{importSummary.skipped}</Text>
           {importConflictDetails.length > 0 && (
             <Stack gap='xs' mt='xs'>
               <div>

--- a/frontend/src/components/GuestTimetableImportModal.tsx
+++ b/frontend/src/components/GuestTimetableImportModal.tsx
@@ -53,6 +53,7 @@ type ImportSummary = {
   alreadyExists: number
   conflicted: number
   failed: number
+  skipped: number
 }
 
 type ImportConflictDetail = {
@@ -79,6 +80,7 @@ const EMPTY_IMPORT_SUMMARY: ImportSummary = {
   alreadyExists: 0,
   conflicted: 0,
   failed: 0,
+  skipped: 0,
 }
 
 const getApiError = (error: unknown): ApiError | null =>
@@ -140,6 +142,7 @@ const AuthenticatedGuestTimetableImportModal: React.FC = () => {
     storage,
     summary: guestSummary,
     error: guestStorageError,
+    isCourseSnapshotCurrent,
     removeCourse,
     clearAll,
   } = useGuestTimetable()
@@ -207,6 +210,7 @@ const AuthenticatedGuestTimetableImportModal: React.FC = () => {
       || phase === 'importing'
       || isSwapSubmitting
       || isClearSubmitting
+      || pendingSwap !== null
     ) return
     markHandled()
     setActionError(null)
@@ -319,6 +323,11 @@ const AuthenticatedGuestTimetableImportModal: React.FC = () => {
         }
 
         try {
+          if (!await isCourseSnapshotCurrent(item)) {
+            nextSummary.skipped += 1
+            continue
+          }
+
           const result = await addTimetableCourse(
             timetableId,
             item.course.id,
@@ -397,6 +406,7 @@ const AuthenticatedGuestTimetableImportModal: React.FC = () => {
         + nextSummary.alreadyExists
         + nextSummary.conflicted
         + nextSummary.failed
+        + nextSummary.skipped
       nextSummary.failed += Math.max(totalCourses - categorizedCourses, 0)
     }
 
@@ -717,9 +727,9 @@ const AuthenticatedGuestTimetableImportModal: React.FC = () => {
         centered
         zIndex={1400}
         scrollAreaComponent={ScrollArea.Autosize}
-        closeOnClickOutside={phase !== 'importing' && !isSwapSubmitting && !isClearSubmitting}
-        closeOnEscape={phase !== 'importing' && !isSwapSubmitting && !isClearSubmitting}
-        withCloseButton={phase !== 'importing' && !isSwapSubmitting && !isClearSubmitting}
+        closeOnClickOutside={phase !== 'importing' && !isSwapSubmitting && !isClearSubmitting && pendingSwap === null}
+        closeOnEscape={phase !== 'importing' && !isSwapSubmitting && !isClearSubmitting && pendingSwap === null}
+        withCloseButton={phase !== 'importing' && !isSwapSubmitting && !isClearSubmitting && pendingSwap === null}
       >
       {visiblePhase === 'idle' && (
         <Stack gap='md'>
@@ -799,6 +809,7 @@ const AuthenticatedGuestTimetableImportModal: React.FC = () => {
           <Text>已存在：{importSummary.alreadyExists}</Text>
           <Text>發生衝堂：{importSummary.conflicted}</Text>
           <Text>匯入失敗：{importSummary.failed}</Text>
+          <Text>已由其他分頁移除：{importSummary.skipped}</Text>
           {importConflictDetails.length > 0 && (
             <Stack gap='xs' mt='xs'>
               <div>

--- a/frontend/src/components/TimetableSection/Timetable.tsx
+++ b/frontend/src/components/TimetableSection/Timetable.tsx
@@ -365,7 +365,9 @@ const Timetable: React.FC = () => {
       />
 
       <Stack gap='md'>
-        {(!isAuthenticated || guestTimetable.summary.totalCourses > 0) && (
+        {(!isAuthenticated
+          || guestTimetable.summary.totalCourses > 0
+          || guestTimetable.error !== null) && (
           <div className={styles.localTimetableNotice}>
             <div className={styles.localTimetableNoticeIcon} aria-hidden='true'>
               <FaLaptop size={18} />
@@ -373,23 +375,27 @@ const Timetable: React.FC = () => {
             <div className={styles.localTimetableNoticeContent}>
               <Text fw={800} size='sm'>
                 {isAuthenticated
-                  ? `本機還有 ${guestTimetable.summary.totalCourses} 門課尚未處理`
+                  ? guestTimetable.error
+                    ? '無法讀取本機課表'
+                    : `本機還有 ${guestTimetable.summary.totalCourses} 門課尚未處理`
                   : '這份課表保存在此裝置'}
               </Text>
               <Text size='xs' c='dimmed'>
                 {isAuthenticated
-                  ? `涵蓋 ${guestTimetable.summary.semesterCount} 個學期，可隨時保存到帳號或清除本機資料。`
+                  ? guestTimetable.error?.message
+                    ?? `涵蓋 ${guestTimetable.summary.semesterCount} 個學期，可隨時保存到帳號或清除本機資料。`
                   : '訪客模式不會寫入帳號；登入後可選擇保存，並跨裝置同步。'}
               </Text>
             </div>
-            {isAuthenticated && guestTimetable.summary.totalCourses > 0 && (
+            {isAuthenticated
+              && (guestTimetable.summary.totalCourses > 0 || guestTimetable.error !== null) && (
               <Button
                 size='xs'
                 leftSection={<FaCloudUploadAlt size={14} />}
                 onClick={requestGuestTimetableImportPrompt}
                 className={styles.localTimetableNoticeAction}
               >
-                處理本機課表
+                {guestTimetable.error ? '重新檢查本機課表' : '處理本機課表'}
               </Button>
             )}
           </div>

--- a/frontend/src/components/TimetableSection/Timetable.tsx
+++ b/frontend/src/components/TimetableSection/Timetable.tsx
@@ -319,13 +319,52 @@ const Timetable: React.FC = () => {
     )
   }
 
+  const localTimetableNotice = (!isAuthenticated
+    || guestTimetable.summary.totalCourses > 0
+    || guestTimetable.error !== null) ? (
+      <div className={styles.localTimetableNotice}>
+        <div className={styles.localTimetableNoticeIcon} aria-hidden='true'>
+          <FaLaptop size={18} />
+        </div>
+        <div className={styles.localTimetableNoticeContent}>
+          <Text fw={800} size='sm'>
+            {isAuthenticated
+              ? guestTimetable.error
+                ? '無法讀取本機課表'
+                : `本機還有 ${guestTimetable.summary.totalCourses} 門課尚未處理`
+              : '這份課表保存在此裝置'}
+          </Text>
+          <Text size='xs' c='dimmed'>
+            {isAuthenticated
+              ? guestTimetable.error?.message
+                ?? `涵蓋 ${guestTimetable.summary.semesterCount} 個學期，可隨時保存到帳號或清除本機資料。`
+              : '訪客模式不會寫入帳號；登入後可選擇保存，並跨裝置同步。'}
+          </Text>
+        </div>
+        {isAuthenticated
+          && (guestTimetable.summary.totalCourses > 0 || guestTimetable.error !== null) && (
+          <Button
+            size='xs'
+            leftSection={<FaCloudUploadAlt size={14} />}
+            onClick={requestGuestTimetableImportPrompt}
+            className={styles.localTimetableNoticeAction}
+          >
+            {guestTimetable.error ? '重新檢查本機課表' : '處理本機課表'}
+          </Button>
+        )}
+      </div>
+    ) : null
+
   if (semesterOptions.length === 0) {
     return (
-      <div className={styles.card}>
-        <Text c='dimmed'>
-          {hasSemestersError ? '無法載入學期資料，請稍後再試。' : '目前沒有可選學期。'}
-        </Text>
-      </div>
+      <Stack gap='md'>
+        {isAuthenticated && localTimetableNotice}
+        <div className={styles.card}>
+          <Text c='dimmed'>
+            {hasSemestersError ? '無法載入學期資料，請稍後再試。' : '目前沒有可選學期。'}
+          </Text>
+        </div>
+      </Stack>
     )
   }
 
@@ -365,41 +404,7 @@ const Timetable: React.FC = () => {
       />
 
       <Stack gap='md'>
-        {(!isAuthenticated
-          || guestTimetable.summary.totalCourses > 0
-          || guestTimetable.error !== null) && (
-          <div className={styles.localTimetableNotice}>
-            <div className={styles.localTimetableNoticeIcon} aria-hidden='true'>
-              <FaLaptop size={18} />
-            </div>
-            <div className={styles.localTimetableNoticeContent}>
-              <Text fw={800} size='sm'>
-                {isAuthenticated
-                  ? guestTimetable.error
-                    ? '無法讀取本機課表'
-                    : `本機還有 ${guestTimetable.summary.totalCourses} 門課尚未處理`
-                  : '這份課表保存在此裝置'}
-              </Text>
-              <Text size='xs' c='dimmed'>
-                {isAuthenticated
-                  ? guestTimetable.error?.message
-                    ?? `涵蓋 ${guestTimetable.summary.semesterCount} 個學期，可隨時保存到帳號或清除本機資料。`
-                  : '訪客模式不會寫入帳號；登入後可選擇保存，並跨裝置同步。'}
-              </Text>
-            </div>
-            {isAuthenticated
-              && (guestTimetable.summary.totalCourses > 0 || guestTimetable.error !== null) && (
-              <Button
-                size='xs'
-                leftSection={<FaCloudUploadAlt size={14} />}
-                onClick={requestGuestTimetableImportPrompt}
-                className={styles.localTimetableNoticeAction}
-              >
-                {guestTimetable.error ? '重新檢查本機課表' : '處理本機課表'}
-              </Button>
-            )}
-          </div>
-        )}
+        {localTimetableNotice}
 
         {guestTimetable.error && !isAuthenticated && (
           <div className={`${styles.alert} ${styles.alertRed}`}>

--- a/frontend/src/components/TimetableSection/Timetable.tsx
+++ b/frontend/src/components/TimetableSection/Timetable.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Button, Collapse, Stack, Text } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
-import { FaLaptop } from 'react-icons/fa'
+import { FaCloudUploadAlt, FaLaptop } from 'react-icons/fa'
 
 import { useAuthStore } from '../../stores/authStore'
 import { useGetSemesters } from '../../hooks/semesters/useGetSemesters'
@@ -18,6 +18,7 @@ import {
   TIMETABLE_PERIOD_ORDER,
 } from '../../utils/timetable'
 import { getUserCacheScope } from '../../utils/userCacheScope'
+import { requestGuestTimetableImportPrompt } from '../../utils/guestTimetableImportSession'
 import styles from '../../styles/components/Timetable.module.css'
 import ConfirmModal from '../ConfirmModal'
 
@@ -364,19 +365,33 @@ const Timetable: React.FC = () => {
       />
 
       <Stack gap='md'>
-        {!isAuthenticated && (
+        {(!isAuthenticated || guestTimetable.summary.totalCourses > 0) && (
           <div className={styles.localTimetableNotice}>
             <div className={styles.localTimetableNoticeIcon} aria-hidden='true'>
               <FaLaptop size={18} />
             </div>
             <div className={styles.localTimetableNoticeContent}>
               <Text fw={800} size='sm'>
-                這份課表保存在此裝置
+                {isAuthenticated
+                  ? `本機還有 ${guestTimetable.summary.totalCourses} 門課尚未處理`
+                  : '這份課表保存在此裝置'}
               </Text>
               <Text size='xs' c='dimmed'>
-                訪客模式不會寫入帳號；登入後可選擇保存，並跨裝置同步。
+                {isAuthenticated
+                  ? `涵蓋 ${guestTimetable.summary.semesterCount} 個學期，可隨時保存到帳號或清除本機資料。`
+                  : '訪客模式不會寫入帳號；登入後可選擇保存，並跨裝置同步。'}
               </Text>
             </div>
+            {isAuthenticated && guestTimetable.summary.totalCourses > 0 && (
+              <Button
+                size='xs'
+                leftSection={<FaCloudUploadAlt size={14} />}
+                onClick={requestGuestTimetableImportPrompt}
+                className={styles.localTimetableNoticeAction}
+              >
+                處理本機課表
+              </Button>
+            )}
           </div>
         )}
 

--- a/frontend/src/hooks/timetables/useGuestTimetable.ts
+++ b/frontend/src/hooks/timetables/useGuestTimetable.ts
@@ -10,6 +10,7 @@ import {
   createEmptyGuestTimetableStorage,
   getGuestTimetableSummary,
   GuestTimetableStorageError,
+  isGuestCourseSnapshotCurrent,
   parseGuestTimetableStorage,
   readGuestTimetableRawValue,
   removeGuestCourse,
@@ -43,6 +44,7 @@ export type UseGuestTimetableResult = {
   error: GuestTimetableStorageError | null
   getItemsBySemester: (semester: string) => GuestTimetableItem[]
   isCourseAdded: (semester: string, courseId: number) => boolean
+  isCourseSnapshotCurrent: (item: GuestTimetableItem) => Promise<boolean>
   addCourse: (item: GuestTimetableItem) => Promise<AddGuestCourseResult>
   removeCourse: (
     semester: string,
@@ -109,6 +111,7 @@ export const useGuestTimetable = (): UseGuestTimetableResult => {
     error,
     getItemsBySemester,
     isCourseAdded,
+    isCourseSnapshotCurrent: isGuestCourseSnapshotCurrent,
     addCourse: addGuestCourse,
     removeCourse: removeGuestCourse,
     clearSemester: clearGuestSemester,

--- a/frontend/src/hooks/timetables/useGuestTimetable.ts
+++ b/frontend/src/hooks/timetables/useGuestTimetable.ts
@@ -14,6 +14,7 @@ import {
   parseGuestTimetableStorage,
   readGuestTimetableRawValue,
   removeGuestCourse,
+  removeGuestCourseSnapshot,
   subscribeGuestTimetable,
   swapGuestCourse,
 } from '../../utils/guestTimetableStorage'
@@ -49,6 +50,10 @@ export type UseGuestTimetableResult = {
   removeCourse: (
     semester: string,
     courseId: number,
+    canRemove?: () => boolean,
+  ) => Promise<boolean>
+  removeCourseSnapshot: (
+    item: GuestTimetableItem,
     canRemove?: () => boolean,
   ) => Promise<boolean>
   clearSemester: (
@@ -114,6 +119,7 @@ export const useGuestTimetable = (): UseGuestTimetableResult => {
     isCourseSnapshotCurrent: isGuestCourseSnapshotCurrent,
     addCourse: addGuestCourse,
     removeCourse: removeGuestCourse,
+    removeCourseSnapshot: removeGuestCourseSnapshot,
     clearSemester: clearGuestSemester,
     clearAll: clearGuestTimetable,
     swapCourse: swapGuestCourse,

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { User } from '../types/userType'
+import { clearGuestTimetableImportPromptGuard } from '../utils/guestTimetableImportSession'
 import { createAuthenticatedUserCacheScope } from '../utils/userCacheScope'
 
 type AuthenticatedUser = User & {
@@ -50,6 +51,7 @@ export const useAuthStore = create<AuthState>()(
           isLogoutInProgress: false,
           user: null,
         })
+        clearGuestTimetableImportPromptGuard()
         localStorage.removeItem('auth-storage')
       },
       markAuthUnresolved: () => set((state) => {

--- a/frontend/src/utils/guestTimetableImportSession.ts
+++ b/frontend/src/utils/guestTimetableImportSession.ts
@@ -1,0 +1,48 @@
+export const GUEST_TIMETABLE_IMPORT_PROMPT_SESSION_KEY =
+  'tainan-select:guest-timetable-import-prompt:v1'
+export const GUEST_TIMETABLE_IMPORT_REQUEST_EVENT =
+  'tainan-select:guest-timetable-import:request'
+
+export const isGuestTimetableImportPromptHandled = (): boolean => {
+  if (typeof window === 'undefined') return false
+
+  try {
+    return window.sessionStorage.getItem(GUEST_TIMETABLE_IMPORT_PROMPT_SESSION_KEY) === 'handled'
+  } catch {
+    return false
+  }
+}
+
+export const markGuestTimetableImportPromptHandled = (): void => {
+  if (typeof window === 'undefined') return
+
+  try {
+    window.sessionStorage.setItem(GUEST_TIMETABLE_IMPORT_PROMPT_SESSION_KEY, 'handled')
+  } catch {
+    return
+  }
+}
+
+export const clearGuestTimetableImportPromptGuard = (): void => {
+  if (typeof window === 'undefined') return
+
+  try {
+    window.sessionStorage.removeItem(GUEST_TIMETABLE_IMPORT_PROMPT_SESSION_KEY)
+  } catch {
+    return
+  }
+}
+
+export const requestGuestTimetableImportPrompt = (): void => {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new Event(GUEST_TIMETABLE_IMPORT_REQUEST_EVENT))
+}
+
+export const subscribeGuestTimetableImportPromptRequest = (
+  listener: () => void,
+): (() => void) => {
+  if (typeof window === 'undefined') return () => undefined
+
+  window.addEventListener(GUEST_TIMETABLE_IMPORT_REQUEST_EVENT, listener)
+  return () => window.removeEventListener(GUEST_TIMETABLE_IMPORT_REQUEST_EVENT, listener)
+}

--- a/frontend/src/utils/guestTimetableStorage.ts
+++ b/frontend/src/utils/guestTimetableStorage.ts
@@ -209,6 +209,17 @@ export const isGuestCourseAdded = (
   courseId: number,
 ): boolean => getGuestItemsBySemester(semester).some((item) => item.course.id === courseId)
 
+export const isGuestCourseSnapshotCurrent = (
+  item: GuestTimetableItem,
+): Promise<boolean> => {
+  assertValidGuestTimetableItem(item)
+
+  return withGuestTimetableWriteLock(() => getGuestItemsBySemester(item.course.semester).some(
+    (currentItem) => currentItem.course.id === item.course.id
+      && currentItem.addedAt === item.addedAt,
+  ))
+}
+
 export const getGuestTimetableSummary = (
   storage: GuestTimetableStorage = getGuestTimetable(),
 ): GuestTimetableSummary => {

--- a/frontend/src/utils/guestTimetableStorage.ts
+++ b/frontend/src/utils/guestTimetableStorage.ts
@@ -147,7 +147,7 @@ const normalizeGuestTimetableStorage = (
   ),
 })
 
-const haveSameGuestTimetableCourses = (
+const haveSameGuestTimetableSnapshots = (
   firstStorage: GuestTimetableStorage,
   secondStorage: GuestTimetableStorage,
 ): boolean => {
@@ -162,8 +162,12 @@ const haveSameGuestTimetableCourses = (
     const secondItems = secondStorage.semesters[semester]
     if (!secondItems || firstItems.length !== secondItems.length) return false
 
-    const secondCourseIds = new Set(secondItems.map((item) => item.course.id))
-    return firstItems.every((item) => secondCourseIds.has(item.course.id))
+    const secondAddedAtByCourseId = new Map(
+      secondItems.map((item) => [item.course.id, item.addedAt]),
+    )
+    return firstItems.every(
+      (item) => secondAddedAtByCourseId.get(item.course.id) === item.addedAt,
+    )
   })
 }
 
@@ -325,6 +329,14 @@ export const removeGuestCourse = (
   if (canRemove && !canRemove()) return false
 
   const storage = getGuestTimetable()
+  return removeGuestCourseFromStorage(storage, semester, courseId)
+})
+
+const removeGuestCourseFromStorage = (
+  storage: GuestTimetableStorage,
+  semester: string,
+  courseId: number,
+): boolean => {
   const currentItems = storage.semesters[semester] ?? []
   const nextItems = currentItems.filter((item) => item.course.id !== courseId)
 
@@ -340,7 +352,27 @@ export const removeGuestCourse = (
   writeGuestTimetable({ ...storage, semesters: nextSemesters })
 
   return true
-})
+}
+
+export const removeGuestCourseSnapshot = (
+  item: GuestTimetableItem,
+  canRemove?: () => boolean,
+): Promise<boolean> => {
+  assertValidGuestTimetableItem(item)
+
+  return withGuestTimetableWriteLock(() => {
+    if (canRemove && !canRemove()) return false
+
+    const storage = getGuestTimetable()
+    const snapshotMatches = (storage.semesters[item.course.semester] ?? []).some(
+      (currentItem) => currentItem.course.id === item.course.id
+        && currentItem.addedAt === item.addedAt,
+    )
+    if (!snapshotMatches) return false
+
+    return removeGuestCourseFromStorage(storage, item.course.semester, item.course.id)
+  })
+}
 
 export const clearGuestSemester = (
   semester: string,
@@ -376,7 +408,7 @@ export const clearGuestTimetable = (
     .some((items) => items.length > 0)
   if (!hasCurrentCourses) return 'already-empty'
 
-  if (!haveSameGuestTimetableCourses(expectedStorage, currentStorage)) {
+  if (!haveSameGuestTimetableSnapshots(expectedStorage, currentStorage)) {
     return 'changed'
   }
 


### PR DESCRIPTION
## 標題

加入訪客課表登入後安全匯入流程

---

## 摘要

登入後偵測尚未處理的本機訪客課表，讓使用者選擇保存到帳號、稍後處理或清除；匯入過程會保留衝堂項目、重新確認交換，並防止 session 切換或 stale local snapshot 導致錯誤清除。

此 PR 僅包含 4 個 commits、5 個 frontend 檔案。

---

## 背景／問題

訪客登入後，本機課表不能直接消失或無條件覆寫帳號課表。匯入流程需要處理：

1. 多個學期與多門課程的逐筆匯入結果。
2. 帳號課表已存在、無時段與衝堂課程。
3. 衝堂確認期間另一分頁修改帳號課表。
4. 匯入途中切換登入 session。
5. 多分頁同時修改本機課表，避免用過期 snapshot 清除較新的資料。
6. 使用者關閉提示後仍能再次手動開啟。

---

## 變更內容

### Import prompt lifecycle

- 使用 sessionStorage 記錄本次登入是否已處理提示。
- 提供 request event，讓課表頁可手動重新開啟匯入流程。
- Logout 時清除 prompt guard，下一次登入可重新判斷。

### Guest timetable import modal

- 依學期讀取本機課表並逐筆匯入帳號。
- 顯示成功、已存在、無時段、衝堂與失敗摘要。
- 成功寫入帳號後才從本機移除對應課程。
- 未處理或失敗項目繼續保留於本機。
- 使用 AbortController 中止已失效的流程。

### Session fence 與 stale snapshot 防護

- 匯入開始時擷取 auth session scope。
- 每次 server request 與結果套用前重新確認 session。
- Session 改變時停止匯入，不清除本機資料。
- 本機 remove／clear 使用 snapshot callback／CAS 語意，避免刪除另一分頁剛更新的內容。

### 衝堂交換

- 顯示實際衝堂課程名稱與連結。
- 使用者確認後傳送 `conflictCourseIds` 與 expected session scope。
- 遇到 `CONFLICTS_CHANGED` 時重新取得帳號課表並重建衝堂摘要。
- 交換成功後才移除本機項目。

### App 與課表頁入口

- App 在 auth 狀態確認完成後掛載 import modal。
- 登入後若仍有本機課程，課表頁顯示待處理數量與學期數。
- 提供「處理本機課表」按鈕，使用者可隨時重新開啟流程。

---

## 測試方式

已執行：

- Frontend production build：
  ```bash
  cd frontend
  npm run build
  ```
- Frontend ESLint：
  ```bash
  cd frontend
  npm run lint
  ```
- Diff whitespace：
  ```bash
  git diff --check
  ```

建議人工驗證：

1. 訪客建立多學期課表後登入，確認出現匯入提示。
2. 匯入無衝堂課程，確認帳號新增成功且本機項目移除。
3. 匯入衝堂課程，取消交換後確認本機項目仍保留。
4. 確認交換後，帳號課表更新且本機項目才移除。
5. 衝堂確認期間從另一分頁修改課表，確認重新要求確認。
6. 匯入途中登出或切換 session，確認流程停止且本機資料未遺失。
7. 選擇稍後處理，再從課表頁按「處理本機課表」重新開啟。
8. 多分頁同時修改本機課表，確認過期 snapshot 不會清除新資料。

---

## 備註

- 此為 feature integration PR 6/6，也是最後一支功能 PR。
- Base：`feat/guest-timetable`
- Head：`feat/guest-timetable-import`
- #70、#71、#77、#78、#80 已先合併完成。
- 舊 #75 僅保留先前誤 merge 的歷史紀錄；本 PR 才是目前應合併的 guest import PR。
- 合併完成後，`feat/guest-timetable` 會包含完整功能；是否再合併到 `main` 另行決定。