### PR TITLE
refactor: 統一 CourseView 匿名識別為 Analytics Client ID

### DIFF
--- a/.agents/skills/fix-pr/SKILL.md
+++ b/.agents/skills/fix-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fix-pr
-description: 處理 GitHub Pull Request 尚未解決且可執行的 review threads，完成程式碼修正、驗證、commit、push，並在每個原始 comment 下以可點擊的完整 commit SHA 逐則回覆，再串行觸發 @codex review 並等待回應。當使用者要求處理 PR 未解決問題、修正 review 意見、推送修正並回覆 reviewer 時使用；預設保留 threads 為 unresolved，不直接 resolve。
+description: 處理 GitHub Pull Request 尚未解決且可執行的 review threads，完成程式碼修正、驗證、commit、push，並在每個原始 comment 下以可點擊的完整 commit SHA 逐則回覆，最後統一觸發一次 @codex review 並等待回應。當使用者要求處理 PR 未解決問題、修正 review 意見、推送修正並回覆 reviewer 時使用；預設保留 threads 為 unresolved，不直接 resolve。
 ---
 
 # 處理未解決的 PR Review
@@ -35,25 +35,23 @@ description: 處理 GitHub Pull Request 尚未解決且可執行的 review threa
    - push 到 PR 的 head branch，並取得 push 後 HEAD 的完整 40 字元 SHA。
    - 若程式碼早已修正，不建立空 commit；找出實際包含修正的 commit。
 
-6. 串行回覆並觸發複查
-   - 等 push 成功後，依序處理每個 thread 的最上層 review comment，不發一則籠統的 PR conversation comment。
-   - 一次只處理一個 thread。禁止以 Promise.all、平行工具呼叫或短時間連續留言同時觸發多個 @codex review。
-   - 每則回覆第一行加入：@codex review 請確認此問題是否已修正。
+6. 逐則回覆修正內容
+   - 等 push 成功後，依序回覆每個 thread 的最上層 review comment，讓修正與原始意見維持一對一的脈絡。
+   - 每個 thread 只回覆對應的修正內容，不在 thread 回覆中加入 @codex review，以免同時觸發多個複查任務。
    - 使用完整 40 字元 commit SHA，且不得用反引號或 code block 包住 SHA，確保 GitHub 可自動產生連結。
    - 以繁體中文簡述該 thread 的實際修正及通過的驗證。
 
 回覆格式：
 
-@codex review 請確認此問題是否已修正。
-
 已於 <完整 40 字元 commit SHA> 修正。<對應修正摘要>。已通過 <驗證項目>。
 
-7. 等待該 thread 的 Codex 回應
-   - 留言後記錄時間與 comment ID，輪詢同一個 review thread，確認出現建立時間較新的 Codex bot 回覆。
+7. 統一觸發並等待 Codex 複查
+   - 所有 thread 都回覆完成後，在 PR conversation 留下一則 @codex review，附上完整 commit SHA，請 Codex 統一複查本輪修正。
+   - 只觸發一次，不為每個 thread 分別觸發 review。
+   - 留言後記錄時間與 comment ID，輪詢 PR review 或 conversation，確認出現建立時間較新的 Codex bot 回覆。
    - 每次輪詢間隔不超過 60 秒，等待期間提供簡短進度更新。
-   - 收到該 thread 的 Codex 回覆後，才觸發下一個 thread；不得只因留言 API 成功就立即處理下一則。
-   - 若 Codex 回覆提出新問題，先處理該問題並重新驗證、push、回覆，再繼續下一個 thread。
-   - 若合理等待時間內沒有回覆，停止後續 @codex 觸發並回報卡住的 thread，避免多個 review 任務互相合併或被忽略。
+   - 若 Codex 回覆提出新問題，先處理該問題並重新驗證、push、逐則回覆，再統一觸發下一輪複查。
+   - 若合理等待時間內沒有回覆，停止重複觸發並回報目前狀態，避免建立重複 review 任務。
 
 8. 保留 thread 未解決
    - 回覆後不要呼叫 resolve review thread。
@@ -61,8 +59,8 @@ description: 處理 GitHub Pull Request 尚未解決且可執行的 review threa
    - 只有使用者在後續明確要求，且複查結果確認修正後，才 resolve 指定 thread。
 
 9. 最後確認
-   - 重新讀取目標 threads，確認新回覆存在、包含 @codex review、完整 SHA 未被 code formatting 包住，且 isResolved 為 false。
-   - 確認每個已觸發的 thread 都收到各自的新 Codex bot 回覆；列出尚未收到回覆的 thread。
+   - 重新讀取目標 threads，確認逐則回覆存在、完整 SHA 未被 code formatting 包住，且 isResolved 為 false。
+   - 確認 PR conversation 存在本輪唯一的 @codex review，並記錄統一複查結果。
    - 確認本機分支與遠端同步、工作區沒有本次流程遺留的未提交變更。
    - 回報修正數量、commit、push、驗證結果及仍保留 unresolved 的 threads。
 

