### PR TITLE
feat: 實作台南選求評價需求排行 Backend

### DIFF
--- a/backend/config/reviewRequest.test.ts
+++ b/backend/config/reviewRequest.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getInterestWeightByAgeDays,
+  getReviewNeedFactor,
+  REVIEW_REQUEST_CONFIG,
+} from "./reviewRequest";
+
+test("收藏 freshness 在各天數邊界使用逐筆權重", () => {
+  assert.deepEqual(
+    [0, 30, 31, 60, 61, 90, 91, 120, 121, 180, 181].map(
+      getInterestWeightByAgeDays
+    ),
+    [5, 5, 4, 4, 3, 3, 2, 2, 1, 1, 0]
+  );
+});
+
+test("review count 依集中設定套用資訊缺口 factor", () => {
+  assert.deepEqual(
+    [0, 1, 2, 3, 4, 5, 7, 8, 20].map(getReviewNeedFactor),
+    [1, 0.8, 0.6, 0.4, 0.4, 0.2, 0.2, 0.1, 0.1]
+  );
+  assert.equal(REVIEW_REQUEST_CONFIG.guestSnapshotTtlDays, 180);
+});

--- a/backend/config/reviewRequest.ts
+++ b/backend/config/reviewRequest.ts
@@ -1,0 +1,36 @@
+import { TIMETABLE_ANALYTICS_CONFIG } from "../types/timetableAnalytics";
+
+export const REVIEW_REQUEST_CONFIG = {
+  interestWeights: [
+    { maxAgeDays: 30, weight: 5 },
+    { maxAgeDays: 60, weight: 4 },
+    { maxAgeDays: 90, weight: 3 },
+    { maxAgeDays: 120, weight: 2 },
+    { maxAgeDays: 180, weight: 1 },
+  ],
+  reviewNeedFactors: [
+    { maxReviewCount: 0, factor: 1 },
+    { maxReviewCount: 1, factor: 0.8 },
+    { maxReviewCount: 2, factor: 0.6 },
+    { maxReviewCount: 4, factor: 0.4 },
+    { maxReviewCount: 7, factor: 0.2 },
+  ],
+  minimumReviewNeedFactor: 0.1,
+  guestSnapshotTtlDays: TIMETABLE_ANALYTICS_CONFIG.guestSnapshotTtlDays,
+  defaultLimit: 5,
+  maxLimit: 20,
+} as const;
+
+export const getInterestWeightByAgeDays = (ageDays: number): number => {
+  if (ageDays < 0) return REVIEW_REQUEST_CONFIG.interestWeights[0].weight;
+
+  return REVIEW_REQUEST_CONFIG.interestWeights.find(
+    ({ maxAgeDays }) => ageDays <= maxAgeDays
+  )?.weight ?? 0;
+};
+
+export const getReviewNeedFactor = (reviewCount: number): number => (
+  REVIEW_REQUEST_CONFIG.reviewNeedFactors.find(
+    ({ maxReviewCount }) => reviewCount <= maxReviewCount
+  )?.factor ?? REVIEW_REQUEST_CONFIG.minimumReviewNeedFactor
+);

--- a/backend/controllers/courseController.reviewRequests.test.ts
+++ b/backend/controllers/courseController.reviewRequests.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { NextFunction, Request, Response } from "express";
+import CourseService, { ReviewRequestServiceError } from "../services/courseService";
+import { getReviewRequestCourses } from "./courseController";
+
+const createResponse = () => {
+  const state: { status?: number; body?: unknown } = {};
+  const response = {
+    status(status: number) {
+      state.status = status;
+      return response;
+    },
+    json(body: unknown) {
+      state.body = body;
+      return response;
+    },
+  } as unknown as Response;
+  return { response, state };
+};
+
+const next = (() => {}) as NextFunction;
+
+test("GET review-requests 傳遞 query 並回傳排行", async (t) => {
+  const result = { semester: "115-1", items: [] };
+  const serviceMock = t.mock.method(CourseService, "getReviewRequestCourses", async () => result);
+  const { response, state } = createResponse();
+
+  await getReviewRequestCourses({
+    query: { semester: "115-1", limit: "5" },
+  } as unknown as Request, response, next);
+
+  assert.deepEqual(serviceMock.mock.calls[0].arguments, ["115-1", "5"]);
+  assert.deepEqual(state, { status: 200, body: result });
+});
+
+test("GET review-requests 的輸入錯誤回傳 400", async (t) => {
+  t.mock.method(CourseService, "getReviewRequestCourses", async () => {
+    throw new ReviewRequestServiceError(400, "semester 格式錯誤");
+  });
+  const { response, state } = createResponse();
+
+  await getReviewRequestCourses({ query: {} } as Request, response, next);
+
+  assert.deepEqual(state, {
+    status: 400,
+    body: { message: "semester 格式錯誤" },
+  });
+});