--- a/backend/controllers/courseController.ts
+++ b/backend/controllers/courseController.ts
@@ -98,15 +98,21 @@ export const getAllAcademies: RequestHandler = async (
 export const getCourse: RequestHandler = async (req, res): Promise<void> => {
   try {
     const user_id = req.user?.id;
-    const ip = req.ip;
-    const user_agent = req.headers['user-agent'] ?? '';
-
     const course_id = parseInt(req.params.course_id);
     const course = await CourseService.getCourse(user_id, course_id);
-    
-    if (course && (await CourseViewService.shouldInsertView(course_id, user_id, ip, user_agent))) {
-      await CourseViewService.insertCourseView(course_id, user_id, ip, user_agent);
-      await CourseService.addViewCount(course_id);
+
+    if (course) {
+      void CourseViewService.trackCourseView({
+          courseId: course_id,
+          userId: user_id,
+          clientId: req.header("x-analytics-client-id"),
+        })
+        .then(async (inserted) => {
+          if (inserted) await CourseService.addViewCount(course_id);
+        })
+        .catch((trackingError) => {
+          console.error("記錄課程瀏覽失敗", trackingError);
+        });
     }
     
     res.status(200).json(course);

--- a/backend/controllers/courseController.ts
+++ b/backend/controllers/courseController.ts
@@ -102,17 +102,16 @@ export const getCourse: RequestHandler = async (req, res): Promise<void> => {
     const course = await CourseService.getCourse(user_id, course_id);
 
     if (course) {
-      void CourseViewService.trackCourseView({
+      try {
+        const inserted = await CourseViewService.trackCourseView({
           courseId: course_id,
           userId: user_id,
           clientId: req.header("x-analytics-client-id"),
-        })
-        .then(async (inserted) => {
-          if (inserted) await CourseService.addViewCount(course_id);
-        })
-        .catch((trackingError) => {
-          console.error("記錄課程瀏覽失敗", trackingError);
         });
+        if (inserted) await CourseService.addViewCount(course_id);
+      } catch (trackingError) {
+        console.error("記錄課程瀏覽失敗", trackingError);
+      }
     }
     
     res.status(200).json(course);

--- a/backend/migrations/20260822140000-add-client-id-to-course-views.js
+++ b/backend/migrations/20260822140000-add-client-id-to-course-views.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('CourseViews', 'client_id', {
+      type: Sequelize.STRING(36),
+      allowNull: true,
+      after: 'user_id',
+    });
+
+    await queryInterface.addIndex('CourseViews', ['course_id', 'client_id', 'viewed_at'], {
+      name: 'idx_course_client_viewed',
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('CourseViews', 'idx_course_client_viewed');
+    await queryInterface.removeColumn('CourseViews', 'client_id');
+  },
+};

--- a/backend/models/CourseView.ts
+++ b/backend/models/CourseView.ts
@@ -1,7 +1,7 @@
 import { DataTypes, InferAttributes, InferCreationAttributes, Model, Optional } from "sequelize";
 import db from ".";
 
-interface CourseViewCreationAttributes extends Optional<InferCreationAttributes<CourseViewModel>, 'id' | 'user_id' | 'ip_address' | 'user_agent'> { }
+interface CourseViewCreationAttributes extends Optional<InferCreationAttributes<CourseViewModel>, 'id' | 'user_id' | 'client_id' | 'ip_address' | 'user_agent'> { }
 
 class CourseViewModel extends Model<
 	InferAttributes<CourseViewModel>,
@@ -9,9 +9,10 @@ class CourseViewModel extends Model<
 >{
 	declare id: number;
 	declare course_id: number;
-	declare user_id?: number;
-	declare ip_address?: string;
-	declare user_agent?:string;
+	declare user_id: number | null;
+	declare client_id: string | null;
+	declare ip_address: string | null;
+	declare user_agent: string | null;
 	declare viewed_at?: Date;
 }
 
@@ -28,6 +29,10 @@ CourseViewModel.init(
     },
     user_id: {
       type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    client_id: {
+      type: DataTypes.STRING(36),
       allowNull: true,
     },
     ip_address: {
@@ -49,6 +54,12 @@ CourseViewModel.init(
     timestamps: true,
     createdAt: 'created_at',  // 映射到資料表中的 created_at
     updatedAt: 'updated_at',  // 映射到資料表中的 updated_at
+    indexes: [
+      {
+        name: 'idx_course_client_viewed',
+        fields: ['course_id', 'client_id', 'viewed_at'],
+      },
+    ],
   }
 );
 

--- a/backend/repositories/courseViewRepository.ts
+++ b/backend/repositories/courseViewRepository.ts
@@ -1,25 +1,26 @@
 import { Op } from "sequelize";
 import CourseViewModel from "../models/CourseView"
 
+export type CourseViewIdentity = {
+  courseId: number;
+} & (
+  | { userId: number; clientId: null }
+  | { userId: null; clientId: string }
+);
+
 class CourseViewRepository {
-  async shouldInsertView(
-    course_id: number,
-    user_id: number | undefined,
-    ip_address: string | undefined,
-    user_agent: string | undefined
-  ): Promise<boolean> {
+  async hasRecentView({ courseId, userId, clientId }: CourseViewIdentity): Promise<boolean> {
     const tenMinsAgo = new Date(Date.now() - 10 * 60 * 1000);
 
-    const condition = user_id
+    const condition = userId !== null
       ? {
-        course_id,
-        user_id,
+        course_id: courseId,
+        user_id: userId,
         viewed_at: { [Op.gt]: tenMinsAgo },
       }
     : {
-        course_id,
-        ip_address,
-        user_agent,
+        course_id: courseId,
+        client_id: clientId,
         viewed_at: { [Op.gt]: tenMinsAgo },
       };
 
@@ -28,20 +29,14 @@ class CourseViewRepository {
         order: [['viewed_at', 'DESC']],
       });
     
-      return !recentView;
+      return Boolean(recentView);
   }
 
-  async insertCourseView(
-    course_id: number,
-    user_id: number | undefined,
-    ip_address: string | undefined,
-    user_agent: string | undefined
-  ): Promise<void> {
+  async insertCourseView({ courseId, userId, clientId }: CourseViewIdentity): Promise<void> {
     await CourseViewModel.create({
-      course_id,
-      user_id,
-      ip_address,
-      user_agent,
+      course_id: courseId,
+      user_id: userId,
+      client_id: clientId,
       viewed_at: new Date(),
     });
   }

--- a/backend/repositories/courseViewRepository.ts
+++ b/backend/repositories/courseViewRepository.ts
@@ -4,7 +4,7 @@ import CourseViewModel from "../models/CourseView"
 export type CourseViewIdentity = {
   courseId: number;
 } & (
-  | { userId: number; clientId: null }
+  | { userId: number; clientId: string | null }
   | { userId: null; clientId: string }
 );
 

--- a/backend/services/courseViewService.ts
+++ b/backend/services/courseViewService.ts
@@ -9,13 +9,11 @@ export type CourseViewTrackingInput = {
 
 class CourseViewService {
   async trackCourseView({ courseId, userId, clientId }: CourseViewTrackingInput): Promise<boolean> {
-    const normalizedClientId = userId === undefined
-      ? normalizeAnalyticsClientId(clientId)
-      : null;
+    const normalizedClientId = normalizeAnalyticsClientId(clientId);
     if (userId === undefined && !normalizedClientId) return false;
 
     const identity = userId !== undefined
-      ? { courseId, userId, clientId: null }
+      ? { courseId, userId, clientId: normalizedClientId }
       : { courseId, userId: null, clientId: normalizedClientId as string };
     if (await CourseViewRepository.hasRecentView(identity)) return false;
 

--- a/backend/services/courseViewService.ts
+++ b/backend/services/courseViewService.ts
@@ -1,36 +1,26 @@
 import CourseViewRepository from "../repositories/courseViewRepository";
+import { normalizeAnalyticsClientId } from "../utils/analyticsClientId";
+
+export type CourseViewTrackingInput = {
+  courseId: number;
+  userId?: number;
+  clientId?: unknown;
+};
 
 class CourseViewService {
-  async shouldInsertView(
-    course_id: number,
-    user_id: number | undefined,
-    ip_address: string | undefined,
-    user_agent: string | undefined
-  ): Promise<boolean> {
-    const MAX_USER_AGENT_LENGTH = 255;
-    const trimmedUserAgent = user_agent?.slice(0, MAX_USER_AGENT_LENGTH);
-    return await CourseViewRepository.shouldInsertView(
-      course_id,
-      user_id,
-      ip_address,
-      trimmedUserAgent
-    );
-  }
+  async trackCourseView({ courseId, userId, clientId }: CourseViewTrackingInput): Promise<boolean> {
+    const normalizedClientId = userId === undefined
+      ? normalizeAnalyticsClientId(clientId)
+      : null;
+    if (userId === undefined && !normalizedClientId) return false;
 
-  async insertCourseView(
-    course_id: number,
-    user_id: number | undefined,
-    ip_address: string | undefined,
-    user_agent: string | undefined
-  ): Promise<void> {
-		const MAX_USER_AGENT_LENGTH = 255;
-    const trimmedUserAgent = user_agent?.slice(0, MAX_USER_AGENT_LENGTH);
-    await CourseViewRepository.insertCourseView(
-      course_id,
-      user_id,
-      ip_address,
-      trimmedUserAgent
-    );
+    const identity = userId !== undefined
+      ? { courseId, userId, clientId: null }
+      : { courseId, userId: null, clientId: normalizedClientId as string };
+    if (await CourseViewRepository.hasRecentView(identity)) return false;
+
+    await CourseViewRepository.insertCourseView(identity);
+    return true;
   }
 }
 

--- a/backend/services/guestTimetableSnapshotService.ts
+++ b/backend/services/guestTimetableSnapshotService.ts
@@ -4,8 +4,8 @@ import CourseRepository from "../repositories/courseRepository";
 import GuestTimetableSnapshotRepository from "../repositories/guestTimetableSnapshotRepository";
 import { GUEST_TIMETABLE_SNAPSHOT_CONFIG } from "../config/guestTimetableSnapshot";
 import { GuestTimetableSnapshotSyncInput } from "../types/guestTimetableSnapshot";
+import { normalizeAnalyticsClientId } from "../utils/analyticsClientId";
 
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SEMESTER_PATTERN = /^\d{3}-[12]$/;
 const snapshotOperationsByClientId = new Map<string, Promise<void>>();
 
@@ -42,7 +42,8 @@ export const normalizeGuestSnapshotInput = (input: unknown): GuestTimetableSnaps
   }
 
   const { clientId, semesters } = input as Record<string, unknown>;
-  if (typeof clientId !== "string" || !UUID_PATTERN.test(clientId)) {
+  const normalizedClientId = normalizeAnalyticsClientId(clientId);
+  if (!normalizedClientId) {
     throw new GuestTimetableSnapshotServiceError(400, "clientId 必須是有效的 UUID");
   }
   if (!semesters || typeof semesters !== "object" || Array.isArray(semesters)) {
@@ -78,7 +79,7 @@ export const normalizeGuestSnapshotInput = (input: unknown): GuestTimetableSnaps
     normalizedSemesters[semester] = [...new Set(rawCourseIds as number[])];
   }
 
-  return { clientId: clientId.toLowerCase(), semesters: normalizedSemesters };
+  return { clientId: normalizedClientId, semesters: normalizedSemesters };
 };
 
 class GuestTimetableSnapshotService {

--- a/backend/tests/courseViews/analyticsClientId.test.ts
+++ b/backend/tests/courseViews/analyticsClientId.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { normalizeAnalyticsClientId } from "../../utils/analyticsClientId";
+
+const CLIENT_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+test("Analytics Client ID 共用相同 UUID 驗證與小寫正規化", () => {
+  assert.equal(normalizeAnalyticsClientId(CLIENT_ID.toUpperCase()), CLIENT_ID);
+  assert.equal(normalizeAnalyticsClientId("invalid"), null);
+  assert.equal(normalizeAnalyticsClientId([CLIENT_ID]), null);
+  assert.equal(normalizeAnalyticsClientId("x".repeat(500)), null);
+});

--- a/backend/tests/courseViews/courseView.controller.test.ts
+++ b/backend/tests/courseViews/courseView.controller.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { NextFunction, Request, Response } from "express";
+import { getCourse } from "../../controllers/courseController";
+import CourseService from "../../services/courseService";
+import CourseViewService from "../../services/courseViewService";
+
+const createResponse = () => {
+  const state: { status?: number; body?: unknown } = {};
+  const response = {
+    status(status: number) {
+      state.status = status;
+      return response;
+    },
+    json(body: unknown) {
+      state.body = body;
+      return response;
+    },
+  } as unknown as Response;
+  return { response, state };
+};
+
+const next = (() => {}) as NextFunction;
+
+test("匿名課程瀏覽會將 clientId 傳入 tracking", async (t) => {
+  const course = { course: { id: 12 } };
+  t.mock.method(CourseService, "getCourse", async () => course as never);
+  const trackingMock = t.mock.method(CourseViewService, "trackCourseView", async () => true);
+  const countMock = t.mock.method(CourseService, "addViewCount", async () => {});
+  const { response, state } = createResponse();
+
+  await getCourse({
+    params: { course_id: "12" },
+    query: {},
+    header: (name: string) => name === "x-analytics-client-id"
+      ? "550e8400-e29b-41d4-a716-446655440000"
+      : undefined,
+  } as unknown as Request, response, next);
+
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(trackingMock.mock.calls[0].arguments[0], {
+    courseId: 12,
+    userId: undefined,
+    clientId: "550e8400-e29b-41d4-a716-446655440000",
+  });
+  assert.equal(countMock.mock.callCount(), 1);
+  assert.deepEqual(state, { status: 200, body: course });
+});
+
+test("CourseView tracking 失敗不影響課程詳情回應", async (t) => {
+  const course = { course: { id: 12 } };
+  const trackingError = new Error("database unavailable");
+  t.mock.method(CourseService, "getCourse", async () => course as never);
+  t.mock.method(CourseViewService, "trackCourseView", async () => { throw trackingError; });
+  const errorMock = t.mock.method(console, "error", () => {});
+  const { response, state } = createResponse();
+
+  await getCourse({
+    params: { course_id: "12" },
+    query: {},
+    header: () => undefined,
+  } as unknown as Request, response, next);
+
+  assert.deepEqual(state, { status: 200, body: course });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(errorMock.mock.calls[0].arguments, ["記錄課程瀏覽失敗", trackingError]);
+});
+
+test("CourseView 寫入尚未完成時就先回傳課程詳情", async (t) => {
+  const course = { course: { id: 12 } };
+  let finishTracking: ((inserted: boolean) => void) | undefined;
+  t.mock.method(CourseService, "getCourse", async () => course as never);
+  t.mock.method(CourseViewService, "trackCourseView", () => new Promise<boolean>((resolve) => {
+    finishTracking = resolve;
+  }));
+  const { response, state } = createResponse();
+
+  await getCourse({
+    params: { course_id: "12" },
+    query: {},
+    header: () => undefined,
+  } as unknown as Request, response, next);
+
+  assert.deepEqual(state, { status: 200, body: course });
+  finishTracking?.(false);
+});

--- a/backend/tests/courseViews/courseView.controller.test.ts
+++ b/backend/tests/courseViews/courseView.controller.test.ts
@@ -37,8 +37,6 @@ test("匿名課程瀏覽會將 clientId 傳入 tracking", async (t) => {
       : undefined,
   } as unknown as Request, response, next);
 
-  await new Promise((resolve) => setImmediate(resolve));
-
   assert.deepEqual(trackingMock.mock.calls[0].arguments[0], {
     courseId: 12,
     userId: undefined,
@@ -63,11 +61,10 @@ test("CourseView tracking 失敗不影響課程詳情回應", async (t) => {
   } as unknown as Request, response, next);
 
   assert.deepEqual(state, { status: 200, body: course });
-  await new Promise((resolve) => setImmediate(resolve));
   assert.deepEqual(errorMock.mock.calls[0].arguments, ["記錄課程瀏覽失敗", trackingError]);
 });
 
-test("CourseView 寫入尚未完成時就先回傳課程詳情", async (t) => {
+test("CourseView 去重與寫入完成後才回傳課程詳情", async (t) => {
   const course = { course: { id: 12 } };
   let finishTracking: ((inserted: boolean) => void) | undefined;
   t.mock.method(CourseService, "getCourse", async () => course as never);
@@ -76,12 +73,16 @@ test("CourseView 寫入尚未完成時就先回傳課程詳情", async (t) => {
   }));
   const { response, state } = createResponse();
 
-  await getCourse({
+  const courseRequest = getCourse({
     params: { course_id: "12" },
     query: {},
     header: () => undefined,
   } as unknown as Request, response, next);
 
-  assert.deepEqual(state, { status: 200, body: course });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(state, {});
+  assert.ok(finishTracking);
   finishTracking?.(false);
+  await courseRequest;
+  assert.deepEqual(state, { status: 200, body: course });
 });

--- a/backend/tests/courseViews/courseView.model.test.ts
+++ b/backend/tests/courseViews/courseView.model.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import CourseViewModel from "../../models/CourseView";
+
+test("CourseViews 保留舊識別欄位並新增 nullable client_id 與 dedupe index", () => {
+  assert.equal(CourseViewModel.rawAttributes.client_id.allowNull, true);
+  assert.ok(CourseViewModel.rawAttributes.ip_address);
+  assert.ok(CourseViewModel.rawAttributes.user_agent);
+
+  const clientIndex = CourseViewModel.options.indexes?.find(
+    (index) => index.name === "idx_course_client_viewed"
+  );
+  assert.deepEqual(clientIndex?.fields, ["course_id", "client_id", "viewed_at"]);
+});

--- a/backend/tests/courseViews/courseView.repository.test.ts
+++ b/backend/tests/courseViews/courseView.repository.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Op } from "sequelize";
+import CourseViewModel from "../../models/CourseView";
+import CourseViewRepository from "../../repositories/courseViewRepository";
+
+const CLIENT_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+test("匿名瀏覽以 course_id、client_id 與時間去重", async (t) => {
+  const findMock = t.mock.method(CourseViewModel, "findOne", async () => null);
+
+  assert.equal(await CourseViewRepository.hasRecentView({
+    courseId: 12,
+    userId: null,
+    clientId: CLIENT_ID,
+  }), false);
+
+  const where = findMock.mock.calls[0].arguments[0]?.where as Record<string | symbol, unknown>;
+  assert.equal(where.course_id, 12);
+  assert.equal(where.client_id, CLIENT_ID);
+  assert.equal(where.ip_address, undefined);
+  assert.equal(where.user_agent, undefined);
+  assert.ok((where.viewed_at as Record<symbol, unknown>)[Op.gt]);
+});
+
+test("新瀏覽只寫入單一 identity，不再寫入 IP 或 user-agent", async (t) => {
+  const createMock = t.mock.method(CourseViewModel, "create", async (values: object) => values as CourseViewModel);
+
+  await CourseViewRepository.insertCourseView({
+    courseId: 12,
+    userId: null,
+    clientId: CLIENT_ID,
+  });
+
+  const values = createMock.mock.calls[0]!.arguments[0] as Record<string, unknown>;
+  assert.equal(values.user_id, null);
+  assert.equal(values.client_id, CLIENT_ID);
+  assert.equal(values.ip_address, undefined);
+  assert.equal(values.user_agent, undefined);
+});

--- a/backend/tests/courseViews/courseView.repository.test.ts
+++ b/backend/tests/courseViews/courseView.repository.test.ts
@@ -23,6 +23,22 @@ test("匿名瀏覽以 course_id、client_id 與時間去重", async (t) => {
   assert.ok((where.viewed_at as Record<symbol, unknown>)[Op.gt]);
 });
 
+test("登入瀏覽保留 client_id context，但只以 user_id 去重", async (t) => {
+  const findMock = t.mock.method(CourseViewModel, "findOne", async () => null);
+
+  assert.equal(await CourseViewRepository.hasRecentView({
+    courseId: 12,
+    userId: 8,
+    clientId: CLIENT_ID,
+  }), false);
+
+  const where = findMock.mock.calls[0].arguments[0]?.where as Record<string | symbol, unknown>;
+  assert.equal(where.course_id, 12);
+  assert.equal(where.user_id, 8);
+  assert.equal(where.client_id, undefined);
+  assert.ok((where.viewed_at as Record<symbol, unknown>)[Op.gt]);
+});
+
 test("新瀏覽只寫入單一 identity，不再寫入 IP 或 user-agent", async (t) => {
   const createMock = t.mock.method(CourseViewModel, "create", async (values: object) => values as CourseViewModel);
 
@@ -34,6 +50,22 @@ test("新瀏覽只寫入單一 identity，不再寫入 IP 或 user-agent", async
 
   const values = createMock.mock.calls[0]!.arguments[0] as Record<string, unknown>;
   assert.equal(values.user_id, null);
+  assert.equal(values.client_id, CLIENT_ID);
+  assert.equal(values.ip_address, undefined);
+  assert.equal(values.user_agent, undefined);
+});
+
+test("登入瀏覽同時寫入 user_id 與 client_id", async (t) => {
+  const createMock = t.mock.method(CourseViewModel, "create", async (values: object) => values as CourseViewModel);
+
+  await CourseViewRepository.insertCourseView({
+    courseId: 12,
+    userId: 8,
+    clientId: CLIENT_ID,
+  });
+
+  const values = createMock.mock.calls[0]!.arguments[0] as Record<string, unknown>;
+  assert.equal(values.user_id, 8);
   assert.equal(values.client_id, CLIENT_ID);
   assert.equal(values.ip_address, undefined);
   assert.equal(values.user_agent, undefined);

--- a/backend/tests/courseViews/courseView.service.test.ts
+++ b/backend/tests/courseViews/courseView.service.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import CourseViewRepository from "../../repositories/courseViewRepository";
+import CourseViewService from "../../services/courseViewService";
+
+const CLIENT_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+test("登入瀏覽只使用 user_id 並忽略 clientId", async (t) => {
+  const recentMock = t.mock.method(CourseViewRepository, "hasRecentView", async () => false);
+  const insertMock = t.mock.method(CourseViewRepository, "insertCourseView", async () => {});
+
+  assert.equal(await CourseViewService.trackCourseView({
+    courseId: 12,
+    userId: 8,
+    clientId: CLIENT_ID,
+  }), true);
+
+  const identity = { courseId: 12, userId: 8, clientId: null };
+  assert.deepEqual(recentMock.mock.calls[0].arguments[0], identity);
+  assert.deepEqual(insertMock.mock.calls[0].arguments[0], identity);
+});
+
+test("匿名瀏覽使用共用 clientId，缺少或無效 identity 時略過", async (t) => {
+  const recentMock = t.mock.method(CourseViewRepository, "hasRecentView", async () => false);
+  const insertMock = t.mock.method(CourseViewRepository, "insertCourseView", async () => {});
+
+  assert.equal(await CourseViewService.trackCourseView({ courseId: 12 }), false);
+  assert.equal(await CourseViewService.trackCourseView({ courseId: 12, clientId: "invalid" }), false);
+  assert.equal(recentMock.mock.callCount(), 0);
+  assert.equal(insertMock.mock.callCount(), 0);
+
+  assert.equal(await CourseViewService.trackCourseView({
+    courseId: 12,
+    clientId: CLIENT_ID.toUpperCase(),
+  }), true);
+  assert.deepEqual(insertMock.mock.calls[0].arguments[0], {
+    courseId: 12,
+    userId: null,
+    clientId: CLIENT_ID,
+  });
+});
+
+test("10 分鐘內已有相同 identity 時不重複新增", async (t) => {
+  t.mock.method(CourseViewRepository, "hasRecentView", async () => true);
+  const insertMock = t.mock.method(CourseViewRepository, "insertCourseView", async () => {});
+
+  assert.equal(await CourseViewService.trackCourseView({
+    courseId: 12,
+    clientId: CLIENT_ID,
+  }), false);
+  assert.equal(insertMock.mock.callCount(), 0);
+});

--- a/backend/tests/courseViews/courseView.service.test.ts
+++ b/backend/tests/courseViews/courseView.service.test.ts
@@ -5,7 +5,7 @@ import CourseViewService from "../../services/courseViewService";
 
 const CLIENT_ID = "550e8400-e29b-41d4-a716-446655440000";
 
-test("登入瀏覽只使用 user_id 並忽略 clientId", async (t) => {
+test("登入瀏覽以 user_id 去重並保留有效 clientId", async (t) => {
   const recentMock = t.mock.method(CourseViewRepository, "hasRecentView", async () => false);
   const insertMock = t.mock.method(CourseViewRepository, "insertCourseView", async () => {});
 
@@ -13,6 +13,21 @@ test("登入瀏覽只使用 user_id 並忽略 clientId", async (t) => {
     courseId: 12,
     userId: 8,
     clientId: CLIENT_ID,
+  }), true);
+
+  const identity = { courseId: 12, userId: 8, clientId: CLIENT_ID };
+  assert.deepEqual(recentMock.mock.calls[0].arguments[0], identity);
+  assert.deepEqual(insertMock.mock.calls[0].arguments[0], identity);
+});
+
+test("登入瀏覽缺少有效 clientId 時仍使用 user_id 記錄", async (t) => {
+  const recentMock = t.mock.method(CourseViewRepository, "hasRecentView", async () => false);
+  const insertMock = t.mock.method(CourseViewRepository, "insertCourseView", async () => {});
+
+  assert.equal(await CourseViewService.trackCourseView({
+    courseId: 12,
+    userId: 8,
+    clientId: "invalid",
   }), true);
 
   const identity = { courseId: 12, userId: 8, clientId: null };

--- a/backend/utils/analyticsClientId.ts
+++ b/backend/utils/analyticsClientId.ts
@@ -1,0 +1,6 @@
+const ANALYTICS_CLIENT_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const normalizeAnalyticsClientId = (value: unknown): string | null => {
+  if (typeof value !== "string" || !ANALYTICS_CLIENT_ID_PATTERN.test(value)) return null;
+  return value.toLowerCase();
+};

--- a/frontend/src/apis/axiosInstance.ts
+++ b/frontend/src/apis/axiosInstance.ts
@@ -12,7 +12,7 @@ export type ApiError = Error & {
 }
 
 export const axiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
+  baseURL: import.meta.env?.VITE_API_BASE_URL,
   withCredentials: true,
 })
 

--- a/frontend/src/apis/courseAPI.ts
+++ b/frontend/src/apis/courseAPI.ts
@@ -18,7 +18,6 @@ export const getCourses = async (searchParams: SearchParams): Promise<CourseResp
 }
 
 type GetCourseOptions = {
-  isAuthenticated: boolean;
   getClientId?: () => Promise<string>;
   onTrackingError?: (error: unknown) => void;
 }
@@ -26,18 +25,15 @@ type GetCourseOptions = {
 export const getCourse = async (
   course_id: string,
   {
-    isAuthenticated,
     getClientId = getOrCreateAnalyticsClientId,
     onTrackingError = (error) => console.error('無法建立匿名課程瀏覽識別碼', error),
-  }: GetCourseOptions,
+  }: GetCourseOptions = {},
 ): Promise<CourseDetailResponse> => {
   let clientId: string | undefined
-  if (!isAuthenticated) {
-    try {
-      clientId = await getClientId()
-    } catch (error) {
-      onTrackingError(error)
-    }
+  try {
+    clientId = await getClientId()
+  } catch (error) {
+    onTrackingError(error)
   }
 
   const response = await axiosInstance.get(`/courses/${course_id}`, {

--- a/frontend/src/apis/courseAPI.ts
+++ b/frontend/src/apis/courseAPI.ts
@@ -1,5 +1,6 @@
 import { Course, CourseDetailResponse, CourseOptionFilters, CourseResponse, SearchParams } from '../types/courseType'
 import { axiosInstance } from './axiosInstance'
+import { getOrCreateAnalyticsClientId } from '../utils/analyticsClientId'
 
 export const getCourses = async (searchParams: SearchParams): Promise<CourseResponse> => {
   const filteredSearchParams = Object.fromEntries(
@@ -16,8 +17,32 @@ export const getCourses = async (searchParams: SearchParams): Promise<CourseResp
   return response.data
 }
 
-export const getCourse = async (course_id: string): Promise<CourseDetailResponse> => {
-  const response = await axiosInstance.get(`/courses/${course_id}`)
+type GetCourseOptions = {
+  isAuthenticated: boolean;
+  getClientId?: () => Promise<string>;
+  onTrackingError?: (error: unknown) => void;
+}
+
+export const getCourse = async (
+  course_id: string,
+  {
+    isAuthenticated,
+    getClientId = getOrCreateAnalyticsClientId,
+    onTrackingError = (error) => console.error('無法建立匿名課程瀏覽識別碼', error),
+  }: GetCourseOptions,
+): Promise<CourseDetailResponse> => {
+  let clientId: string | undefined
+  if (!isAuthenticated) {
+    try {
+      clientId = await getClientId()
+    } catch (error) {
+      onTrackingError(error)
+    }
+  }
+
+  const response = await axiosInstance.get(`/courses/${course_id}`, {
+    headers: clientId ? { 'X-Analytics-Client-Id': clientId } : undefined,
+  })
   return response.data
 }
 

--- a/frontend/src/hooks/courses/useGetCourse.ts
+++ b/frontend/src/hooks/courses/useGetCourse.ts
@@ -4,19 +4,13 @@ import { getCourse } from '../../apis/courseAPI'
 import { useAuthStore } from '../../stores/authStore'
 import { getUserCacheScope } from '../../utils/userCacheScope'
 
-export const canFetchCourse = (courseId: string, isAuthResolved: boolean): boolean => (
-    Boolean(courseId) && isAuthResolved
-)
-
 export const useGetCourse = (course_id: string) => {
     const userCacheScope = useAuthStore((state) => getUserCacheScope(state.user))
-    const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
-    const isAuthResolved = useAuthStore((state) => state.isAuthResolved)
 
     return useQuery({
         queryKey: [QUERY_KEYS.COURSE, course_id, userCacheScope],
-        queryFn: () => getCourse(course_id, { isAuthenticated }),
-        enabled: canFetchCourse(course_id, isAuthResolved),
+        queryFn: () => getCourse(course_id),
+        enabled: Boolean(course_id),
         staleTime: 5 * 60 * 1000,
     })
 }

--- a/frontend/src/hooks/courses/useGetCourse.ts
+++ b/frontend/src/hooks/courses/useGetCourse.ts
@@ -4,13 +4,19 @@ import { getCourse } from '../../apis/courseAPI'
 import { useAuthStore } from '../../stores/authStore'
 import { getUserCacheScope } from '../../utils/userCacheScope'
 
+export const canFetchCourse = (courseId: string, isAuthResolved: boolean): boolean => (
+    Boolean(courseId) && isAuthResolved
+)
+
 export const useGetCourse = (course_id: string) => {
     const userCacheScope = useAuthStore((state) => getUserCacheScope(state.user))
+    const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
+    const isAuthResolved = useAuthStore((state) => state.isAuthResolved)
 
     return useQuery({
         queryKey: [QUERY_KEYS.COURSE, course_id, userCacheScope],
-        queryFn: () => getCourse(course_id),
-        enabled: !!course_id,
+        queryFn: () => getCourse(course_id, { isAuthenticated }),
+        enabled: canFetchCourse(course_id, isAuthResolved),
         staleTime: 5 * 60 * 1000,
     })
 }

--- a/frontend/tests/courses/courseViewTracking.test.ts
+++ b/frontend/tests/courses/courseViewTracking.test.ts
@@ -2,21 +2,13 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { getCourse } from '../../src/apis/courseAPI'
 import { axiosInstance } from '../../src/apis/axiosInstance'
-import { canFetchCourse } from '../../src/hooks/courses/useGetCourse'
 
 const CLIENT_ID = '550e8400-e29b-41d4-a716-446655440000'
 
-test('課程詳情會等待 auth resolved', () => {
-  assert.equal(canFetchCourse('12', false), false)
-  assert.equal(canFetchCourse('', true), false)
-  assert.equal(canFetchCourse('12', true), true)
-})
-
-test('匿名課程 request 共用 Analytics Client ID', async (t) => {
+test('課程 request 一律共用 Analytics Client ID', async (t) => {
   const getMock = t.mock.method(axiosInstance, 'get', async () => ({ data: { course: {} } }))
 
   await getCourse('12', {
-    isAuthenticated: false,
     getClientId: async () => CLIENT_ID,
   })
 
@@ -26,32 +18,12 @@ test('匿名課程 request 共用 Analytics Client ID', async (t) => {
   ])
 })
 
-test('登入 request 不取得或傳送 clientId', async (t) => {
-  const getMock = t.mock.method(axiosInstance, 'get', async () => ({ data: { course: {} } }))
-  let clientIdRequested = false
-
-  await getCourse('12', {
-    isAuthenticated: true,
-    getClientId: async () => {
-      clientIdRequested = true
-      return CLIENT_ID
-    },
-  })
-
-  assert.equal(clientIdRequested, false)
-  assert.deepEqual(getMock.mock.calls[0].arguments, [
-    '/courses/12',
-    { headers: undefined },
-  ])
-})
-
 test('clientId localStorage 失敗時仍取得課程資料', async (t) => {
   const getMock = t.mock.method(axiosInstance, 'get', async () => ({ data: { course: {} } }))
   const trackingError = new Error('storage unavailable')
   let receivedError: unknown
 
   await getCourse('12', {
-    isAuthenticated: false,
     getClientId: async () => { throw trackingError },
     onTrackingError: (error) => { receivedError = error },
   })

--- a/frontend/tests/courses/courseViewTracking.test.ts
+++ b/frontend/tests/courses/courseViewTracking.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { getCourse } from '../../src/apis/courseAPI'
+import { axiosInstance } from '../../src/apis/axiosInstance'
+import { canFetchCourse } from '../../src/hooks/courses/useGetCourse'
+
+const CLIENT_ID = '550e8400-e29b-41d4-a716-446655440000'
+
+test('課程詳情會等待 auth resolved', () => {
+  assert.equal(canFetchCourse('12', false), false)
+  assert.equal(canFetchCourse('', true), false)
+  assert.equal(canFetchCourse('12', true), true)
+})
+
+test('匿名課程 request 共用 Analytics Client ID', async (t) => {
+  const getMock = t.mock.method(axiosInstance, 'get', async () => ({ data: { course: {} } }))
+
+  await getCourse('12', {
+    isAuthenticated: false,
+    getClientId: async () => CLIENT_ID,
+  })
+
+  assert.deepEqual(getMock.mock.calls[0].arguments, [
+    '/courses/12',
+    { headers: { 'X-Analytics-Client-Id': CLIENT_ID } },
+  ])
+})
+
+test('登入 request 不取得或傳送 clientId', async (t) => {
+  const getMock = t.mock.method(axiosInstance, 'get', async () => ({ data: { course: {} } }))
+  let clientIdRequested = false
+
+  await getCourse('12', {
+    isAuthenticated: true,
+    getClientId: async () => {
+      clientIdRequested = true
+      return CLIENT_ID
+    },
+  })
+
+  assert.equal(clientIdRequested, false)
+  assert.deepEqual(getMock.mock.calls[0].arguments, [
+    '/courses/12',
+    { headers: undefined },
+  ])
+})
+
+test('clientId localStorage 失敗時仍取得課程資料', async (t) => {
+  const getMock = t.mock.method(axiosInstance, 'get', async () => ({ data: { course: {} } }))
+  const trackingError = new Error('storage unavailable')
+  let receivedError: unknown
+
+  await getCourse('12', {
+    isAuthenticated: false,
+    getClientId: async () => { throw trackingError },
+    onTrackingError: (error) => { receivedError = error },
+  })
+
+  assert.equal(receivedError, trackingError)
+  assert.deepEqual(getMock.mock.calls[0].arguments, [
+    '/courses/12',
+    { headers: undefined },
+  ])
+})


### PR DESCRIPTION
## 標題

統一 CourseView 與課表 Snapshot 的匿名識別

---

## 摘要

將匿名 `CourseView` 從 IP＋user-agent 改為沿用既有 Analytics Client ID，使匿名課程瀏覽與 `GuestTimetableSnapshots` 能以相同 `client_id` 建立資料關聯；登入瀏覽亦保留 Client ID 作為 browser context。

---

## 背景／問題

目前匿名課程瀏覽以 IP＋user-agent 去重，無法穩定代表同一個 browser storage environment，也無法和匿名課表 Snapshot 可靠串接。#92、#93 已建立獨立 Analytics Client ID，因此 CourseView 應共用相同識別來源。

---

## 變更內容

- 新增 migration，為 `CourseViews` 加入 nullable `client_id` 與 `(course_id, client_id, viewed_at)` 索引。
- 保留既有 `ip_address`、`user_agent` 欄位與歷史資料，不執行 drop 或假資料 backfill。
- 前端取得公開課程時不等待 auth resolved，並一律嘗試透過 `X-Analytics-Client-Id` header 附帶既有 Analytics Client ID。
- 登入瀏覽同時保存 `user_id` 與有效的 `client_id`；去重仍只以 `user_id` 作為帳號 identity，`client_id` 僅作為 browser context。
- 匿名瀏覽以經共用 validator 驗證的 `client_id` 作為 identity；缺少有效 Client ID 時略過 tracking，不再 fallback 至 IP＋user-agent。
- 不將既有匿名瀏覽紀錄回填或歸戶至後續登入的使用者。
- 課程詳情會等待 CourseView 去重與寫入完成，避免快速重整產生重複紀錄；tracking 失敗仍不影響課程回應。
- 將 Guest Snapshot 與 CourseView 的 Analytics Client ID validation 集中共用。
- 新增 `backend/tests/courseViews` 與 `frontend/tests/courses` 測試。
- 更新 `.agents/skills/fix-pr/SKILL.md`，改為逐條回覆修正內容後只統一觸發一次 Codex review。

---

## 測試方式

- `cd backend && npm test`：37 項測試通過。
- `cd backend && .\node_modules\.bin\tsc.cmd --noEmit`：TypeScript 檢查通過。
- `cd frontend && npm test`：23 項測試通過。
- `cd frontend && npm run lint`：ESLint 通過。
- `cd frontend && npm run build`：Production build 通過；僅保留既有 chunk size 警告。
- `git diff --check -- .agents/skills/fix-pr/SKILL.md`：格式檢查通過。

---

## 備註

- Base branch：`feat/timetable-analytics`。
- 本 PR 只完成 Phase 1，不刪除 `CourseViews.ip_address` 或 `CourseViews.user_agent`。
- `client_id` 僅為 Analytics identifier 與 browser context，不作為 authentication 或 authorization credential。
- Closes #98