--- a/backend/controllers/courseController.ts
+++ b/backend/controllers/courseController.ts
@@ -1,4 +1,4 @@
-import CourseService from "../services/courseService";
+import CourseService, { ReviewRequestServiceError } from "../services/courseService";
 import CourseViewService from "../services/courseViewService";
 import { RequestHandler } from "express";
 import { PERIOD_ORDER } from "../utils/courseSchedule";
@@ -115,15 +115,21 @@ export const getCourse: RequestHandler = async (req, res): Promise<void> => {
   }
 };
 
-// NOTE: 暫時移除此功能
-export const getMostCuriousButUnreviewedCourses: RequestHandler = async (
+export const getReviewRequestCourses: RequestHandler = async (
   req,
   res
 ): Promise<void> => {
   try {
-    const courses = await CourseService.getMostCuriousButUnreviewedCourses();
-    res.status(200).json(courses);
+    const result = await CourseService.getReviewRequestCourses(
+      req.query.semester,
+      req.query.limit
+    );
+    res.status(200).json(result);
   } catch (err) {
-    res.status(500).json({ message: err });
+    if (err instanceof ReviewRequestServiceError) {
+      res.status(err.status).json({ message: err.message });
+      return;
+    }
+    res.status(500).json({ message: "取得求評價課程失敗" });
   }
 };

--- a/backend/docs/review-request-ranking-explain.md
+++ b/backend/docs/review-request-ranking-explain.md
@@ -1,0 +1,42 @@
+# 求評價排行 Query 驗證紀錄
+
+驗證日期：2026-08-22
+
+## 驗證環境
+
+- MySQL 8.0.35
+- 使用既有 Courses、Interests、Timetables、TimetableItems 資料
+- 使用 115-1 學期
+- 以 connection-scoped temporary table 建立 30 筆 GuestTimetableSnapshots 測試資料
+- 執行 `npm run explain:review-requests` 取得 Top 20 與 `EXPLAIN FORMAT=JSON`
+
+## 結果摘要
+
+- `JSON_TABLE` 可正確展開 `course_ids` JSON 並依 course ID 聚合。
+- 登入課表與匿名課表計數皆在同一個 aggregate query 完成，沒有 N+1 query。
+- 暫存 guest snapshots 中，同一課程出現在 10 個不同 client 時，排行訊號正確顯示 `timetableCount = 10`。
+- 現有真實資料中，同分課程若評價數不同，review need factor 會明顯降低已有較多評價課程的分數。
+- 排序結果符合 score、課表數、收藏分數、評價數、course ID 的固定 tie-breaker。
+
+## EXPLAIN 觀察
+
+| 資料來源 | 約略掃描筆數 | 觀察 |
+| --- | ---: | --- |
+| Courses | 5,702 | 目前資料量小，指定學期占比高，optimizer 選擇 full scan。 |
+| Interests | 24 | 資料量很小，full scan 成本低。 |
+| Timetables | 6 | 使用既有 `uniq_timetables_user_semester` index scan。 |
+| TimetableItems | 每份課表約 7 | 使用既有 timetable/course unique index。 |
+| GuestTimetableSnapshots | 30 | 暫存資料全部為同一學期，因此 optimizer 未選擇學期索引。 |
+| JSON_TABLE 展開結果 | 每筆約 2 | 測試 payload 每個 snapshot 含 1～3 個 course ID。 |
+
+## Index 決策
+
+已確認現有索引與 #92 migration 的：
+
+- Interests(course_id) 外鍵索引
+- TimetableItems(course_id) 外鍵索引
+- TimetableItems(timetable_id, course_id) unique index
+- Timetables(user_id, semester) unique index
+- GuestTimetableSnapshots(semester, last_synced_at) index
+
+目前資料規模與 query plan 沒有顯示新增複合索引能帶來明確收益，因此本次不新增 index migration。資料量成長後可再次執行診斷 script，比較 `Interests(created_at, course_id)`、`Timetables(semester, id)` 等候選索引前後的實際成本。

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,9 +10,12 @@
     "scrape:ewant": "tsx scraper/scraperEwant.ts",
     "test:course-time": "tsx --test utils/parseCourseTime.test.ts",
     "test:timetable-analytics": "tsx --test models/GuestTimetableSnapshot.test.ts services/timetableAnalyticsService.test.ts repositories/timetableAnalyticsRepository.test.ts controllers/timetableAnalyticsController.test.ts routes/timetableAnalytics.test.ts",
+    "test:review-requests": "tsx --test config/reviewRequest.test.ts repositories/courseRepository.reviewRequests.test.ts services/courseService.reviewRequests.test.ts controllers/courseController.reviewRequests.test.ts routes/courses.reviewRequests.test.ts",
+    "test:review-requests": "tsx --test config/reviewRequest.test.ts repositories/courseRepository.reviewRequests.test.ts services/courseService.reviewRequests.test.ts controllers/courseController.reviewRequests.test.ts routes/courses.reviewRequests.test.ts",
     "backfill:schedules": "tsx scripts/backfillCourseSchedules.ts",
     "backfill:course-identity": "tsx scripts/backfillCourseIdentity.ts",
     "backfill:dcard-related-post-counts": "tsx scripts/backfillDcardRelatedPostCounts.ts",
+    "explain:review-requests": "tsx scripts/explainReviewRequestRanking.ts",
     "migrate": "sequelize-cli db:migrate --config config/config.cjs"
   },
   "keywords": [],

--- a/backend/repositories/courseRepository.reviewRequests.test.ts
+++ b/backend/repositories/courseRepository.reviewRequests.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { QueryTypes } from "sequelize";
+import db from "../models";
+import CourseRepository from "./courseRepository";
+
+test("求評價排行使用單次 aggregate query、JSON snapshot 與安全參數", async (t) => {
+  const queryMock = t.mock.method(db.sequelize, "query", async () => []);
+
+  await CourseRepository.getReviewRequestCourses("115-1", 5);
+
+  const [sql, options] = queryMock.mock.calls[0].arguments;
+  assert.equal(typeof sql, "string");
+  const query = String(sql);
+  assert.match(query, /COUNT\(DISTINCT timetable_items\.timetable_id\)/);
+  assert.match(query, /JSON_TABLE\(/);
+  assert.match(query, /COUNT\(DISTINCT guest_snapshots\.client_id\)/);
+  assert.match(query, /guest_snapshots\.last_synced_at >= DATE_SUB/);
+  assert.doesNotMatch(query, /\bview_count\b/i);
+  assert.deepEqual(options?.replacements, {
+    semester: "115-1",
+    limit: 5,
+    interestTtlDays: 180,
+    guestSnapshotTtlDays: 180,
+  });
+  assert.equal(options?.type, QueryTypes.SELECT);
+});
+
+test("求評價排行 tie-breaker 順序固定", async (t) => {
+  const queryMock = t.mock.method(db.sequelize, "query", async () => []);
+
+  await CourseRepository.getReviewRequestCourses("115-1", 20);
+
+  const query = String(queryMock.mock.calls[0].arguments[0]);
+  const sortExpressions = [
+    "reviewRequestScore DESC",
+    "ranked.timetableCount DESC",
+    "ranked.weightedFavoriteScore DESC",
+    "ranked.review_count ASC",
+    "ranked.id DESC",
+  ];
+  const positions = sortExpressions.map((expression) => query.indexOf(expression));
+  assert.ok(positions.every((position) => position >= 0));
+  assert.deepEqual([...positions].sort((first, second) => first - second), positions);
+});

--- a/backend/repositories/courseRepository.ts
+++ b/backend/repositories/courseRepository.ts
@@ -1,8 +1,14 @@
-import { Op, Transaction } from "sequelize";
+import { Op, QueryTypes, Transaction } from "sequelize";
 import CourseModel from "../models/Course";
 import CourseScheduleModel from "../models/CourseSchedule";
-import { Course, CourseOptionFilters, PaginationParams } from "../types/course";
+import {
+  Course,
+  CourseOptionFilters,
+  PaginationParams,
+  ReviewRequestCourseRow,
+} from "../types/course";
 import db from "../models";
+import { REVIEW_REQUEST_CONFIG } from "../config/reviewRequest";
 import {
   EWANT_DEPARTMENT,
   normalizeCourseSchedule,
@@ -13,6 +19,18 @@ const PERIOD_INDEX_MAP = PERIOD_ORDER.reduce<Record<string, number>>((acc, perio
   acc[period] = index;
   return acc;
 }, {});
+
+const INTEREST_WEIGHT_CASE_SQL = REVIEW_REQUEST_CONFIG.interestWeights
+  .map(({ maxAgeDays, weight }) => (
+    `WHEN interests.created_at >= DATE_SUB(NOW(), INTERVAL ${maxAgeDays} DAY) THEN ${weight}`
+  ))
+  .join("\n              ");
+
+const REVIEW_NEED_FACTOR_CASE_SQL = REVIEW_REQUEST_CONFIG.reviewNeedFactors
+  .map(({ maxReviewCount, factor }) => (
+    `WHEN courses.review_count <= ${maxReviewCount} THEN ${factor}`
+  ))
+  .join("\n          ");
 
 const getCategoryConditions = (category?: string): any[] => {
   if (category === "general") {
@@ -218,20 +236,108 @@ class CourseRepository {
       .filter((semester): semester is string => Boolean(semester));
   }
 
-  // NOTE: 暫時移除此功能
-  async getMostCuriousButUnreviewedCourses(): Promise<Course[]> {
-    // 想了解程度 ÷ 評論數 = 被大量收藏或瀏覽、但評論數很少的課程
-    const courses = await CourseModel.findAll({
-      attributes: {
-        include: [[
-          db.Sequelize.literal(`(interests_count * 0.9 + view_count * 0.1) / (review_count + 1)`),
-          "curiosity_score"
-        ]]
+  async getReviewRequestCourses(
+    semester: string,
+    limit: number,
+    transaction?: Transaction
+  ): Promise<ReviewRequestCourseRow[]> {
+    const query = `
+      SELECT
+        ranked.id,
+        ranked.course_name,
+        ranked.department,
+        ranked.instructor,
+        ranked.review_count,
+        ranked.recentInterestCount,
+        ranked.weightedFavoriteScore,
+        ranked.timetableCount,
+        ranked.demandScore * ranked.reviewNeedFactor AS reviewRequestScore
+      FROM (
+        SELECT
+          courses.id,
+          courses.course_name,
+          courses.department,
+          courses.instructor,
+          courses.review_count,
+          COALESCE(interest_signals.recentInterestCount, 0) AS recentInterestCount,
+          COALESCE(interest_signals.weightedFavoriteScore, 0) AS weightedFavoriteScore,
+          COALESCE(auth_timetable_signals.authenticatedTimetableCount, 0)
+            + COALESCE(guest_timetable_signals.guestTimetableCount, 0) AS timetableCount,
+          COALESCE(interest_signals.weightedFavoriteScore, 0)
+            + COALESCE(auth_timetable_signals.authenticatedTimetableCount, 0)
+            + COALESCE(guest_timetable_signals.guestTimetableCount, 0) AS demandScore,
+          CASE
+            ${REVIEW_NEED_FACTOR_CASE_SQL}
+            ELSE ${REVIEW_REQUEST_CONFIG.minimumReviewNeedFactor}
+          END AS reviewNeedFactor
+        FROM Courses AS courses
+        LEFT JOIN (
+          SELECT
+            interests.course_id,
+            COUNT(*) AS recentInterestCount,
+            SUM(
+              CASE
+                ${INTEREST_WEIGHT_CASE_SQL}
+                ELSE 0
+              END
+            ) AS weightedFavoriteScore
+          FROM Interests AS interests
+          INNER JOIN Courses AS interest_courses
+            ON interest_courses.id = interests.course_id
+            AND interest_courses.semester = :semester
+          WHERE interests.created_at >= DATE_SUB(NOW(), INTERVAL :interestTtlDays DAY)
+          GROUP BY interests.course_id
+        ) AS interest_signals ON interest_signals.course_id = courses.id
+        LEFT JOIN (
+          SELECT
+            timetable_items.course_id,
+            COUNT(DISTINCT timetable_items.timetable_id) AS authenticatedTimetableCount
+          FROM TimetableItems AS timetable_items
+          INNER JOIN Timetables AS timetables
+            ON timetables.id = timetable_items.timetable_id
+          WHERE timetables.semester = :semester
+          GROUP BY timetable_items.course_id
+        ) AS auth_timetable_signals ON auth_timetable_signals.course_id = courses.id
+        LEFT JOIN (
+          SELECT
+            guest_courses.course_id,
+            COUNT(DISTINCT guest_snapshots.client_id) AS guestTimetableCount
+          FROM GuestTimetableSnapshots AS guest_snapshots
+          INNER JOIN JSON_TABLE(
+            guest_snapshots.course_ids,
+            '$[*]' COLUMNS(course_id INT PATH '$')
+          ) AS guest_courses ON TRUE
+          WHERE guest_snapshots.semester = :semester
+            AND guest_snapshots.last_synced_at >= DATE_SUB(
+              NOW(),
+              INTERVAL :guestSnapshotTtlDays DAY
+            )
+          GROUP BY guest_courses.course_id
+        ) AS guest_timetable_signals ON guest_timetable_signals.course_id = courses.id
+        WHERE courses.semester = :semester
+      ) AS ranked
+      WHERE ranked.demandScore > 0
+      ORDER BY
+        reviewRequestScore DESC,
+        ranked.timetableCount DESC,
+        ranked.weightedFavoriteScore DESC,
+        ranked.review_count ASC,
+        ranked.id DESC
+      LIMIT :limit
+    `;
+
+    return await db.sequelize.query<ReviewRequestCourseRow>(query, {
+      replacements: {
+        semester,
+        limit,
+        interestTtlDays: REVIEW_REQUEST_CONFIG.interestWeights[
+          REVIEW_REQUEST_CONFIG.interestWeights.length - 1
+        ].maxAgeDays,
+        guestSnapshotTtlDays: REVIEW_REQUEST_CONFIG.guestSnapshotTtlDays,
       },
-      limit: 5,
-      order: [['curiosity_score', 'desc']]
-    })
-    return courses;
+      type: QueryTypes.SELECT,
+      transaction,
+    });
   }
 
   async decrementCount(

--- a/backend/routes/courses.reviewRequests.test.ts
+++ b/backend/routes/courses.reviewRequests.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import router from "./courses";
+
+test("review-requests route 位於動態 course_id route 前", () => {
+  const paths = (router as unknown as {
+    stack: Array<{ route?: { path: string } }>;
+  }).stack
+    .filter((layer) => layer.route)
+    .map((layer) => layer.route!.path);
+
+  const reviewRequestIndex = paths.indexOf("/review-requests");
+  const courseIdIndex = paths.indexOf("/:course_id");
+  assert.ok(reviewRequestIndex >= 0);
+  assert.ok(courseIdIndex >= 0);
+  assert.ok(reviewRequestIndex < courseIdIndex);
+});

--- a/backend/routes/courses.ts
+++ b/backend/routes/courses.ts
@@ -1,15 +1,13 @@
 import express, { Router } from 'express';
-import { getAllAcademies, getAllCourses, getAllDepartments, getCourse, getMostCuriousButUnreviewedCourses } from '../controllers/courseController';
+import { getAllAcademies, getAllCourses, getAllDepartments, getCourse, getReviewRequestCourses } from '../controllers/courseController';
 import { getCookie } from '../middlewares/authMiddleware';
 
 const router: Router = express.Router();
 
 router.get("/getAllDepartments", getAllDepartments);
 router.get("/getAllAcademies", getAllAcademies);
+router.get("/review-requests", getReviewRequestCourses);
 router.get("/:course_id", getCookie, getCourse);
 router.get("/", getAllCourses);
-
-// NOTE: 暫時移除此功能
-// router.get("/getMostCuriousButUnreviewedCourses", getMostCuriousButUnreviewedCourses);
 
 export default router;

--- a/backend/scripts/explainReviewRequestRanking.ts
+++ b/backend/scripts/explainReviewRequestRanking.ts
@@ -1,0 +1,183 @@
+import { randomUUID } from "node:crypto";
+import { QueryTypes, Transaction } from "sequelize";
+import db from "../models";
+import CourseRepository from "../repositories/courseRepository";
+
+type ExplainNode = Record<string, unknown>;
+
+const collectExplainTables = (value: unknown, rows: string[] = []): string[] => {
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectExplainTables(item, rows));
+    return rows;
+  }
+  if (!value || typeof value !== "object") return rows;
+
+  const node = value as ExplainNode;
+  if (typeof node.table_name === "string") {
+    rows.push([
+      node.table_name,
+      `access=${String(node.access_type ?? "unknown")}`,
+      `key=${String(node.key ?? "none")}`,
+      `rows=${String(node.rows_examined_per_scan ?? "unknown")}`,
+    ].join(" | "));
+  }
+  Object.values(node).forEach((item) => collectExplainTables(item, rows));
+  return rows;
+};
+
+const run = async (): Promise<void> => {
+  await db.sequelize.authenticate();
+
+  const semesters = await db.sequelize.query<{ semester: string }>(
+    `SELECT semester
+     FROM Courses
+     WHERE semester REGEXP '^[0-9]{3}-[12]$'
+     GROUP BY semester
+     ORDER BY semester DESC
+     LIMIT 1`,
+    { type: QueryTypes.SELECT }
+  );
+  const semester = semesters[0]?.semester;
+  if (!semester) throw new Error("找不到可用學期資料");
+
+  await db.sequelize.transaction(async (transaction: Transaction) => {
+    await db.sequelize.query(
+      `CREATE TEMPORARY TABLE GuestTimetableSnapshots (
+        id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+        client_id CHAR(36) NOT NULL,
+        semester VARCHAR(10) NOT NULL,
+        course_ids JSON NOT NULL,
+        last_synced_at DATETIME NOT NULL,
+        created_at DATETIME NOT NULL,
+        updated_at DATETIME NOT NULL,
+        UNIQUE KEY uniq_guest_timetable_snapshots_client_semester (client_id, semester),
+        KEY idx_guest_timetable_snapshots_semester_synced_at (semester, last_synced_at)
+      )`,
+      { transaction }
+    );
+
+    const courses = await db.sequelize.query<{ id: number }>(
+      `SELECT id
+       FROM Courses
+       WHERE semester = :semester
+       ORDER BY id DESC
+       LIMIT 10`,
+      { replacements: { semester }, type: QueryTypes.SELECT, transaction }
+    );
+    if (courses.length === 0) throw new Error(`${semester} 沒有可用課程`);
+
+    const snapshots = Array.from({ length: 30 }, (_, index) => ({
+      clientId: randomUUID(),
+      courseIds: courses
+        .filter((_, courseIndex) => courseIndex % 3 === index % 3)
+        .slice(0, 3)
+        .map((course) => course.id),
+    }));
+    for (const snapshot of snapshots) {
+      await db.sequelize.query(
+        `INSERT INTO GuestTimetableSnapshots
+          (client_id, semester, course_ids, last_synced_at, created_at, updated_at)
+         VALUES (:clientId, :semester, :courseIds, NOW(), NOW(), NOW())`,
+        {
+          replacements: {
+            clientId: snapshot.clientId,
+            semester,
+            courseIds: JSON.stringify(snapshot.courseIds),
+          },
+          transaction,
+        }
+      );
+    }
+    await db.sequelize.query(
+      `INSERT INTO GuestTimetableSnapshots
+        (client_id, semester, course_ids, last_synced_at, created_at, updated_at)
+       VALUES (
+         :clientId,
+         :semester,
+         :courseIds,
+         DATE_SUB(NOW(), INTERVAL 181 DAY),
+         NOW(),
+         NOW()
+       )`,
+      {
+        replacements: {
+          clientId: randomUUID(),
+          semester,
+          courseIds: JSON.stringify([courses[0].id]),
+        },
+        transaction,
+      }
+    );
+
+    let rankingSql = "";
+    const sequelizeOptions = (db.sequelize as unknown as {
+      options: { logging: false | ((sql: string) => void) };
+    }).options;
+    const previousLogging = sequelizeOptions.logging;
+    sequelizeOptions.logging = (sql: string) => {
+      if (sql.includes("SELECT") && sql.includes("reviewRequestScore")) {
+        rankingSql = sql.replace(/^Executing \([^)]+\):\s*/, "");
+      }
+    };
+
+    let ranking;
+    try {
+      ranking = await CourseRepository.getReviewRequestCourses(
+        semester,
+        20,
+        transaction
+      );
+    } finally {
+      sequelizeOptions.logging = previousLogging;
+    }
+    if (!rankingSql) throw new Error("無法取得排行 SQL");
+
+    const authenticatedCounts = await db.sequelize.query<{ count: number | string }>(
+      `SELECT COUNT(DISTINCT timetable_items.timetable_id) AS count
+       FROM TimetableItems AS timetable_items
+       INNER JOIN Timetables AS timetables
+         ON timetables.id = timetable_items.timetable_id
+       WHERE timetable_items.course_id = :courseId
+         AND timetables.semester = :semester`,
+      {
+        replacements: { courseId: courses[0].id, semester },
+        type: QueryTypes.SELECT,
+        transaction,
+        logging: false,
+      }
+    );
+    const firstCourseRanking = ranking.find((item) => Number(item.id) === Number(courses[0].id));
+    const expectedTimetableCount = Number(authenticatedCounts[0]?.count ?? 0) + 10;
+    if (Number(firstCourseRanking?.timetableCount) !== expectedTimetableCount) {
+      throw new Error("過期 Guest Snapshot TTL 驗證失敗");
+    }
+
+    const explainRows = await db.sequelize.query<Record<string, string>>(
+      `EXPLAIN FORMAT=JSON ${rankingSql}`,
+      { type: QueryTypes.SELECT, transaction, logging: false }
+    );
+    const explainJson = JSON.parse(explainRows[0]?.EXPLAIN ?? "{}");
+
+    console.log(`驗證學期：${semester}`);
+    console.log(`候選結果：${ranking.length} 筆`);
+    console.table(ranking.slice(0, 20).map((item) => ({
+      id: item.id,
+      課名: item.course_name,
+      評價數: item.review_count,
+      近期收藏分數: Number(item.weightedFavoriteScore),
+      課表數: Number(item.timetableCount),
+      求評價分數: Number(item.reviewRequestScore),
+    })));
+    console.log("EXPLAIN 存取摘要：");
+    collectExplainTables(explainJson).forEach((row) => console.log(row));
+  });
+};
+
+run()
+  .catch((error) => {
+    console.error("求評價排行驗證失敗：", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await db.sequelize.close();
+  });

--- a/backend/services/courseService.reviewRequests.test.ts
+++ b/backend/services/courseService.reviewRequests.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import CourseRepository from "../repositories/courseRepository";
+import CourseService, { ReviewRequestServiceError } from "./courseService";
+
+test("求評價排行驗證 semester 與 limit", async () => {
+  await assert.rejects(
+    CourseService.getReviewRequestCourses("115-3", 5),
+    (error) => error instanceof ReviewRequestServiceError && error.status === 400
+  );
+  await assert.rejects(
+    CourseService.getReviewRequestCourses("115-1", "5abc"),
+    ReviewRequestServiceError
+  );
+  await assert.rejects(
+    CourseService.getReviewRequestCourses("115-1", 21),
+    ReviewRequestServiceError
+  );
+});
+
+test("求評價排行只查指定學期並將 aggregate 數值正規化", async (t) => {
+  const repositoryMock = t.mock.method(
+    CourseRepository,
+    "getReviewRequestCourses",
+    async () => [{
+      id: 123,
+      course_name: "資料結構",
+      department: "資訊工程學系",
+      instructor: "測試教師",
+      review_count: 0,
+      recentInterestCount: "5",
+      weightedFavoriteScore: "21",
+      timetableCount: "12",
+      reviewRequestScore: "33",
+    }]
+  );
+
+  const result = await CourseService.getReviewRequestCourses(" 115-1 ", undefined);
+
+  assert.deepEqual(repositoryMock.mock.calls[0].arguments, ["115-1", 5]);
+  assert.deepEqual(result, {
+    semester: "115-1",
+    items: [{
+      course: {
+        id: 123,
+        course_name: "資料結構",
+        department: "資訊工程學系",
+        instructor: "測試教師",
+        review_count: 0,
+      },
+      signals: {
+        recentInterestCount: 5,
+        weightedFavoriteScore: 21,
+        timetableCount: 12,
+        reviewCount: 0,
+      },
+      reviewRequestScore: 33,
+    }],
+  });
+});
+
+test("沒有候選課程時回傳空 items", async (t) => {
+  t.mock.method(CourseRepository, "getReviewRequestCourses", async () => []);
+
+  assert.deepEqual(
+    await CourseService.getReviewRequestCourses("115-1", 5),
+    { semester: "115-1", items: [] }
+  );
+});

--- a/backend/services/courseService.ts
+++ b/backend/services/courseService.ts
@@ -4,6 +4,7 @@ import {
   CourseListResult,
   CourseOptionFilters,
   CourseWithTimeslots,
+  ReviewRequestCoursesResponse,
 } from "../types/course";
 import { PaginationParams } from "../types/course";
 import CourseRepository from "../repositories/courseRepository";
@@ -15,6 +16,18 @@ import {
   normalizeCourseSchedule,
   normalizeCourseSchedules,
 } from "../utils/courseSchedule";
+import { REVIEW_REQUEST_CONFIG } from "../config/reviewRequest";
+
+const SEMESTER_PATTERN = /^\d{3}-[12]$/;
+
+export class ReviewRequestServiceError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
 
 class CourseService {
   async getAllCourses(params: PaginationParams): Promise<CourseListResult>;
@@ -86,9 +99,49 @@ class CourseService {
     return await CourseRepository.getAllSemesters();
   }
 
-  // NOTE: 暫時移除此功能
-  async getMostCuriousButUnreviewedCourses(): Promise<Course[]>{
-    return await CourseRepository.getMostCuriousButUnreviewedCourses();
+  async getReviewRequestCourses(
+    rawSemester: unknown,
+    rawLimit: unknown
+  ): Promise<ReviewRequestCoursesResponse> {
+    const semester = typeof rawSemester === "string" ? rawSemester.trim() : "";
+    if (!SEMESTER_PATTERN.test(semester)) {
+      throw new ReviewRequestServiceError(400, "semester 格式錯誤");
+    }
+
+    const limit = rawLimit === undefined || rawLimit === ""
+      ? REVIEW_REQUEST_CONFIG.defaultLimit
+      : Number(rawLimit);
+    if (
+      !Number.isSafeInteger(limit)
+      || limit < 1
+      || limit > REVIEW_REQUEST_CONFIG.maxLimit
+    ) {
+      throw new ReviewRequestServiceError(
+        400,
+        `limit 必須介於 1 與 ${REVIEW_REQUEST_CONFIG.maxLimit} 之間`
+      );
+    }
+
+    const rows = await CourseRepository.getReviewRequestCourses(semester, limit);
+    return {
+      semester,
+      items: rows.map((row) => ({
+        course: {
+          id: Number(row.id),
+          course_name: row.course_name,
+          department: row.department,
+          instructor: row.instructor,
+          review_count: Number(row.review_count),
+        },
+        signals: {
+          recentInterestCount: Number(row.recentInterestCount),
+          weightedFavoriteScore: Number(row.weightedFavoriteScore),
+          timetableCount: Number(row.timetableCount),
+          reviewCount: Number(row.review_count),
+        },
+        reviewRequestScore: Number(row.reviewRequestScore),
+      })),
+    };
   }
 
   async addViewCount(course_id: number): Promise<void>{

--- a/backend/types/course.ts
+++ b/backend/types/course.ts
@@ -32,6 +32,40 @@ export interface CourseListResult<TCourse extends Course = Course> {
   total: number;
 }
 
+export interface ReviewRequestCourseItem {
+  course: {
+    id: number;
+    course_name: string;
+    department: string;
+    instructor: string;
+    review_count: number;
+  };
+  signals: {
+    recentInterestCount: number;
+    weightedFavoriteScore: number;
+    timetableCount: number;
+    reviewCount: number;
+  };
+  reviewRequestScore: number;
+}
+
+export interface ReviewRequestCoursesResponse {
+  semester: string;
+  items: ReviewRequestCourseItem[];
+}
+
+export interface ReviewRequestCourseRow {
+  id: number;
+  course_name: string;
+  department: string;
+  instructor: string;
+  review_count: number;
+  recentInterestCount: number | string;
+  weightedFavoriteScore: number | string;
+  timetableCount: number | string;
+  reviewRequestScore: number | string;
+}
+
 export interface CourseRelatedPost {
   id: number;
   course_id?: number;


### PR DESCRIPTION
## 標題

實作台南選求評價需求排行 Backend

---

## 摘要

新增指定學期的求評價需求排行 API，整合近期收藏、登入課表與匿名課表 Snapshot，依評論資訊缺口計算固定排序結果。

---

## 背景／問題

既有求評價查詢依賴累積欄位與 `view_count`，無法反映近期選課需求，也未納入登入與匿名課表資料。

---

## 變更內容

- 在 `backend/config/reviewRequest.ts` 集中管理收藏時效權重、評論需求係數、Guest Snapshot TTL 與 limit。
- 在 `backend/repositories/courseRepository.ts` 以單一 aggregate query 聚合指定學期收藏、登入課表及匿名課表資料。
- 新增 `GET /courses/review-requests?semester=115-1&limit=5`，並將 route 放在 `/:course_id` 前。
- 套用分數、課表數、收藏分數、評論數與課程 ID 的固定 tie-breaker。
- 將相關測試統一放在 `backend/tests/reviewRequests`。

---

## 測試方式

- `cd backend && npm test`：34 項測試通過。
- `cd backend && .\node_modules\.bin\tsc.cmd --noEmit`：TypeScript 檢查通過。
- 測試涵蓋收藏時效邊界、評論需求係數、學期驗證、Guest JSON／TTL、聚合查詢與 tie-breaker。

---

## 備註

- Base branch：`feat/guest-timetable-analytics-sync`。
- 本 PR 僅處理 Backend，Frontend UI 由 #95 處理。
- Closes #94
